### PR TITLE
.build/k, data, tests/simple/*: using correct wasm format for comments

### DIFF
--- a/data.md
+++ b/data.md
@@ -8,6 +8,19 @@ module WASM-DATA
     imports DOMAINS
 ```
 
+Layout
+------
+
+WASM allows for block comments using `(;` and `;)`, and line comments using `;;`.
+Additionally, white-space is skipped/ignored.
+
+```k
+    syntax #Layout ::= r"(\\(;([^;]|(;+([^;\\)])))*;\\))"
+                     | r"(;;[^\\n\\r]*)"
+                     | r"([\\ \\n\\r\\t])"
+ // --------------------------------------
+```
+
 WASM Types
 ----------
 

--- a/tests/simple/arithmetic.wast
+++ b/tests/simple/arithmetic.wast
@@ -73,7 +73,7 @@ i32.const 10
 i32.rem_s
 #assertTrap "rem_s"
 
-// The following tests were generated using the reference OCaml WASM interpreter.
+;; The following tests were generated using the reference OCaml WASM interpreter.
 
 i32.const 3
 i32.const 10

--- a/tests/simple/constants.wast
+++ b/tests/simple/constants.wast
@@ -1,5 +1,5 @@
-// Integers
-// --------
+;; Integers
+;; --------
 
 i32.const 3
 #assertTopStack < i32 > 3 "i32 1"
@@ -22,8 +22,8 @@ i32.const -5
 i32.const #unsigned(i32, -5)
 #assertTopStack < i32 > -5 "i32 signed assert"
 
-// Floating point
-// --------------
+;; Floating point
+;; --------------
 
 f32.const 3.245
 #assertTopStack < f32 > 3.245 "f32"
@@ -40,13 +40,13 @@ f32.const 3.245
 (f64.const 1.63176601e-302)
 #assertTopStack < f64 > 1.63176601e-302 "f64 scientific 3"
 
-// Below examples do not work with current float parser
-// (f64.const 0x1.da21c460a6f44p+52)
-// (f64.const 0x1.60859d2e7714ap-321)
-// (f64.const 0x1.e63f1b7b660e1p-302)
+;; Below examples do not work with current float parser
+;; (f64.const 0x1.da21c460a6f44p+52)
+;; (f64.const 0x1.60859d2e7714ap-321)
+;; (f64.const 0x1.e63f1b7b660e1p-302)
 
-// Helper conversions
-// ------------------
+;; Helper conversions
+;; ------------------
 
 i32.const #unsigned(i32, #signed(i32, 0))
 #assertTopStack < i32 > 0 "#unsigned . #signed 1"

--- a/tests/simple/control-flow.wast
+++ b/tests/simple/control-flow.wast
@@ -1,4 +1,4 @@
-// Blocks
+;; Blocks
 
 block [ i32 i32 i32 ]
     i32.const 1
@@ -22,7 +22,7 @@ block [ i32 i32 ]
 end
 #assertStack < i32 > 3 : < i32 > 2 : .Stack "block 3 (invalid)"
 
-// Breaks
+;; Breaks
 
 i32.const 1
 i32.const 2
@@ -98,7 +98,7 @@ block [ ]
 end
 #assertStack < i32 > 2 : < i32 > 1 : .Stack "br_if 1 true"
 
-// Conditional
+;; Conditional
 
 i32.const 1
 if [ i32 ] i32.const 1 else i32.const -1 end
@@ -108,24 +108,24 @@ i32.const 0
 if [ i32 ] i32.const 1 else i32.const -1 end
 #assertTopStack < i32 > -1 "if false"
 
-// Looping
-// TODO: We need locals before loops become effective.
-// i32.const 0
-// loop [ ]
-//     block [ ]
-//         i32.const 10
-//         i32.eq
-//         br_if 1
-//     end
-//     i32.const 1
-//     i32.add
-// end
-// #assertTopStack < i32 > 10 "loop"
+;; Looping
+;; TODO: We need locals before loops become effective.
+;; i32.const 0
+;; loop [ ]
+;;     block [ ]
+;;         i32.const 10
+;;         i32.eq
+;;         br_if 1
+;;     end
+;;     i32.const 1
+;;     i32.add
+;; end
+;; #assertTopStack < i32 > 10 "loop"
 
-// Stack Underflow
-// TODO: We need to give semantics to stack underflow (though it could not happen with a validated program).
-// We need `trap` semantics first.
-// i32.const 0
-// block [ i32 i32 ]
-//     i32.const 7
-// end
+;; Stack Underflow
+;; TODO: We need to give semantics to stack underflow (though it could not happen with a validated program).
+;; We need `trap` semantics first.
+;; i32.const 0
+;; block [ i32 i32 ]
+;;     i32.const 7
+;; end

--- a/tests/simple/functions.wast
+++ b/tests/simple/functions.wast
@@ -1,4 +1,4 @@
-// Simple add function
+;; Simple add function
 
 (func 0 param i32 i32 result i32
     get_local 0
@@ -13,7 +13,7 @@ invoke 0
 #assertTopStack < i32 > 15 "invoke function 0"
 #assertFunction 0          "invoke function 0 exists"
 
-// Remove return statement
+;; Remove return statement
 
 (func 0 param i32 i32 result i32
     get_local 0
@@ -27,7 +27,7 @@ invoke 0
 #assertTopStack < i32 > 15 "invoke function 0 no return"
 #assertFunction 0          "invoke function 0 exists no return"
 
-// More complicated function with locals
+;; More complicated function with locals
 
 (func 1 param i64 i64 i64 local i64 result i64
     get_local 0

--- a/tests/simple/memory.wast
+++ b/tests/simple/memory.wast
@@ -1,4 +1,4 @@
-// Test locals
+;; Test locals
 
 init_locals < i32 > 0 : < i32 > 0 : < i32 > 0 : .Stack
 
@@ -17,7 +17,7 @@ tee_local 2
 #assertTopStack < i32 > 67 "tee_local stack"
 #assertLocal 2 < i32 > 67 "tee_local local"
 
-// Test globals
+;; Test globals
 
 init_global 0 < i32 > 0
 init_global 1 < i32 > 0

--- a/tests/simple/polymorphic.wast
+++ b/tests/simple/polymorphic.wast
@@ -1,4 +1,4 @@
-// drop
+;; drop
 
 i32.const 15
 drop
@@ -16,7 +16,7 @@ f64.const 15.0
 drop
 #assertStack .Stack "drop f64"
 
-// select
+;; select
 
 i32.const -1
 i32.const 1


### PR DESCRIPTION
Switching to using correct comment style in WASM after adding support in K for it.