### PR TITLE
Add `unreachable` instruction

### DIFF
--- a/tests/simple/control-flow.wast
+++ b/tests/simple/control-flow.wast
@@ -1,3 +1,7 @@
+;; Unreachable
+unreachable
+#assertTrap "unreachable"
+
 ;; Blocks
 
 block [ i32 i32 i32 ]

--- a/wasm.md
+++ b/wasm.md
@@ -258,7 +258,7 @@ Structured Control Flow
 
 ```k
     syntax Instr ::= "unreachable"
- // -----------------------
+ // ------------------------------
     rule unreachable => trap
 ```
 

--- a/wasm.md
+++ b/wasm.md
@@ -254,6 +254,14 @@ Structured Control Flow
     rule <k> nop => . ... </k>
 ```
 
+`unreachable` causes an immediate `trap`.
+
+```k
+    syntax Instr ::= "unreachable"
+ // -----------------------
+    rule unreachable => trap
+```
+
 Labels are administrative instructions used to mark the targets of break instructions.
 They contain the continuation to use following the label, as well as the original stack to restore.
 The supplied type represents the values that should taken from the current stack.


### PR DESCRIPTION
I noticed this was missing in the control flow instruction set. [It is used a few times in the official test suite](https://github.com/search?q=unreachable+repo%3AWebAssembly%2Fspec+path%3A%2Ftest%2Fcore&type=Code), whereas the `trap` is not used in any programs as far as I can tell.

From page 69 in official spec:

`unreachable`
1. Trap.
unreachable ˓→ trap