### PR TITLE
Simplifying parsing for introduction of folded syntax by requiring paranthesis

### DIFF
--- a/tests/simple/arithmetic.wast
+++ b/tests/simple/arithmetic.wast
@@ -1,151 +1,151 @@
-i32.const 5
-i32.const 7
-i32.add
+(i32.const 5)
+(i32.const 7)
+(i32.add)
 #assertTopStack < i32 > 12 "add"
 
-i32.const 5
-i32.const 7
-i32.sub
+(i32.const 5)
+(i32.const 7)
+(i32.sub)
 #assertTopStack < i32 > 2 "sub"
 
-i32.const 15
-i32.const 3
-i32.mul
+(i32.const 15)
+(i32.const 3)
+(i32.mul)
 #assertTopStack < i32 > 45 "mul"
 
-i32.const 3
-i32.const 15
-i32.div_u
+(i32.const 3)
+(i32.const 15)
+(i32.div_u)
 #assertTopStack < i32 > 5 "div_u1"
 
-i32.const 2
-i32.const 15
-i32.div_u
+(i32.const 2)
+(i32.const 15)
+(i32.div_u)
 #assertTopStack < i32 > 7 "div_u2"
 
-i32.const 0
-i32.const 15
-i32.div_u
+(i32.const 0)
+(i32.const 15)
+(i32.div_u)
 #assertTrap "div_u3"
 
-i32.const 3
-i32.const 15
-i32.rem_u
+(i32.const 3)
+(i32.const 15)
+(i32.rem_u)
 #assertTopStack < i32 > 0 "rem_u1"
 
-i32.const 2
-i32.const 15
-i32.rem_u
+(i32.const 2)
+(i32.const 15)
+(i32.rem_u)
 #assertTopStack < i32 > 1 "rem_u2"
 
-i32.const 0
-i32.const 15
-i32.rem_u
+(i32.const 0)
+(i32.const 15)
+(i32.rem_u)
 #assertTrap "rem_u3"
 
-i32.const 3
-i32.const 10
-i32.div_s
+(i32.const 3)
+(i32.const 10)
+(i32.div_s)
 #assertTopStack < i32 > 3 "i32.div_s 1"
 
-i32.const 4
-i32.const 10
-i32.div_s
+(i32.const 4)
+(i32.const 10)
+(i32.div_s)
 #assertTopStack < i32 > 2 "i32.div_s 2"
 
-i32.const 0
-i32.const 10
-i32.div_s
+(i32.const 0)
+(i32.const 10)
+(i32.div_s)
 #assertTrap "i32.div_s 3"
 
