### PR TITLE
Labels control flow

### DIFF
--- a/tests/stack/control-flow.wast
+++ b/tests/stack/control-flow.wast
@@ -121,3 +121,11 @@ if [ i32 ] i32.const 1 else i32.const -1 end
 //     i32.add
 // end
 // #assertTopStack < i32 > 10 "loop"
+
+// Stack Underflow
+// TODO: We need to give semantics to stack underflow (though it could not happen with a validated program).
+// We need `trap` semantics first.
+// i32.const 0
+// block [ i32 i32 ]
+//     i32.const 7
+// end

--- a/tests/stack/control-flow.wast
+++ b/tests/stack/control-flow.wast
@@ -29,3 +29,11 @@ block [ ]
     br 0
 end
 #assertStack < i32 > 2 : < i32 > 1 : .Stack "block 4"
+
+i32.const 1
+if [ i32 ] i32.const 1 else i32.const -1 end
+#assertTopStack < i32 > 1 "if true"
+
+i32.const 0
+if [ i32 ] i32.const 1 else i32.const -1 end
+#assertTopStack < i32 > -1 "if false"

--- a/tests/stack/control-flow.wast
+++ b/tests/stack/control-flow.wast
@@ -1,3 +1,5 @@
+// Blocks
+
 block [ i32 i32 i32 ]
     i32.const 1
     i32.const 2
@@ -20,6 +22,8 @@ block [ i32 i32 ]
 end
 #assertStack < i32 > 3 : < i32 > 2 : .Stack "block 3 (invalid)"
 
+// Breaks
+
 i32.const 1
 i32.const 2
 block [ ]
@@ -28,7 +32,51 @@ block [ ]
     i32.const 4
     br 0
 end
-#assertStack < i32 > 2 : < i32 > 1 : .Stack "block 4"
+#assertStack < i32 > 2 : < i32 > 1 : .Stack "br 1"
+
+i32.const 1
+i32.const 2
+block [ ]
+    i32.const 3
+    block [ i32 i32 ]
+        i32.const 4
+        i32.const 5
+        br 1
+    end
+    i32.const 6
+    br 0
+end
+#assertStack < i32 > 2 : < i32 > 1 : .Stack "br 2"
+
+i32.const 1
+i32.const 2
+block [ i32 i32 ]
+    i32.const 3
+    block [ i32 i32 ]
+        i32.const 4
+        i32.const 5
+        br 1
+    end
+    i32.const 6
+    br 0
+end
+#assertStack < i32 > 5 : < i32 > 4 : < i32 > 2 : < i32 > 1 : .Stack "br 3"
+
+i32.const 1
+i32.const 2
+block [ i32 i32 ]
+    i32.const 3
+    block [ ]
+        i32.const 4
+        i32.const 5
+        br 1
+    end
+    i32.const 6
+    br 0
+end
+#assertStack < i32 > 5 : < i32 > 4 : < i32 > 2 : < i32 > 1 : .Stack "br 3"
+
+// Conditional
 
 i32.const 1
 if [ i32 ] i32.const 1 else i32.const -1 end

--- a/tests/stack/control-flow.wast
+++ b/tests/stack/control-flow.wast
@@ -74,7 +74,29 @@ block [ i32 i32 ]
     i32.const 6
     br 0
 end
-#assertStack < i32 > 5 : < i32 > 4 : < i32 > 2 : < i32 > 1 : .Stack "br 3"
+#assertStack < i32 > 5 : < i32 > 4 : < i32 > 2 : < i32 > 1 : .Stack "br 4"
+
+i32.const 1
+i32.const 2
+block [ i32 ]
+    i32.const 3
+    i32.const 0
+    br_if 0
+    i32.const 4
+    br 0
+end
+#assertStack < i32 > 4 : < i32 > 2 : < i32 > 1 : .Stack "br_if 1 false"
+
+i32.const 1
+i32.const 2
+block [ ]
+    i32.const 3
+    i32.const 1
+    br_if 0
+    i32.const 4
+    br 0
+end
+#assertStack < i32 > 2 : < i32 > 1 : .Stack "br_if 1 true"
 
 // Conditional
 

--- a/tests/stack/control-flow.wast
+++ b/tests/stack/control-flow.wast
@@ -107,3 +107,17 @@ if [ i32 ] i32.const 1 else i32.const -1 end
 i32.const 0
 if [ i32 ] i32.const 1 else i32.const -1 end
 #assertTopStack < i32 > -1 "if false"
