### PR TITLE
Update to use proper WASM identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ make test
 Resources
 =========
 
-[WebAssembly]: <https://github.com/WebAssembly/design>
+[WebAssembly]: <https://webassembly.github.io/spec/>

--- a/data.md
+++ b/data.md
@@ -8,17 +8,31 @@ module WASM-DATA
     imports DOMAINS
 ```
 
-Layout
-------
+Parsing
+-------
+
+### Layout
 
 WASM allows for block comments using `(;` and `;)`, and line comments using `;;`.
 Additionally, white-space is skipped/ignored.
+Declaring regular expressions of sort `#Layout` infroms the K lexer to drop these tokens.
 
 ```k
-    syntax #Layout ::= r"(\\(;([^;]|(;+([^;\\)])))*;\\))"
-                     | r"(;;[^\\n\\r]*)"
-                     | r"([\\ \\n\\r\\t])"
- // --------------------------------------
+    syntax #Layout ::= r"\\(;([^;]|(;+([^;\\)])))*;\\)"
+                     | r";;[^\\n\\r]*"
+                     | r"[\\ \\n\\r\\t]"
+ // ------------------------------------
+```
+
+### Identifiers
+
+As defined in the [WASM Spec], the syntax of identifiers is as follows.
+
+**TODO**: Unsupported characters: `.:^@`
+
+```k
+    syntax Identifier ::= r"\\$[0-9a-zA-Z!$%&'*+/<>?_`|~=-]*" [avoid, token]
+ // ------------------------------------------------------------------------
 ```
 
 WASM Types
@@ -187,3 +201,8 @@ Operator `_++_` implements an append operator for sort `Stack`.
     rule #drop(TYPE VTYPES, < TYPE > VAL:Number : STACK) => #drop(VTYPES, STACK)
 endmodule
 ```
+
+Resources
+=========
+
+[WASM Spec]: <https://github.com/WebAssembly/design>

--- a/tests/simple/functions.wast
+++ b/tests/simple/functions.wast
@@ -16,7 +16,7 @@ invoke 0
 
 ;; String-named add function
 
