### PR TITLE
Remove unnecessary production

### DIFF
--- a/data.md
+++ b/data.md
@@ -104,8 +104,7 @@ Proper values are numbers annotated with their types.
 ```k
     syntax IVal ::= "<" IValType ">" Int
     syntax FVal ::= "<" FValType ">" Float
-    syntax  Val ::= "<"  ValType ">" Number
-                  | IVal | FVal
+    syntax  Val ::=  IVal | FVal
  // ---------------------------
 ```
 


### PR DESCRIPTION
The rule ` "<"  ValType ">" Number ` seems unnecessary, and allows, in theory, `Val`s with integer type and float value, and vice versa. 

These two cases (int/float mixed type and value) are the only cases not covered by the rule `IVal | FVal`, because `syntax  ValType ::= IValType | FValType`.

```
    syntax IVal ::= "<" IValType ">" Int
    syntax FVal ::= "<" FValType ">" Float
     syntax  Val ::= "<"  ValType ">" Number 
                     | IVal | FVal
```