+
+// Looping
+// TODO: We need locals before loops become effective.
+// i32.const 0
+// loop [ ]
+//     block [ ]
+//         i32.const 10
+//         i32.eq
+//         br_if 1
+//     end
+//     i32.const 1
+//     i32.add
+// end
+// #assertTopStack < i32 > 10 "loop"

--- a/tests/stack/control-flow.wast
+++ b/tests/stack/control-flow.wast
@@ -1,0 +1,31 @@
+block [ i32 i32 i32 ]
+    i32.const 1
+    i32.const 2
+    i32.const 3
+end
+#assertStack < i32 > 3 : < i32 > 2 : < i32 > 1 : .Stack "block 1"
+
+block [ i32 i32 ]
+    i32.const 1
+    i32.const 2
+    i32.const 3
+    drop
+end
+#assertStack < i32 > 2 : < i32 > 1 : .Stack "block 2"
+
+block [ i32 i32 ]
+    i32.const 1
+    i32.const 2
+    i32.const 3
+end
+#assertStack < i32 > 3 : < i32 > 2 : .Stack "block 3 (invalid)"
+
+i32.const 1
+i32.const 2
+block [ ]
+    i32.const 3
+    br 0
+    i32.const 4
+    br 0
+end
+#assertStack < i32 > 2 : < i32 > 1 : .Stack "block 4"

--- a/wasm-syntax.md
+++ b/wasm-syntax.md
@@ -156,6 +156,13 @@ module WASM-BASIC-INSTRUCTIONS
     rule I:Instr IS:Instrs => I ~> IS
 ```
 
+**TODO**: avoid having to duplicate above rules for second position here.
+
+```k
+    rule I:Instr ~> .Instrs            => I
+    rule I:Instr ~> I':Instr IS:Instrs => I ~> I' ~> IS
+```
+
 Operator Evaluation
 -------------------
 

--- a/wasm-syntax.md
+++ b/wasm-syntax.md
@@ -123,6 +123,20 @@ WASM is a stack-machine, so here we provide the stack to operate over.
     syntax Stack     ::= ".Stack"
                        | StackItem ":" Stack
  // ----------------------------------------
+```
+
+Operator `_++_` implements an append operator for sort `Stack`.
+Operator `#take` will take the prefix of a given stack, checking that the value types match the supplied type-sequence.
+
+```k
+    syntax Stack ::= Stack "++" Stack           [function]
+                   | #take ( ValTypes , Stack ) [function]
+ // ------------------------------------------------------
+    rule .Stack       ++ STACK' => STACK'
+    rule (SI : STACK) ++ STACK' => SI : (STACK ++ STACK')
+
+    rule #take(.ValTypes,   _)                           => .Stack
+    rule #take(TYPE VTYPES, < TYPE > VAL:Number : STACK) => < TYPE > VAL : #take(VTYPES, STACK)
 endmodule
 ```
 

--- a/wasm-syntax.md
+++ b/wasm-syntax.md
@@ -28,25 +28,26 @@ $2^32$ and $2^64$ are used often enough to warrant providing macros for them.
     rule #pow64 => 18446744073709551616 [macro]
 ```
 
-### Values
+### Types
 
-WASM values are either integers or floating-point numbers, of 32- or 64-bit widths.
-First, the type of values is built, then values annotated with their types are provided.
+WASM has four basic types, for 32 and 64 bit integers and floats.
+There are two basic type-constructors: sequencing (`[_]`) and function spaces (`_->_`).
 
 ```k
-    syntax Number ::= Int | Float
- // -----------------------------
-
     syntax IValType ::= "i32" | "i64"
     syntax FValType ::= "f32" | "f64"
     syntax  ValType ::= IValType | FValType
  // ---------------------------------------
 
-    syntax IVal ::= "<" IValType ">" Int
-    syntax FVal ::= "<" FValType ">" Float
-    syntax  Val ::= "<"  ValType ">" Number
-                  | IVal | FVal
- // ---------------------------
+    syntax ValTypes ::= List{ValType, ""}
+    syntax VecType  ::= "[" ValTypes "]"
+ // ------------------------------------
+
+    syntax FuncType ::= VecType "->" VecType
+ // ----------------------------------------
+
+    syntax Type ::= ".Type" | ValType | VecType | FuncType
+ // ------------------------------------------------------
 ```
 
 The `#width` function returns the bit-width of a given `IValType`.