-(func "add" :: [ i32 i32 ] -> [ i32 ]
+(func $add :: [ i32 i32 ] -> [ i32 ]
     [ ]
     get_local 0
     get_local 1
@@ -24,18 +24,18 @@ invoke 0
     return
 )
 
-#assertFunction "add" [ i32 i32 ] -> [ i32 ] [ ] "function string-named add"
+#assertFunction $add [ i32 i32 ] -> [ i32 ] [ ] "function string-named add"
 
 ;; Exported name add function
 
-(func export "add" param i32 i32 result i32
+(func export $add param i32 i32 result i32
     get_local 0
     get_local 1
     i32.add
     return
 )
 
-#assertFunction "add" [ i32 i32 ] -> [ i32 ] [ ] "exported function name add"
+#assertFunction $add [ i32 i32 ] -> [ i32 ] [ ] "exported function name add"
 
 ;; Remove return statement
 

--- a/tests/simple/functions.wast
+++ b/tests/simple/functions.wast
@@ -110,3 +110,9 @@ i64.const 8
 invoke 1
 #assertTopStack < i64 > 8 "empty type declaration + parens"
 #assertFunction 1 [ i64 i64 ] -> [ i64 ] [ ] "empty type declarations + parens"
+
+;; Function with just a name
+
+(func 3)
+
+#assertFunction 3 [ ] -> [ ] [ ] "no domain/range or locals"

--- a/tests/simple/identifiers.wast
+++ b/tests/simple/identifiers.wast
@@ -1,6 +1,6 @@
 ;; tests of function identifier names
 
-( func "oeauth" :: [ i32 i32 ] -> [ i32 ]
+( func $oeauth :: [ i32 i32 ] -> [ i32 ]
     [ ]
     get_local 0
     get_local 1
@@ -8,7 +8,7 @@
     return
 )
 
-#assertFunction "oeauth" [ i32 i32 ] -> [ i32 ] [ ] "string function name"
+#assertFunction $oeauth [ i32 i32 ] -> [ i32 ] [ ] "simple function name"
 
 ( func $023eno!thu324 :: [ i32 i32 ] -> [ i32 ]
     [ ]

--- a/tests/simple/identifiers.wast
+++ b/tests/simple/identifiers.wast
@@ -1,0 +1,61 @@
+;; tests of function identifier names
+
+( func "oeauth" :: [ i32 i32 ] -> [ i32 ]
+    [ ]
+    get_local 0
+    get_local 1
+    i32.add
+    return
+)
+
+#assertFunction "oeauth" [ i32 i32 ] -> [ i32 ] [ ] "string function name"
+
+( func $023eno!thu324 :: [ i32 i32 ] -> [ i32 ]
+    [ ]
+    get_local 0
+    get_local 1
+    i32.add
+    return
+)
+
+#assertFunction $023eno!thu324 [ i32 i32 ] -> [ i32 ] [ ] "identifier function name 1"
+
+( func $02$3e%no!t&hu324 :: [ i32 i32 ] -> [ i32 ]
+    [ ]
+    get_local 0
+    get_local 1
+    i32.add
+    return
+)
+
+#assertFunction $02$3e%no!t&hu324 [ i32 i32 ] -> [ i32 ] [ ] "identifier function name 2"
+
+( func $02$3e%no!t&hu3'24*32++2ao-eunth :: [ i32 i32 ] -> [ i32 ]
+    [ ]
+    get_local 0
+    get_local 1
+    i32.add
+    return
+)
+
+#assertFunction $02$3e%no!t&hu3'24*32++2ao-eunth [ i32 i32 ] -> [ i32 ] [ ] "identifier function name 3"
+
+( func $02$3e%no!t&hu3'24*32++2ao-eu//n<t>h? :: [ i32 i32 ] -> [ i32 ]
+    [ ]
+    get_local 0
+    get_local 1
+    i32.add
+    return
+)
+
+#assertFunction $02$3e%no!t&hu3'24*32++2ao-eu//n<t>h? [ i32 i32 ] -> [ i32 ] [ ] "identifier function name 3"
+
+( func $aenuth_ae`st|23~423 :: [ i32 i32 ] -> [ i32 ]
+    [ ]
+    get_local 0
+    get_local 1
+    i32.add
+    return
+)
+
+#assertFunction $aenuth_ae`st|23~423 [ i32 i32 ] -> [ i32 ] [ ] "identifier function name 3"

--- a/tests/simple/modules.wast
+++ b/tests/simple/modules.wast
@@ -76,3 +76,17 @@ invoke "f2"
 #assertTopStack < i32 > 77000 "nested method call"
 #assertFunction "f2" [ i32 i32 i32 ] -> [ i32 ] [ i32 i32 ] "outer calling method"
 #assertFunction "f1" [ i32 i32     ] -> [ i32 ] [ i32     ] "inner calling method"
+
+(module
+    (func $dummy)
+
+    (func "$add" (param i32 i32) (result i32)
+        get_local 0
+        get_local 1
+        i32.add
+        return
+    )
+)
+
+#assertFunction $dummy [         ] -> [     ] [ ] "$dummy function in module"
+#assertFunction "$add" [ i32 i32 ] -> [ i32 ] [ ] "second function in module"

--- a/tests/simple/modules.wast
+++ b/tests/simple/modules.wast
@@ -1,5 +1,5 @@
 (module
-    (func "add" :: [ i32 i32 ] -> [ i32 ]
+    (func $add :: [ i32 i32 ] -> [ i32 ]
         [ ]
         get_local 0
         get_local 1
@@ -7,7 +7,7 @@
         return
     )
 
-    (func "mul" :: [ i32 i32 ] -> [ i32 ]
+    (func $mul :: [ i32 i32 ] -> [ i32 ]
         [ ]
         get_local 0
         get_local 1
@@ -15,7 +15,7 @@
         return
     )
 
-    (func (export "xor") (param i32 i32) (result i32)
+    (func (export $xor) (param i32 i32) (result i32)
         get_local 0
         get_local 1
         i32.xor
@@ -24,25 +24,25 @@
 
 i32.const 3
 i32.const 5
-invoke "add"
+invoke $add
 #assertTopStack < i32 > 8 "add in module correctly"
 
 i32.const 3
 i32.const 5
-invoke "mul"
+invoke $mul
 #assertTopStack < i32 > 15 "mul in module correctly"
 
 i32.const 3
 i32.const 5
-invoke "xor"
+invoke $xor
 #assertTopStack < i32 > 6 "xor in module correctly"
 
-#assertFunction "add" [ i32 i32 ] -> [ i32 ] [ ] "add function typed correctly"
-#assertFunction "mul" [ i32 i32 ] -> [ i32 ] [ ] "mul function typed correctly"
-#assertFunction "xor" [ i32 i32 ] -> [ i32 ] [ ] "xor function typed correctly"
+#assertFunction $add [ i32 i32 ] -> [ i32 ] [ ] "add function typed correctly"
+#assertFunction $mul [ i32 i32 ] -> [ i32 ] [ ] "mul function typed correctly"
+#assertFunction $xor [ i32 i32 ] -> [ i32 ] [ ] "xor function typed correctly"
 
 (module
-    (func "f1" :: [ i32 i32 ] -> [ i32 ]
+    (func $f1 :: [ i32 i32 ] -> [ i32 ]
         [ i32 ]
         get_local 0
         get_local 1
@@ -54,13 +54,13 @@ invoke "xor"
         return
     )
 
-    (func "f2" :: [ i32 i32 i32 ] -> [ i32 ]
+    (func $f2 :: [ i32 i32 i32 ] -> [ i32 ]
         [ i32 i32 ]
         get_local 0
         get_local 2
-        invoke "f1"
+        invoke $f1
         get_local 1
-        invoke "f1"
+        invoke $f1
         get_local 0
         i32.mul
         return
@@ -69,18 +69,18 @@ invoke "xor"
 
 i32.const 3
 i32.const 5
-invoke "f1"
+invoke $f1
 i32.const 5
 i32.const 8
-invoke "f2"
+invoke $f2
 #assertTopStack < i32 > 77000 "nested method call"
-#assertFunction "f2" [ i32 i32 i32 ] -> [ i32 ] [ i32 i32 ] "outer calling method"
-#assertFunction "f1" [ i32 i32     ] -> [ i32 ] [ i32     ] "inner calling method"
+#assertFunction $f2 [ i32 i32 i32 ] -> [ i32 ] [ i32 i32 ] "outer calling method"
+#assertFunction $f1 [ i32 i32     ] -> [ i32 ] [ i32     ] "inner calling method"
 
 (module
     (func $dummy)
 
-    (func "$add" (param i32 i32) (result i32)
+    (func $add (param i32 i32) (result i32)
         get_local 0
         get_local 1
         i32.add
@@ -89,4 +89,4 @@ invoke "f2"
 )
 
 #assertFunction $dummy [         ] -> [     ] [ ] "$dummy function in module"
-#assertFunction "$add" [ i32 i32 ] -> [ i32 ] [ ] "second function in module"
+#assertFunction $add   [ i32 i32 ] -> [ i32 ] [ ] "second function in module"

--- a/wasm.md
+++ b/wasm.md
@@ -456,8 +456,8 @@ Function declarations can look quite different depending on which fields are omm
 Here, we allow for an "abstract" function declaration using syntax `func_::___`, and a more concrete one which allows arbitrary order of declaration of parameters, locals, and results.
 
 ```k
-    syntax FunctionName ::= Int | String | Identifier
- // -------------------------------------------------
+    syntax FunctionName ::= Int | Identifier
+ // ----------------------------------------
 
     syntax TypeKeyWord ::= "param" | "result" | "local"
  // ---------------------------------------------------

--- a/wasm.md
+++ b/wasm.md
@@ -456,8 +456,8 @@ Function declarations can look quite different depending on which fields are omm
 Here, we allow for an "abstract" function declaration using syntax `func_::___`, and a more concrete one which allows arbitrary order of declaration of parameters, locals, and results.
 
 ```k
-    syntax FunctionName ::= Int | String
- // ------------------------------------
+    syntax FunctionName ::= Int | String | Identifier
+ // -------------------------------------------------
 
     syntax TypeKeyWord ::= "param" | "result" | "local"
  // ---------------------------------------------------


### PR DESCRIPTION
This isn't a perfect match of allowable identifiers, but I was having trouble getting the Flex lexer to accept the remaining characters. The unsupported characters are documented, so that a later PR can come through and fix them.

@mrchico I know you were looking at this, can you take a peek and see what you think?