-i32.const #pow(i32) -Int 1
-i32.const #pow1(i32)
-i32.div_s
+(i32.const #pow(i32) -Int 1)
+(i32.const #pow1(i32))
+(i32.div_s)
 #assertTrap "i32.div_s 4"
 
-i32.const 5
-i32.const 10
-i32.div_s
+(i32.const 5)
+(i32.const 10)
+(i32.div_s)
 #assertTopStack < i32 > 2 "div_s"
 
-i32.const 0
-i32.const 10
-i32.rem_s
+(i32.const 0)
+(i32.const 10)
+(i32.rem_s)
 #assertTrap "rem_s"
 
 ;; The following tests were generated using the reference OCaml WASM interpreter.
 
-i32.const 3
-i32.const 10
-i32.rem_s
+(i32.const 3)
+(i32.const 10)
+(i32.rem_s)
 #assertTopStack < i32 > 1 "i32.rem_s 1"
 
-i32.const 4
-i32.const 10
-i32.rem_s
+(i32.const 4)
+(i32.const 10)
+(i32.rem_s)
 #assertTopStack < i32 > 2 "i32.rem_s 2"
 
-i32.const 5
-i32.const 10
-i32.rem_s
+(i32.const 5)
+(i32.const 10)
+(i32.rem_s)
 #assertTopStack < i32 > 0 "i32.rem_s 3"
 
-i32.const 3
-i32.const -10
-i32.div_s
+(i32.const 3)
+(i32.const -10)
+(i32.div_s)
 #assertTopStack < i32 > -3 "i32.div_s 3"
 
-i32.const 4
-i32.const -10
-i32.div_s
+(i32.const 4)
+(i32.const -10)
+(i32.div_s)
 #assertTopStack < i32 > -2 "i32.div_s 4"
 
-i32.const 5
-i32.const -10
-i32.div_s
+(i32.const 5)
+(i32.const -10)
+(i32.div_s)
 #assertTopStack < i32 > -2 "i32.div_s 5"
 
-i32.const 3
-i32.const -10
-i32.rem_s
+(i32.const 3)
+(i32.const -10)
+(i32.rem_s)
 #assertTopStack < i32 > -1 "i32.rem_s 4"
 
-i32.const 4
-i32.const -10
-i32.rem_s
+(i32.const 4)
+(i32.const -10)
+(i32.rem_s)
 #assertTopStack < i32 > -2 "i32.rem_s 5"
 
-i32.const 5
-i32.const -10
-i32.rem_s
+(i32.const 5)
+(i32.const -10)
+(i32.rem_s)
 #assertTopStack < i32 > 0 "i32.rem_s 6"
 
-i32.const -3
-i32.const -10
-i32.div_s
+(i32.const -3)
+(i32.const -10)
+(i32.div_s)
 #assertTopStack < i32 > 3 "i32.div_s 6"
 
-i32.const -4
-i32.const -10
-i32.div_s
+(i32.const -4)
+(i32.const -10)
+(i32.div_s)
 #assertTopStack < i32 > 2 "i32.div_s 7"
 
-i32.const -5
-i32.const -10
-i32.div_s
+(i32.const -5)
+(i32.const -10)
+(i32.div_s)
 #assertTopStack < i32 > 2 "i32.div_s 8"
 
-i32.const -3
-i32.const -10
-i32.rem_s
+(i32.const -3)
+(i32.const -10)
+(i32.rem_s)
 #assertTopStack < i32 > -1 "i32.rem_s 7"
 
-i32.const -4
-i32.const -10
-i32.rem_s
+(i32.const -4)
+(i32.const -10)
+(i32.rem_s)
 #assertTopStack < i32 > -2 "i32.rem_s 8"
 
-i32.const -5
-i32.const -10
-i32.rem_s
+(i32.const -5)
+(i32.const -10)
+(i32.rem_s)
 #assertTopStack < i32 > 0 "i32.rem_s 9"

--- a/tests/simple/bitwise.wast
+++ b/tests/simple/bitwise.wast
@@ -1,150 +1,150 @@
-i32.const 20
-i32.const 18
-i32.and
+(i32.const 20)
+(i32.const 18)
+(i32.and)
 #assertTopStack < i32 > 16 "and"
 
-i32.const 20
-i32.const 18
-i32.or
+(i32.const 20)
+(i32.const 18)
+(i32.or)
 #assertTopStack < i32 > 22 "or"
 
-i32.const 20
-i32.const 18
-i32.xor
+(i32.const 20)
+(i32.const 18)
+(i32.xor)
 #assertTopStack < i32 > 6 "xor"
 
-i32.const 2
-i32.const 1
-i32.shl
+(i32.const 2)
+(i32.const 1)
+(i32.shl)
 #assertTopStack < i32 > 4 "shl 1"
 
-i32.const 2
-i32.const #pow1(i32) +Int 1
-i32.shl
+(i32.const 2)
+(i32.const #pow1(i32) +Int 1)
+(i32.shl)
 #assertTopStack < i32 > 4 "shl 2"
 
-i32.const 2
-i32.const #pow1(i32)
-i32.shr_u
+(i32.const 2)
+(i32.const #pow1(i32))
+(i32.shr_u)
 #assertTopStack < i32 > 2 ^Int 29 "shr_u 1"
 
-i32.const 2
-i32.const 2
-i32.shr_u
+(i32.const 2)
+(i32.const 2)
+(i32.shr_u)
 #assertTopStack < i32 > 0 "shr_u 2"
 
-i32.const 1
-i32.const #pow(i32) -Int 2
-i32.shr_s
+(i32.const 1)
+(i32.const #pow(i32) -Int 2)
+(i32.shr_s)
 #assertTopStack < i32 > #pow(i32) -Int 1 "shr_s 1"
 
-i32.const 2
-i32.const 2
-i32.shr_s
+(i32.const 2)
+(i32.const 2)
+(i32.shr_s)
 #assertTopStack < i32 > 0 "shr_s 2"
 
-i32.const 3
-i32.const #pow1(i32) +Int 2
-i32.rotl
+(i32.const 3)
+(i32.const #pow1(i32) +Int 2)
+(i32.rotl)
 #assertTopStack < i32 > 20 "rotl"
 
-i32.const 3
-i32.const #pow1(i32) +Int 16
-i32.rotr
+(i32.const 3)
+(i32.const #pow1(i32) +Int 16)
+(i32.rotr)
 #assertTopStack < i32 > 2 ^Int 28 +Int 2 "rotr"
 
 ;; clz
 
-i32.const #pow1(i32)
-i32.clz
+(i32.const #pow1(i32))
+(i32.clz)
 #assertTopStack < i32 > 0 "clz #pow1(i32)"
-i64.const #pow1(i64)
-i64.clz
+(i64.const #pow1(i64))
+(i64.clz)
 #assertTopStack < i64 > 0 "clz #pow1(i32)"
 
-i32.const 0
-i32.clz
+(i32.const 0)
+(i32.clz)
 #assertTopStack < i32 > 32 "clz 0"
-i64.const 0
-i64.clz
+(i64.const 0)
+(i64.clz)
 #assertTopStack < i64 > 64 "clz 0"
 
-i32.const 1
-i32.clz
+(i32.const 1)
+(i32.clz)
 #assertTopStack < i32 > 31 "clz 1"
-i64.const 1
-i64.clz
+(i64.const 1)
+(i64.clz)
 #assertTopStack < i64 > 63 "clz 1"
 
-i32.const 2 ^Int 32 -Int 1
-i32.clz
+(i32.const 2 ^Int 32 -Int 1)
+(i32.clz)
 #assertTopStack < i32 > 0 "clz 2^32 - 1"
-i64.const 2 ^Int 64 -Int 1
-i64.clz
+(i64.const 2 ^Int 64 -Int 1)
+(i64.clz)
 #assertTopStack < i64 > 0 "clz 2^64 - 1"
 
-i32.const 2 ^Int 31 -Int 1
-i32.clz
+(i32.const 2 ^Int 31 -Int 1)
+(i32.clz)
 #assertTopStack < i32 > 1 "clz 2^31 - 1"
-i64.const 2 ^Int 63 -Int 1
-i64.clz
+(i64.const 2 ^Int 63 -Int 1)
+(i64.clz)
 #assertTopStack < i64 > 1 "clz 2^63 - 1"
 
 ;; ctz
-i32.const #pow1(i32)
-i32.ctz
+(i32.const #pow1(i32))
+(i32.ctz)
 #assertTopStack < i32 > 31 "ctz #pow1(i32)"
-i64.const #pow1(i64)
-i64.ctz
+(i64.const #pow1(i64))
+(i64.ctz)
 #assertTopStack < i64 > 63 "ctz #pow1(i32)"
 
-i32.const 0
-i32.ctz
+(i32.const 0)
+(i32.ctz)
 #assertTopStack < i32 > 32 "ctz 0"
-i64.const 0
-i64.ctz
+(i64.const 0)
+(i64.ctz)
 #assertTopStack < i64 > 64 "ctz 0"
 
-i32.const 1
-i32.ctz
+(i32.const 1)
+(i32.ctz)
 #assertTopStack < i32 > 0 "ctz 1"
-i64.const 1
-i64.ctz
+(i64.const 1)
+(i64.ctz)
 #assertTopStack < i64 > 0 "ctz 1"
 
-i32.const 2 ^Int 32 -Int 1
-i32.ctz
+(i32.const 2 ^Int 32 -Int 1)
+(i32.ctz)
 #assertTopStack < i32 > 0 "ctz 2^32 - 1"
-i64.const 2 ^Int 64 -Int 1
-i64.ctz
+(i64.const 2 ^Int 64 -Int 1)
+(i64.ctz)
 #assertTopStack < i64 > 0 "ctz 2^64 - 1"
 
 ;; popcnt
 
-i32.const #pow1(i32)
-i32.popcnt
+(i32.const #pow1(i32))
+(i32.popcnt)
 #assertTopStack < i32 > 1 "popcnt #pow1(i32)"
-i64.const #pow1(i64)
-i64.popcnt
+(i64.const #pow1(i64))
+(i64.popcnt)
 #assertTopStack < i64 > 1 "popcnt #pow1(i32)"
 
-i32.const 0
-i32.popcnt
+(i32.const 0)
+(i32.popcnt)
 #assertTopStack < i32 > 0 "popcnt 0"
-i64.const 0
-i64.popcnt
+(i64.const 0)
+(i64.popcnt)
 #assertTopStack < i64 > 0 "popcnt 0"
 
-i32.const 1
-i32.popcnt
+(i32.const 1)
+(i32.popcnt)
 #assertTopStack < i32 > 1 "popcnt 1"
-i64.const 1
-i64.popcnt
+(i64.const 1)
+(i64.popcnt)
 #assertTopStack < i64 > 1 "popcnt 1"
 
-i32.const 2 ^Int 32 -Int 1
-i32.popcnt
+(i32.const 2 ^Int 32 -Int 1)
+(i32.popcnt)
 #assertTopStack < i32 > 32 "popcnt 2^32 - 1"
-i64.const 2 ^Int 64 -Int 1
-i64.popcnt
+(i64.const 2 ^Int 64 -Int 1)
+(i64.popcnt)
 #assertTopStack < i64 > 64 "popcnt 2^64 - 1"

--- a/tests/simple/comments.wast
+++ b/tests/simple/comments.wast
@@ -1,7 +1,7 @@
-i32.const 7
+(i32.const 7)
 ;; this should be ignored
-i32.const 8 ;; this should be ignored as well
-i32.add
+(i32.const 8) ;; this should be ignored as well
+(i32.add)
 
 (;
 all this text
@@ -10,7 +10,12 @@ should be ignored
 
 #assertTopStack < i32 > 15 "dummy test 1"
 
-i32.const -3
-i32.const 6     (; comment at end of line ;)
-i32.add
+(i32.const -3)
+(i32.const 6)     (; comment at end of line ;)
+(i32.add)
+#assertTopStack < i32 > 3 "dummy test 2"
+
+(i32.const -3)
+(i32.(;comment in the middle;)const 6)
+(i32.add)
 #assertTopStack < i32 > 3 "dummy test 2"

--- a/tests/simple/comparison.wast
+++ b/tests/simple/comparison.wast
@@ -1,107 +1,107 @@
-i32.const 0
-i32.eqz
+(i32.const 0)
+(i32.eqz)
 #assertTopStack < i32 > 1 "eqz1"
 
-i32.const 3
-i32.eqz
+(i32.const 3)
+(i32.eqz)
 #assertTopStack < i32 > 0 "eqz2"
 
-i32.const 3
-i32.const 3
-i32.eq
+(i32.const 3)
+(i32.const 3)
+(i32.eq)
 #assertTopStack < i32 > 1 "eq1"
 
-i32.const 3
-i32.const 4
-i32.eq
+(i32.const 3)
+(i32.const 4)
+(i32.eq)
 #assertTopStack < i32 > 0 "eq2"
 
-i32.const 3
-i32.const 3
-i32.ne
+(i32.const 3)
+(i32.const 3)
+(i32.ne)
 #assertTopStack < i32 > 0 "ne1"
 
-i32.const 3
-i32.const 4
-i32.ne
+(i32.const 3)
+(i32.const 4)
+(i32.ne)
 #assertTopStack < i32 > 1 "ne2"
 
-i32.const 32
-i32.const 2
-i32.lt_u
+(i32.const 32)
+(i32.const 2)
+(i32.lt_u)
 #assertTopStack < i32 > 1 "lt_u"
 
-i32.const 32
-i32.const 2
-i32.gt_u
+(i32.const 32)
+(i32.const 2)
+(i32.gt_u)
 #assertTopStack < i32 > 0 "gt_u"
 
-i32.const #pow1(i32) +Int 15
-i32.const #pow1(i32) +Int 7
-i32.lt_s
+(i32.const #pow1(i32) +Int 15)
+(i32.const #pow1(i32) +Int 7)
+(i32.lt_s)
 #assertTopStack < i32 > 1 "lt_s 1"
 
-i32.const 32
-i32.const -32
-i32.lt_s
+(i32.const 32)
+(i32.const -32)
+(i32.lt_s)
 #assertTopStack < i32 > 1 "lt_s 2"
 
-i32.const #pow1(i32) +Int 15
-i32.const #pow1(i32) +Int 7
-i32.gt_s
+(i32.const #pow1(i32) +Int 15)
+(i32.const #pow1(i32) +Int 7)
+(i32.gt_s)
 #assertTopStack < i32 > 0 "gt_s 1"
 
-i32.const 32
-i32.const -32
-i32.gt_s
+(i32.const 32)
+(i32.const -32)
+(i32.gt_s)
 #assertTopStack < i32 > 0 "gt_s 2"
 
-i32.const 32
-i32.const 2
-i32.le_u
+(i32.const 32)
+(i32.const 2)
+(i32.le_u)
 #assertTopStack < i32 > 1 "le_u 1"
 
-i32.const 32
-i32.const 32
-i32.le_u
+(i32.const 32)
+(i32.const 32)
+(i32.le_u)
 #assertTopStack < i32 > 1 "le_u 2"
 
-i32.const 32
-i32.const 2
-i32.ge_u
+(i32.const 32)
+(i32.const 2)
+(i32.ge_u)
 #assertTopStack < i32 > 0 "ge_u 1"
 
-i32.const 32
-i32.const 32
-i32.ge_u
+(i32.const 32)
+(i32.const 32)
+(i32.ge_u)
 #assertTopStack < i32 > 1 "ge_u 2"
 
-i32.const #pow1(i32) +Int 15
-i32.const #pow1(i32) +Int 7
-i32.le_s
+(i32.const #pow1(i32) +Int 15)
+(i32.const #pow1(i32) +Int 7)
+(i32.le_s)
 #assertTopStack < i32 > 1 "le_s 1"
 
-i32.const 32
-i32.const 32
-i32.le_s
+(i32.const 32)
+(i32.const 32)
+(i32.le_s)
 #assertTopStack < i32 > 1 "le_s 2"
 
-i32.const 32
-i32.const -32
-i32.le_s
+(i32.const 32)
+(i32.const -32)
+(i32.le_s)
 #assertTopStack < i32 > 1 "le_s 3"
 
-i32.const #pow1(i32) +Int 15
-i32.const #pow1(i32) +Int 7
-i32.ge_s
+(i32.const #pow1(i32) +Int 15)
+(i32.const #pow1(i32) +Int 7)
+(i32.ge_s)
 #assertTopStack < i32 > 0 "ge_s 1"
 
-i32.const 32
-i32.const 32
-i32.ge_s
+(i32.const 32)
+(i32.const 32)
+(i32.ge_s)
 #assertTopStack < i32 > 1 "ge_s 2"
 
-i32.const 32
-i32.const -32
-i32.ge_s
+(i32.const 32)
+(i32.const -32)
+(i32.ge_s)
 #assertTopStack < i32 > 0 "ge_s 3"

--- a/tests/simple/constants.wast
+++ b/tests/simple/constants.wast
@@ -1,37 +1,37 @@
 ;; Integers
 ;; --------
 
-i32.const 3
+(i32.const 3)
 #assertTopStack < i32 > 3 "i32 1"
 
 (i32.const 5)
 #assertTopStack < i32 > 5 "i32 parens"
 
-i64.const 71
+(i64.const 71)
 #assertTopStack < i64 > 71 "i64"
 
-i32.const #unsigned(i32, -5)
+(i32.const #unsigned(i32, -5))
 #assertTopStack < i32 > #pow(i32) -Int 5 "i32 manual unsigned"
 
-i32.const #pow(i32) -Int 5
+(i32.const #pow(i32) -Int 5)
 #assertTopStack < i32 > -5 "i32 manual unsigned"
 
-i32.const -5
+(i32.const -5)
 #assertTopStack < i32 > #unsigned(i32, -5) "i32 signed constant"
 
-i32.const #unsigned(i32, -5)
+(i32.const #unsigned(i32, -5))
 #assertTopStack < i32 > -5 "i32 signed assert"
 
 ;; Floating point
 ;; --------------
 
-f32.const 3.245
+(f32.const 3.245)
 #assertTopStack < f32 > 3.245 "f32"
 
 (f64.const 3.234523)
 #assertTopStack < f64 > 3.234523 "f32 parens"
 
-( (f64.const 1.21460644e+52) )
+(f64.const 1.21460644e+52)
 #assertTopStack < f64 > 1.21460644e+52 "f64 scientific 1"
 
 (f64.const 1.6085927714e-321)
@@ -48,20 +48,20 @@ f32.const 3.245
 ;; Helper conversions
 ;; ------------------
 
-i32.const #unsigned(i32, #signed(i32, 0))
+(i32.const #unsigned(i32, #signed(i32, 0)))
 #assertTopStack < i32 > 0 "#unsigned . #signed 1"
 
-i32.const #unsigned(i32, #signed(i32, #pow1(i32)))
+(i32.const #unsigned(i32, #signed(i32, #pow1(i32))))
 #assertTopStack < i32 > #pow1(i32) "#unsigned . #signed 2"
 
-i32.const #unsigned(i32, #signed(i32, #pow(i32) -Int 1))
+(i32.const #unsigned(i32, #signed(i32, #pow(i32) -Int 1)))
 #assertTopStack < i32 > #pow(i32) -Int 1 "#unsigned . #signed 3"
 
-i64.const #unsigned(i64, #signed(i64, 0))
+(i64.const #unsigned(i64, #signed(i64, 0)))
 #assertTopStack < i64 > 0 "#unsigned . #signed 4"
 
-i64.const #unsigned(i64, #signed(i64, #pow1(i64)))
+(i64.const #unsigned(i64, #signed(i64, #pow1(i64))))
 #assertTopStack < i64 > #pow1(i64) "#unsigned . #signed 5"
 
-i64.const #unsigned(i64, #signed(i64, #pow(i64) -Int 1))
+(i64.const #unsigned(i64, #signed(i64, #pow(i64) -Int 1)))
 #assertTopStack < i64 > #pow(i64) -Int 1 "#unsigned . #signed 6"

--- a/tests/simple/control-flow.wast
+++ b/tests/simple/control-flow.wast
@@ -5,123 +5,123 @@ unreachable
 ;; Blocks
 
 block [ i32 i32 i32 ]
-    i32.const 1
-    i32.const 2
-    i32.const 3
+    (i32.const 1)
+    (i32.const 2)
+    (i32.const 3)
 end
 #assertStack < i32 > 3 : < i32 > 2 : < i32 > 1 : .Stack "block 1"
 
 block [ i32 i32 ]
-    i32.const 1
-    i32.const 2
-    i32.const 3
+    (i32.const 1)
+    (i32.const 2)
+    (i32.const 3)
     drop
 end
 #assertStack < i32 > 2 : < i32 > 1 : .Stack "block 2"
 
 block [ i32 i32 ]
-    i32.const 1
-    i32.const 2
-    i32.const 3
+    (i32.const 1)
+    (i32.const 2)
+    (i32.const 3)
 end
 #assertStack < i32 > 3 : < i32 > 2 : .Stack "block 3 (invalid)"
 
 (block (result i32)
-    i32.const 1
+    (i32.const 1)
 )
 #assertTopStack < i32 > 1 "block with named result 1"
 
 (block result i64 i32
-    i32.const 2
-    i32.const 1
-    i64.const 5
+    (i32.const 2)
+    (i32.const 1)
+    (i64.const 5)
 )
 #assertStack < i64 > 5 : < i32 > 1 : .Stack "block with named result 2"
 
 ;; Breaks
 
-i32.const 1
-i32.const 2
+(i32.const 1)
+(i32.const 2)
 block [ ]
-    i32.const 3
+    (i32.const 3)
     br 0
-    i32.const 4
+    (i32.const 4)
     br 0
 end
 #assertStack < i32 > 2 : < i32 > 1 : .Stack "br 1"
 
-i32.const 1
-i32.const 2
+(i32.const 1)
+(i32.const 2)
 block [ ]
-    i32.const 3
+    (i32.const 3)
     block [ i32 i32 ]
-        i32.const 4
-        i32.const 5
+        (i32.const 4)
+        (i32.const 5)
         br 1
     end
-    i32.const 6
+    (i32.const 6)
     br 0
 end
 #assertStack < i32 > 2 : < i32 > 1 : .Stack "br 2"
 
-i32.const 1
-i32.const 2
+(i32.const 1)
+(i32.const 2)
 block [ i32 i32 ]
-    i32.const 3
+    (i32.const 3)
     block [ i32 i32 ]
-        i32.const 4
-        i32.const 5
+        (i32.const 4)
+        (i32.const 5)
         br 1
     end
-    i32.const 6
+    (i32.const 6)
     br 0
 end
 #assertStack < i32 > 5 : < i32 > 4 : < i32 > 2 : < i32 > 1 : .Stack "br 3"
 
-i32.const 1
-i32.const 2
+(i32.const 1)
+(i32.const 2)
 block [ i32 i32 ]
-    i32.const 3
+    (i32.const 3)
     block [ ]
-        i32.const 4
-        i32.const 5
+        (i32.const 4)
+        (i32.const 5)
         br 1
     end
-    i32.const 6
+    (i32.const 6)
     br 0
 end
 #assertStack < i32 > 5 : < i32 > 4 : < i32 > 2 : < i32 > 1 : .Stack "br 4"
 
-i32.const 1
-i32.const 2
+(i32.const 1)
+(i32.const 2)
 block [ i32 ]
-    i32.const 3
-    i32.const 0
+    (i32.const 3)
+    (i32.const 0)
     br_if 0
-    i32.const 4
+    (i32.const 4)
     br 0
 end
 #assertStack < i32 > 4 : < i32 > 2 : < i32 > 1 : .Stack "br_if 1 false"
 
-i32.const 1
-i32.const 2
+(i32.const 1)
+(i32.const 2)
 block [ ]
-    i32.const 3
-    i32.const 1
+    (i32.const 3)
+    (i32.const 1)
     br_if 0
-    i32.const 4
+    (i32.const 4)
     br 0
 end
 #assertStack < i32 > 2 : < i32 > 1 : .Stack "br_if 1 true"
 
 ;; Conditional
 
-i32.const 1
-if [ i32 ] i32.const 1 else i32.const -1 end
+(i32.const 1)
+if [ i32 ] (i32.const 1) else (i32.const -1) end
 #assertTopStack < i32 > 1 "if true"
 
-i32.const 0
-if [ i32 ] i32.const 1 else i32.const -1 end
+(i32.const 0)
+if [ i32 ] (i32.const 1) else (i32.const -1) end
 #assertTopStack < i32 > -1 "if false"
 
 ;; Looping
@@ -131,13 +131,13 @@ block [ ]
     loop [ ]
         get_local 0
         get_local 1
-        i32.add
+        (i32.add)
         set_local 1
-        i32.const 1
+        (i32.const 1)
         get_local 0
-        i32.sub
+        (i32.sub)
         tee_local 0
-        i32.eqz
+        (i32.eqz)
         br_if 1
     end
 end
@@ -147,7 +147,7 @@ end
 ;; Stack Underflow
 ;; TODO: We need to give semantics to stack underflow (though it could not happen with a validated program).
 ;; We need `trap` semantics first.
-;; i32.const 0
+;; (i32.const 0)
 ;; block [ i32 i32 ]
-;;     i32.const 7
+;;     (i32.const 7)
 ;; end

--- a/tests/simple/conversion.wast
+++ b/tests/simple/conversion.wast
@@ -1,19 +1,19 @@
 ;; Wrap.
 
-i64.const 4294967296    ;; 2^32
-i32.wrap_i64
+(i64.const 4294967296)    ;; 2^32
+(i32.wrap_i64)
 #assertTopStack < i32 > 0 "wrap 2^32"
 
-i64.const 4294967295    ;; 2^32 - 1
-i32.wrap_i64
+(i64.const 4294967295)    ;; 2^32 - 1
+(i32.wrap_i64)
 #assertTopStack < i32 > 4294967295 "wrap 2^32 - 1"
 
 ;; Extend.
 
-i32.const 4294967295    ;; 2^32 - 1
-i64.extend_i32_u
+(i32.const 4294967295)    ;; 2^32 - 1
+(i64.extend_i32_u)
 #assertTopStack < i64 > 4294967295 "extend unsig"
 
-i32.const -1    ;; 2^32 - 1
-i64.extend_i32_s
+(i32.const -1)    ;; 2^32 - 1
+(i64.extend_i32_s)
 #assertTopStack < i64 > -1 "extend sig"

--- a/tests/simple/conversion.wast
+++ b/tests/simple/conversion.wast
@@ -17,3 +17,11 @@
 (i32.const -1)    ;; 2^32 - 1
 (i64.extend_i32_s)
 #assertTopStack < i64 > -1 "extend sig"
+
+(i32.const 10)
+(i32.extend_i32_s)
+#assertTrap "Bad return type for `extend_i32_s`"
+
+(i64.const 10)
+(i64.wrap_i64)
+#assertTrap "Bad return type for `wrap_i64`"

--- a/tests/simple/functions.wast
+++ b/tests/simple/functions.wast
@@ -1,12 +1,12 @@
 ;; Simple add function
 
-(func 0 :: [ i32 i32 ] -> [ i32 ]
-    [ ]
+func 0 :: [ i32 i32 ] -> [ i32 ]
+    [ ] {
     get_local 0
     get_local 1
     i32.add
     return
-)
+}
 
 i32.const 7
 i32.const 8
@@ -16,13 +16,13 @@ invoke 0
 
 ;; String-named add function
 
-(func $add :: [ i32 i32 ] -> [ i32 ]
-    [ ]
+func $add :: [ i32 i32 ] -> [ i32 ]
+    [ ] {
     get_local 0
     get_local 1
     i32.add
     return
-)
+}
 
 #assertFunction $add [ i32 i32 ] -> [ i32 ] [ ] "function string-named add"
 

--- a/tests/simple/functions.wast
+++ b/tests/simple/functions.wast
@@ -4,12 +4,12 @@ func 0 :: [ i32 i32 ] -> [ i32 ]
     [ ] {
     get_local 0
     get_local 1
-    i32.add
+    (i32.add)
     return
 }
 
-i32.const 7
-i32.const 8
+(i32.const 7)
+(i32.const 8)
 invoke 0
 #assertTopStack < i32 > 15 "invoke function 0"
 #assertFunction 0 [ i32 i32 ] -> [ i32 ] [ ] "invoke function 0 exists"
@@ -20,7 +20,7 @@ func $add :: [ i32 i32 ] -> [ i32 ]
     [ ] {
     get_local 0
     get_local 1
-    i32.add
+    (i32.add)
     return
 }
 
@@ -31,7 +31,7 @@ func $add :: [ i32 i32 ] -> [ i32 ]
 (func export $add param i32 i32 result i32
     get_local 0
     get_local 1
-    i32.add
+    (i32.add)
     return
 )
 
@@ -42,11 +42,11 @@ func $add :: [ i32 i32 ] -> [ i32 ]
 (func 0 param i32 i32 result i32
     get_local 0
     get_local 1
-    i32.add
+    (i32.add)
 )
 
-i32.const 7
-i32.const 8
+(i32.const 7)
+(i32.const 8)
 invoke 0
 #assertTopStack < i32 > 15 "invoke function 0 no return"
 #assertFunction 0 [ i32 i32 ] -> [ i32 ] [ ] "invoke function 0 exists no return"
@@ -56,17 +56,17 @@ invoke 0
 (func 1 param i64 i64 i64 result i64 local i64
     get_local 0
     get_local 1
-    i64.add
+    (i64.add)
     get_local 2
-    i64.sub
+    (i64.sub)
     set_local 3
     get_local 3
     return
 )
 
-i64.const 100
-i64.const 43
-i64.const 22
+(i64.const 100)
+(i64.const 43)
+(i64.const 22)
 invoke 1
 #assertTopStack < i64 > 35 "invoke function 1"
 #assertFunction 1 [ i64 i64 i64 ] -> [ i64 ] [ i64 ] "invoke function 1 exists"
@@ -78,9 +78,9 @@ invoke 1
     return
 )
 
-i64.const 7
-i64.const 8
-i32.const 5
+(i64.const 7)
+(i64.const 8)
+(i32.const 5)
 invoke 1
 #assertTopStack < i32 > 5 "out of order type declaration"
 #assertFunction 1 [ i32 i64 i64 ] -> [ i32 ] [ i32 ] "out of order type declarations"
@@ -92,8 +92,8 @@ invoke 1
     return
 )
 
-i64.const 7
-i64.const 8
+(i64.const 7)
+(i64.const 8)
 invoke 1
 #assertTopStack < i64 > 8 "empty type declaration"
 #assertFunction 1 [ i64 i64 ] -> [ i64 ] [ ] "empty type declarations"
@@ -105,8 +105,8 @@ invoke 1
     return
 )
 
-i64.const 7
-i64.const 8
+(i64.const 7)
+(i64.const 8)
 invoke 1
 #assertTopStack < i64 > 8 "empty type declaration + parens"
 #assertFunction 1 [ i64 i64 ] -> [ i64 ] [ ] "empty type declarations + parens"

--- a/tests/simple/identifiers.wast
+++ b/tests/simple/identifiers.wast
@@ -4,7 +4,7 @@ func $oeauth :: [ i32 i32 ] -> [ i32 ]
     [ ] {
     get_local 0
     get_local 1
-    i32.add
+    (i32.add)
     return
 }
 
@@ -14,7 +14,7 @@ func $023eno!thu324 :: [ i32 i32 ] -> [ i32 ]
     [ ] {
     get_local 0
     get_local 1
-    i32.add
+    (i32.add)
     return
 }
 
@@ -24,7 +24,7 @@ func $02$3e%no!t&hu324 :: [ i32 i32 ] -> [ i32 ]
     [ ] {
     get_local 0
     get_local 1
-    i32.add
+    (i32.add)
     return
 }
 
@@ -34,7 +34,7 @@ func $02$3e%no!t&hu3'24*32++2ao-eunth :: [ i32 i32 ] -> [ i32 ]
     [ ] {
     get_local 0
     get_local 1
-    i32.add
+    (i32.add)
     return
 }
 
@@ -44,7 +44,7 @@ func $02$3e%no!t&hu3'24*32++2ao-eu//n<t>h? :: [ i32 i32 ] -> [ i32 ]
     [ ] {
     get_local 0
     get_local 1
-    i32.add
+    (i32.add)
     return
 }
 
@@ -54,7 +54,7 @@ func $aenuth_ae`st|23~423 :: [ i32 i32 ] -> [ i32 ]
     [ ] {
     get_local 0
     get_local 1
-    i32.add
+    (i32.add)
     return
 }
 

--- a/tests/simple/identifiers.wast
+++ b/tests/simple/identifiers.wast
@@ -1,61 +1,61 @@
 ;; tests of function identifier names
 
-( func $oeauth :: [ i32 i32 ] -> [ i32 ]
-    [ ]
+func $oeauth :: [ i32 i32 ] -> [ i32 ]
+    [ ] {
     get_local 0
     get_local 1
     i32.add
     return
-)
+}
 
 #assertFunction $oeauth [ i32 i32 ] -> [ i32 ] [ ] "simple function name"
 
-( func $023eno!thu324 :: [ i32 i32 ] -> [ i32 ]
-    [ ]
+func $023eno!thu324 :: [ i32 i32 ] -> [ i32 ]
+    [ ] {
     get_local 0
     get_local 1
     i32.add
     return
-)
+}
 
 #assertFunction $023eno!thu324 [ i32 i32 ] -> [ i32 ] [ ] "identifier function name 1"
 
-( func $02$3e%no!t&hu324 :: [ i32 i32 ] -> [ i32 ]
-    [ ]
+func $02$3e%no!t&hu324 :: [ i32 i32 ] -> [ i32 ]
+    [ ] {
     get_local 0
     get_local 1
     i32.add
     return
-)
+}
 
 #assertFunction $02$3e%no!t&hu324 [ i32 i32 ] -> [ i32 ] [ ] "identifier function name 2"
 
-( func $02$3e%no!t&hu3'24*32++2ao-eunth :: [ i32 i32 ] -> [ i32 ]
-    [ ]
+func $02$3e%no!t&hu3'24*32++2ao-eunth :: [ i32 i32 ] -> [ i32 ]
+    [ ] {
     get_local 0
     get_local 1
     i32.add
     return
-)
+}
 
 #assertFunction $02$3e%no!t&hu3'24*32++2ao-eunth [ i32 i32 ] -> [ i32 ] [ ] "identifier function name 3"
 
-( func $02$3e%no!t&hu3'24*32++2ao-eu//n<t>h? :: [ i32 i32 ] -> [ i32 ]
-    [ ]
+func $02$3e%no!t&hu3'24*32++2ao-eu//n<t>h? :: [ i32 i32 ] -> [ i32 ]
+    [ ] {
     get_local 0
     get_local 1
     i32.add
     return
-)
+}
 
 #assertFunction $02$3e%no!t&hu3'24*32++2ao-eu//n<t>h? [ i32 i32 ] -> [ i32 ] [ ] "identifier function name 3"
 
-( func $aenuth_ae`st|23~423 :: [ i32 i32 ] -> [ i32 ]
-    [ ]
+func $aenuth_ae`st|23~423 :: [ i32 i32 ] -> [ i32 ]
+    [ ] {
     get_local 0
     get_local 1
     i32.add
     return
-)
+}
 
 #assertFunction $aenuth_ae`st|23~423 [ i32 i32 ] -> [ i32 ] [ ] "identifier function name 3"

--- a/tests/simple/memory.wast
+++ b/tests/simple/memory.wast
@@ -2,17 +2,17 @@
 
 init_locals < i32 > 0 : < i32 > 0 : < i32 > 0 : .Stack
 
-i32.const 43
+(i32.const 43)
 set_local 0
 #assertLocal 0 < i32 > 43 "set_local"
 
-i32.const 55
+(i32.const 55)
 set_local 1
 get_local 1
 #assertTopStack < i32 > 55 "set_local stack"
 #assertLocal 1 < i32 > 55 "set_local"
 
-i32.const 67
+(i32.const 67)
 tee_local 2
 #assertTopStack < i32 > 67 "tee_local stack"
 #assertLocal 2 < i32 > 67 "tee_local local"
@@ -22,11 +22,11 @@ tee_local 2
 init_global 0 < i32 > 0
 init_global 1 < i32 > 0
 
-i32.const 43
+(i32.const 43)
 set_global 0
 #assertGlobal 0 < i32 > 43 "set_global"
 
-i32.const 55
+(i32.const 55)
 set_global 1
 get_global 1
 #assertTopStack < i32 > 55 "set_global stack"

--- a/tests/simple/modules.wast
+++ b/tests/simple/modules.wast
@@ -3,7 +3,7 @@
         [ ] {
         get_local 0
         get_local 1
-        i32.add
+        (i32.add)
         return
     }
 
@@ -11,29 +11,29 @@
         [ ] {
         get_local 0
         get_local 1
-        i32.mul
+        (i32.mul)
         return
     }
 
     (func (export $xor) (param i32 i32) (result i32)
         get_local 0
         get_local 1
-        i32.xor
+        (i32.xor)
     )
 )
 
-i32.const 3
-i32.const 5
+(i32.const 3)
+(i32.const 5)
 invoke $add
 #assertTopStack < i32 > 8 "add in module correctly"
 
-i32.const 3
-i32.const 5
+(i32.const 3)
+(i32.const 5)
 invoke $mul
 #assertTopStack < i32 > 15 "mul in module correctly"
 
-i32.const 3
-i32.const 5
+(i32.const 3)
+(i32.const 5)
 invoke $xor
 #assertTopStack < i32 > 6 "xor in module correctly"
 
@@ -46,11 +46,11 @@ invoke $xor
         [ i32 ] {
         get_local 0
         get_local 1
-        i32.add
+        (i32.add)
         set_local 2
         get_local 0
         get_local 2
-        i32.mul
+        (i32.mul)
         return
     }
 
@@ -62,16 +62,16 @@ invoke $xor
         get_local 1
         invoke $f1
         get_local 0
-        i32.mul
+        (i32.mul)
         return
     }
 )
 
-i32.const 3
-i32.const 5
+(i32.const 3)
+(i32.const 5)
 invoke $f1
-i32.const 5
-i32.const 8
+(i32.const 5)
+(i32.const 8)
 invoke $f2
 #assertTopStack < i32 > 77000 "nested method call"
 #assertFunction $f2 [ i32 i32 i32 ] -> [ i32 ] [ i32 i32 ] "outer calling method"
@@ -83,7 +83,7 @@ invoke $f2
     (func $add (param i32 i32) (result i32)
         get_local 0
         get_local 1
-        i32.add
+        (i32.add)
         return
     )
 )

--- a/tests/simple/modules.wast
+++ b/tests/simple/modules.wast
@@ -1,19 +1,19 @@
 (module
-    (func $add :: [ i32 i32 ] -> [ i32 ]
-        [ ]
+    func $add :: [ i32 i32 ] -> [ i32 ]
+        [ ] {
         get_local 0
         get_local 1
         i32.add
         return
-    )
+    }
 
-    (func $mul :: [ i32 i32 ] -> [ i32 ]
-        [ ]
+    func $mul :: [ i32 i32 ] -> [ i32 ]
+        [ ] {
         get_local 0
         get_local 1
         i32.mul
         return
-    )
+    }
 
     (func (export $xor) (param i32 i32) (result i32)
         get_local 0
@@ -42,8 +42,8 @@ invoke $xor
 #assertFunction $xor [ i32 i32 ] -> [ i32 ] [ ] "xor function typed correctly"
 
 (module
-    (func $f1 :: [ i32 i32 ] -> [ i32 ]
-        [ i32 ]
+    func $f1 :: [ i32 i32 ] -> [ i32 ]
+        [ i32 ] {
         get_local 0
         get_local 1
         i32.add
@@ -52,10 +52,10 @@ invoke $xor
         get_local 2
         i32.mul
         return
-    )
+    }
 
-    (func $f2 :: [ i32 i32 i32 ] -> [ i32 ]
-        [ i32 i32 ]
+    func $f2 :: [ i32 i32 i32 ] -> [ i32 ]
+        [ i32 i32 ] {
         get_local 0
         get_local 2
         invoke $f1
@@ -64,7 +64,7 @@ invoke $xor
         get_local 0
         i32.mul
         return
-    )
+    }
 )
 
 i32.const 3

--- a/tests/simple/polymorphic.wast
+++ b/tests/simple/polymorphic.wast
@@ -1,43 +1,43 @@
 ;; drop
 
-i32.const 15
+(i32.const 15)
 drop
 #assertStack .Stack "drop i32"
 
-i64.const 15
+(i64.const 15)
 drop
 #assertStack .Stack "drop i64"
 
-f32.const 15.0
+(f32.const 15.0)
 drop
 #assertStack .Stack "drop f32"
 
-f64.const 15.0
+(f64.const 15.0)
 drop
 #assertStack .Stack "drop f64"
 
 ;; select
 
-i32.const -1
-i32.const 1
-i32.const 1
+(i32.const -1)
+(i32.const 1)
+(i32.const 1)
 select
 #assertTopStack < i32 > 1 "select i32 true"
 
-i32.const -1
-i32.const 1
-i32.const 0
+(i32.const -1)
+(i32.const 1)
+(i32.const 0)
 select
 #assertTopStack < i32 > -1 "select i32 false"
 
-i64.const -1
-i64.const 1
-i32.const 1
+(i64.const -1)
+(i64.const 1)
+(i32.const 1)
 select
 #assertTopStack < i64 > 1 "select i64 true"
 
-i64.const -1
-i64.const 1
-i32.const 0
+(i64.const -1)
+(i64.const 1)
+(i32.const 0)
 select
 #assertTopStack < i64 > -1 "select i64 false"

--- a/wasm.md
+++ b/wasm.md
@@ -72,11 +72,11 @@ If the value is the special `undefined`, then `trap` is generated instead.
       requires V =/=K undefined
 ```
 
-Numeric Operators
------------------
+Common Operator Machinery
+-------------------------
 
-A large portion of the available opcodes are pure arithmetic.
-This allows us to give purely functional semantics to many numeric opcodes.
+Common machinery for operators is supplied here, based on their categorization.
+This allows us to give purely functional semantics to many of the opcodes.
 
 ### Constants
 
@@ -123,6 +123,9 @@ When a binary operator is the next instruction, the two arguments are loaded fro
          <stack> < ITYPE > SI1 : < ITYPE > SI2 : STACK => STACK </stack>
 ```
 
+Numeric Operators
+-----------------
+
 ### Integer Arithmetic
 
 `add`, `sub`, and `mul` are given semantics by lifting the correct K operators through the `#chop` function.
@@ -163,7 +166,39 @@ Note that we do not need to call `#chop` on the results here.
          </k>
 ```
 
-### Bitwise Operations
+### Comparison Operations
+
+All of the following opcodes are liftings of the K builtin operators using the helper `#bool`.
+
+```k
+    syntax IUnOp ::= "eqz"
+ // ----------------------
+    rule <k> ITYPE . eqz I1 => < ITYPE > #bool(I1 ==Int 0) ... </k>
+
+    syntax IBinOp ::= "eq" | "ne"
+ // -----------------------------
+    rule <k> ITYPE . eq I1 I2 => < ITYPE > #bool(I1  ==Int I2) ... </k>
+    rule <k> ITYPE . ne I1 I2 => < ITYPE > #bool(I1 =/=Int I2) ... </k>
+
+    syntax IBinOp ::= "lt_u" | "gt_u" | "lt_s" | "gt_s"
+ // ---------------------------------------------------
+    rule <k> ITYPE . lt_u I1 I2 => < ITYPE > #bool(I1 <Int I2) ... </k>
+    rule <k> ITYPE . gt_u I1 I2 => < ITYPE > #bool(I1 >Int I2) ... </k>
+
+    rule <k> ITYPE . lt_s I1 I2 => < ITYPE > #bool(#signed(ITYPE, I1) <Int #signed(ITYPE, I2)) ... </k>
+    rule <k> ITYPE . gt_s I1 I2 => < ITYPE > #bool(#signed(ITYPE, I1) >Int #signed(ITYPE, I2)) ... </k>
+
+    syntax IBinOp ::= "le_u" | "ge_u" | "le_s" | "ge_s"
+ // ---------------------------------------------------
+    rule <k> ITYPE . le_u I1 I2 => < ITYPE > #bool(I1 <=Int I2) ... </k>
+    rule <k> ITYPE . ge_u I1 I2 => < ITYPE > #bool(I1 >=Int I2) ... </k>
+
+    rule <k> ITYPE . le_s I1 I2 => < ITYPE > #bool(#signed(ITYPE, I1) <=Int #signed(ITYPE, I2)) ... </k>
+    rule <k> ITYPE . ge_s I1 I2 => < ITYPE > #bool(#signed(ITYPE, I1) >=Int #signed(ITYPE, I2)) ... </k>
+```
+
+Bitwise Operations
+------------------
 
 Of the bitwise operators, `and` will not overflow, but `or` and `xor` could.
 These simply are the lifted K operators.
@@ -198,9 +233,20 @@ The rotation operators `rotl` and `rotr` do not have appropriate K builtins, and
 ```
 
 The bit counting operators also lack appropriate K builtins, and are implemented by using width-agnostic helper functions.
+
+`clz` counts the number of leading zero-bits, with 0 having all leading zero-bits.
+`ctz` counts the number of trailing zero-bits, with 0 having all trailing zero-bits.
+`popcnt` counts the number of non-zero bits.
+
 Note: The actual `ctz` operator considers the integer 0 to have *all* zero-bits, whereas the `#ctz` helper function considers it to have *no* zero-bits, in order for it to be width-agnostic.
 
 ```k
+    syntax IUnOp ::= "clz" | "ctz" | "popcnt"
+ // -----------------------------------------
+    rule <k> ITYPE . clz    I1 => < ITYPE > #width(ITYPE) -Int #minWidth(I1)                      ... </k>
+    rule <k> ITYPE . ctz    I1 => < ITYPE > #if I1 ==Int 0 #then #width(ITYPE) #else #ctz(I1) #fi ... </k>
+    rule <k> ITYPE . popcnt I1 => < ITYPE > #popcnt(I1)                                           ... </k>
+
     syntax Int ::= #minWidth ( Int ) [function]
                  | #ctz      ( Int ) [function]
                  | #popcnt   ( Int ) [function]
@@ -215,50 +261,8 @@ Note: The actual `ctz` operator considers the integer 0 to have *all* zero-bits,
     rule #popcnt(N) => #bool(N modInt 2 ==Int 1) +Int #popcnt(N >>Int 1)             requires N =/=Int 0
 ```
 
-`clz` counts the number of leading zero-bits, with 0 having all leading zero-bits.
-`ctz` counts the number of trailing zero-bits, with 0 having all trailing zero-bits.
-`popcnt` counts the number of non-zero bits.
-
-```k
-    syntax IUnOp ::= "clz" | "ctz" | "popcnt"
- // -----------------------------------------
-    rule <k> ITYPE . clz    I1 => < ITYPE > #width(ITYPE) -Int #minWidth(I1)                      ... </k>
-    rule <k> ITYPE . ctz    I1 => < ITYPE > #if I1 ==Int 0 #then #width(ITYPE) #else #ctz(I1) #fi ... </k>
-    rule <k> ITYPE . popcnt I1 => < ITYPE > #popcnt(I1)                                           ... </k>
-```
-
-### Comparison Operations
-
-All of the following opcodes are liftings of the K builtin operators using the helper `#bool`.
-
-```k
-    syntax IUnOp ::= "eqz"
- // ----------------------
-    rule <k> ITYPE . eqz I1 => < ITYPE > #bool(I1 ==Int 0) ... </k>
-
-    syntax IBinOp ::= "eq" | "ne"
- // -----------------------------
-    rule <k> ITYPE . eq I1 I2 => < ITYPE > #bool(I1  ==Int I2) ... </k>
-    rule <k> ITYPE . ne I1 I2 => < ITYPE > #bool(I1 =/=Int I2) ... </k>
-
-    syntax IBinOp ::= "lt_u" | "gt_u" | "lt_s" | "gt_s"
- // ---------------------------------------------------
-    rule <k> ITYPE . lt_u I1 I2 => < ITYPE > #bool(I1 <Int I2) ... </k>
-    rule <k> ITYPE . gt_u I1 I2 => < ITYPE > #bool(I1 >Int I2) ... </k>
-
-    rule <k> ITYPE . lt_s I1 I2 => < ITYPE > #bool(#signed(ITYPE, I1) <Int #signed(ITYPE, I2)) ... </k>
-    rule <k> ITYPE . gt_s I1 I2 => < ITYPE > #bool(#signed(ITYPE, I1) >Int #signed(ITYPE, I2)) ... </k>
-
-    syntax IBinOp ::= "le_u" | "ge_u" | "le_s" | "ge_s"
- // ---------------------------------------------------
-    rule <k> ITYPE . le_u I1 I2 => < ITYPE > #bool(I1 <=Int I2) ... </k>
-    rule <k> ITYPE . ge_u I1 I2 => < ITYPE > #bool(I1 >=Int I2) ... </k>
-
-    rule <k> ITYPE . le_s I1 I2 => < ITYPE > #bool(#signed(ITYPE, I1) <=Int #signed(ITYPE, I2)) ... </k>
-    rule <k> ITYPE . ge_s I1 I2 => < ITYPE > #bool(#signed(ITYPE, I1) >=Int #signed(ITYPE, I2)) ... </k>
-```
-
-### Conversion Operations
+Conversion Operations
+---------------------
 
 These operators convert constant elements at the top of the stack to another type. The target type is before the `.`, and the source type is after the `_`.
 

--- a/wasm.md
+++ b/wasm.md
@@ -262,7 +262,7 @@ Conversion Operations
 ---------------------
 
 Conversion operators always take a single argument as input and cast it to another type.
-For each element added to `ConvOp`, function `#confSourceType` must be defined over it.
+For each element added to `ConvOp`, function `#convSourceType` must be defined over it.
 
 ```k
     syntax Instr ::= "(" IValType "." ConvOp ")" | IValType "." ConvOp Int

--- a/wasm.md
+++ b/wasm.md
@@ -283,6 +283,7 @@ Wrapping cuts of the 32 most significant bits of an `i64` value.
     syntax ConvOp ::= "wrap_i64"
  // ----------------------------
     rule <k> i32 . wrap_i64 I => #chop(< i32 > I) ... </k>
+    rule <k> i64 . wrap_i64 I => trap             ... </k>
 
     rule #convSourceType(wrap_i64) => i64
 ```
@@ -294,6 +295,9 @@ Extension turns an `i32` type value into the corresponding `i64` type value.
  // -------------------------------------------------
     rule <k> i64 . extend_i32_u I => < i64 > I                               ... </k>
     rule <k> i64 . extend_i32_s I => < i64 > #unsigned(i64, #signed(i32, I)) ... </k>
+
+    rule <k> i32 . extend_i32_u I => trap ... </k>
+    rule <k> i32 . extend_i32_s I => trap ... </k>
 
     rule #convSourceType(extend_i32_u) => i32
     rule #convSourceType(extend_i32_s) => i32

--- a/wasm.md
+++ b/wasm.md
@@ -23,7 +23,7 @@ Configuration
       <store>
         <funcs>
           <funcDef multiplicity="*" type="Map">
-            <fname>  0              </fname>
+            <fname>  .FunctionName  </fname>
             <fcode>  .Instrs:Instrs </fcode>
             <ftype>  .Type          </ftype>
             <flocal> .Type          </flocal>
@@ -470,8 +470,8 @@ Function declarations can look quite different depending on which fields are omm
 Here, we allow for an "abstract" function declaration using syntax `func_::___`, and a more concrete one which allows arbitrary order of declaration of parameters, locals, and results.
 
 ```k
-    syntax FunctionName ::= Int | Identifier
- // ----------------------------------------
+    syntax FunctionName ::= ".FunctionName" | Int | Identifier
+ // ----------------------------------------------------------
 
     syntax TypeKeyWord ::= "param" | "result" | "local"
  // ---------------------------------------------------

--- a/wasm.md
+++ b/wasm.md
@@ -487,19 +487,19 @@ Here, we allow for an "abstract" function declaration using syntax `func_::___`,
 
     syntax Instr ::= "func" FuncDecls Instrs
                    | "func" FunctionName FuncDecls Instrs
-                   | "func" FunctionName "::" FuncType VecType Instrs
- // -----------------------------------------------------------------
+                   | "func" FunctionName "::" FuncType VecType "{" Instrs "}"
+ // -------------------------------------------------------------------------
     rule <k> func FDECLS INSTRS
-          => func gatherExportedName(FDECLS) :: gatherFuncType(FDECLS) gatherTypes(local, FDECLS) INSTRS
+          => func gatherExportedName(FDECLS) :: gatherFuncType(FDECLS) gatherTypes(local, FDECLS) { INSTRS }
          ...
          </k>
 
     rule <k> func FNAME FDECLS INSTRS
-          => func FNAME :: gatherFuncType(FDECLS) gatherTypes(local, FDECLS) INSTRS
+          => func FNAME :: gatherFuncType(FDECLS) gatherTypes(local, FDECLS) { INSTRS }
          ...
          </k>
 
-    rule <k> func FNAME :: FTYPE LTYPE INSTRS => . ... </k>
+    rule <k> func FNAME :: FTYPE LTYPE { INSTRS } => . ... </k>
          <funcs>
            ( .Bag
           => <funcDef>


### PR DESCRIPTION
Hey @hjorthjort this prepares for introducing a folded syntax which works with the parser by forcing the use of paranthesis around the concrete syntax. Once it's applied to an argument, the parens go away (so that the semantics are given over the abstract non-paren form).

I also factored out an operator category `ConvOp`. Not sure how I feel about it, but I'll let you decide. It avoids the parsing issues with `_` by building it into the larger tokens (as you did), but still has it type-parametric on the output type (like the other opcodes). I could take it or leave it.