@@ -56,6 +57,22 @@ The `#width` function returns the bit-width of a given `IValType`.
  // ---------------------------------------------
     rule #width(i32) => 32
     rule #width(i64) => 64
+```
+
+### Values
+
+WASM values are either integers or floating-point numbers, of 32- or 64-bit widths.
+First, the type of values is built, then values annotated with their types are provided.
+
+```k
+    syntax Number ::= Int | Float
+ // -----------------------------
+
+    syntax IVal ::= "<" IValType ">" Int
+    syntax FVal ::= "<" FValType ">" Float
+    syntax  Val ::= "<"  ValType ">" Number
+                  | IVal | FVal
+ // ---------------------------
 ```
 
 The `#chop` function will ensure that an integer value is wrapped to the correct bit-width.

--- a/wasm.md
+++ b/wasm.md
@@ -88,6 +88,11 @@ Structured Control Flow
          ...
          </k>
          <stack> < i32 > VAL : STACK => .Stack </stack>
+
+    syntax Instr ::= "loop" VecType Instrs "end"
+ // --------------------------------------------
+    rule <k> loop VTYPE IS end => IS ~> label [ .ValTypes ] { loop VTYPE IS end } STACK ... </k>
+         <stack> STACK => .Stack </stack>
 ```
 
 Testing

--- a/wasm.md
+++ b/wasm.md
@@ -71,6 +71,11 @@ Structured Control Flow
     rule <k> br N ~> (I:Instr => .) ... </k>
     rule <k> br N ~> L:Label => #if N ==Int 0 #then L #else br (N -Int 1) #fi ... </k>
 
+    syntax Instr ::= "br_if" Int
+ // ----------------------------
+    rule <k> br_if N => #if VAL =/=Int 0 #then br N #else .K #fi ... </k>
+         <stack> < TYPE > VAL : STACK => STACK </stack>
+
     syntax Instr ::= "if" VecType Instrs "else" Instrs "end"
  // --------------------------------------------------------
     rule <k> if VTYPE IS else IS' end

--- a/wasm.md
+++ b/wasm.md
@@ -52,6 +52,26 @@ The `select` operator picks one of the second or third stack values based on the
          </stack>
 ```
 
+Structured Control Flow
+-----------------------
+
+```k
+    syntax Label ::= "label" VecType "{" Instrs "}" Stack
+ // -----------------------------------------------------
+    rule <k> label [ TYPES ] { IS } STACK' => IS ... </k>
+         <stack> STACK => #take(TYPES, STACK) ++ STACK' </stack>
+
+    syntax Instr ::= "block" VecType Instrs "end"
+ // ---------------------------------------------
+    rule <k> block VTYPE IS end => IS ~> label VTYPE { .Instrs } STACK ... </k>
+         <stack> STACK => .Stack </stack>
+
+    syntax Instr ::= "br" Int
+ // -------------------------
+    rule <k> br N ~> (I:Instr => .) ... </k>
+    rule <k> br N ~> L:Label => #if N ==Int 0 #then L #else br (N -Int 1) #fi ... </k>
+```
+
 Testing
 -------
 

--- a/wasm.md
+++ b/wasm.md
@@ -56,6 +56,10 @@ Structured Control Flow
 -----------------------
 
 ```k
+    syntax Instr ::= "nop"
+ // ----------------------
+    rule <k> nop => . ... </k>
+
     syntax Label ::= "label" VecType "{" Instrs "}" Stack
  // -----------------------------------------------------
     rule <k> label [ TYPES ] { IS } STACK' => IS ... </k>

--- a/wasm.md
+++ b/wasm.md
@@ -70,6 +70,15 @@ Structured Control Flow
  // -------------------------
     rule <k> br N ~> (I:Instr => .) ... </k>
     rule <k> br N ~> L:Label => #if N ==Int 0 #then L #else br (N -Int 1) #fi ... </k>
+
+    syntax Instr ::= "if" VecType Instrs "else" Instrs "end"
+ // --------------------------------------------------------
+    rule <k> if VTYPE IS else IS' end
+          => #if VAL =/=Int 0 #then IS #else IS' #fi
+          ~> label VTYPE { .Instrs } STACK
+         ...
+         </k>
+         <stack> < i32 > VAL : STACK => .Stack </stack>
 ```
 
 Testing


### PR DESCRIPTION
This pull request introduces labels in the semantics, as well as the structured control-flow instructions which use them. It does not implement the inter-function instructions (like `call*`, `invoke`, or `return`).