### PR TITLE
Fix for MacOS where absolute path messes up because of filename conventions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Settings
 # --------
 
-build_dir:=$(CURDIR)/.build
+build_dir:=.build
 defn_dir:=$(build_dir)/defn
 k_submodule:=$(build_dir)/k
 pandoc_tangle_submodule:=$(build_dir)/pandoc-tangle

--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,9 @@ ocaml-deps:
 	opam repository add k "$(k_submodule)/k-distribution/target/release/k/lib/opam" \
 		|| opam repository set-url k "$(k_submodule)/k-distribution/target/release/k/lib/opam"
 	opam update
-	opam switch 4.03.0+k
+	opam switch 4.06.1+k
 	eval $$(opam config env) \
-	opam install --yes mlgmp zarith uuidm
+	    opam install --yes mlgmp zarith uuidm
 
 # Building Definition
 # -------------------

--- a/Makefile
+++ b/Makefile
@@ -79,14 +79,14 @@ build-wasm: $(wasm_dir)/wasm-kompiled/interpreter
 $(wasm_dir)/wasm-kompiled/interpreter: $(defn_wasm_files)
 	@echo "== kompile: $@"
 	eval $$(opam config env) \
-	$(k_bin)/kompile --debug --gen-ml-only -O3 --non-strict \
+	$(k_bin)/kompile --gen-ml-only -O3 --non-strict \
 					 --main-module WASM --syntax-module WASM $< --directory $(wasm_dir) \
 		&& ocamlfind opt -c $(wasm_dir)/wasm-kompiled/constants.ml -package gmp -package zarith \
 		&& ocamlfind opt -c -I $(wasm_dir)/wasm-kompiled \
 		&& ocamlfind opt -a -o $(wasm_dir)/semantics.cmxa \
 		&& ocamlfind remove wasm-semantics-plugin \
 		&& ocamlfind install wasm-semantics-plugin META $(wasm_dir)/semantics.cmxa $(wasm_dir)/semantics.a \
-		&& $(k_bin)/kompile --debug --packages wasm-semantics-plugin -O3 --non-strict \
+		&& $(k_bin)/kompile --packages wasm-semantics-plugin -O3 --non-strict \
 					 --main-module WASM --syntax-module WASM $< --directory $(wasm_dir) \
 		&& cd $(wasm_dir)/wasm-kompiled \
 		&& ocamlfind opt -o interpreter \
@@ -98,14 +98,14 @@ build-test: $(test_dir)/test-kompiled/interpreter
 $(test_dir)/test-kompiled/interpreter: $(defn_test_files)
 	@echo "== kompile: $@"
 	eval $$(opam config env) \
-	$(k_bin)/kompile --debug --gen-ml-only -O3 --non-strict \
+	$(k_bin)/kompile --gen-ml-only -O3 --non-strict \
 					 --main-module WASM-TEST --syntax-module WASM-TEST $< --directory $(test_dir) \
 		&& ocamlfind opt -c $(test_dir)/test-kompiled/constants.ml -package gmp -package zarith \
 		&& ocamlfind opt -c -I $(test_dir)/test-kompiled \
 		&& ocamlfind opt -a -o $(test_dir)/semantics.cmxa \
 		&& ocamlfind remove test-semantics-plugin \
 		&& ocamlfind install test-semantics-plugin META $(test_dir)/semantics.cmxa $(test_dir)/semantics.a \
-		&& $(k_bin)/kompile --debug --packages test-semantics-plugin -O3 --non-strict \
+		&& $(k_bin)/kompile --packages test-semantics-plugin -O3 --non-strict \
 					 --main-module WASM-TEST --syntax-module WASM-TEST $< --directory $(test_dir) \
 		&& cd $(test_dir)/test-kompiled \
 		&& ocamlfind opt -o interpreter \

--- a/kwasm
+++ b/kwasm
@@ -3,6 +3,16 @@
 set -e      # Exit immediately if any command fails
 set -u      # Using undefined variables is an error. Exit immediately
 
+# https://stackoverflow.com/questions/59895/getting-the-source-directory-of-a-bash-script-from-within
+kwasm_script="$0"
+while [[ -h "$kwasm_script" ]]; do
+    kwasm_dir="$(cd -P "$(dirname "$kwasm_script")" && pwd)"
+    kwasm_script="$(readlink "$kwasm_script")"
+    [[ "$kwasm_script" != /* ]] && kwasm_script="$kwasm_dir/$kwasm_script"
+done
+kwasm_dir="$(cd -P "$(dirname "$kwasm_script")" && pwd)"
+build_dir="$kwasm_dir/.build"
+
 # Utilities
 # ---------
 
@@ -18,11 +28,11 @@ pretty_diff() {
 
 run_env() {
     local run_file="$1"
-    local build_dir="$(pwd)/.build"
     local release_dir="$build_dir/k/k-distribution/target/release/k"
     [[ "$run_file" =~ ^tests/* ]] && DEFN_DIRECTORY=$build_dir/defn/test
     export DEFN_DIR="${DEFN_DIRECTORY:-$build_dir/defn/wasm}"
     export PATH="$release_dir/lib/native/linux:$release_dir/lib/native/linux64:$release_dir/bin/:$PATH"
+    export LD_LIBRARY_PATH="$release_dir/lib/native/linux64:${LD_LIBRARY_PATH:-}"
     eval $(opam config env)
 }
 


### PR DESCRIPTION
@mrchico this should address #21 