### PR TITLE
Binop fix

### DIFF
--- a/tests/simple/arithmetic.wast
+++ b/tests/simple/arithmetic.wast
@@ -75,18 +75,18 @@
 
 ;; The following tests were generated using the reference OCaml WASM interpreter.
 
-(i32.const 3)
 (i32.const 10)
+(i32.const 3)
 (i32.rem_s)
 #assertTopStack < i32 > 1 "i32.rem_s 1"
 
-(i32.const 4)
 (i32.const 10)
+(i32.const 4)
 (i32.rem_s)
 #assertTopStack < i32 > 2 "i32.rem_s 2"
 
-(i32.const 5)
 (i32.const 10)
+(i32.const 5)
 (i32.rem_s)
 #assertTopStack < i32 > 0 "i32.rem_s 3"
 

--- a/tests/simple/arithmetic.wast
+++ b/tests/simple/arithmetic.wast
@@ -6,70 +6,70 @@
 (i32.const 5)
 (i32.const 7)
 (i32.sub)
-#assertTopStack < i32 > 2 "sub"
+#assertTopStack < i32 > -2 "sub"
 
 (i32.const 15)
 (i32.const 3)
 (i32.mul)
 #assertTopStack < i32 > 45 "mul"
 
-(i32.const 3)
 (i32.const 15)
+(i32.const 3)
 (i32.div_u)
 #assertTopStack < i32 > 5 "div_u1"
 
-(i32.const 2)
 (i32.const 15)
+(i32.const 2)
 (i32.div_u)
 #assertTopStack < i32 > 7 "div_u2"
 
-(i32.const 0)
 (i32.const 15)
+(i32.const 0)
 (i32.div_u)
 #assertTrap "div_u3"
 
-(i32.const 3)
 (i32.const 15)
+(i32.const 3)
 (i32.rem_u)
 #assertTopStack < i32 > 0 "rem_u1"
 
-(i32.const 2)
 (i32.const 15)
+(i32.const 2)
 (i32.rem_u)
 #assertTopStack < i32 > 1 "rem_u2"
 
-(i32.const 0)
 (i32.const 15)
+(i32.const 0)
 (i32.rem_u)
 #assertTrap "rem_u3"
 
-(i32.const 3)
 (i32.const 10)
+(i32.const 3)
 (i32.div_s)
 #assertTopStack < i32 > 3 "i32.div_s 1"
 
-(i32.const 4)
 (i32.const 10)
+(i32.const 4)
 (i32.div_s)
 #assertTopStack < i32 > 2 "i32.div_s 2"
 
-(i32.const 0)
 (i32.const 10)
+(i32.const 0)
 (i32.div_s)
 #assertTrap "i32.div_s 3"
 
-(i32.const #pow(i32) -Int 1)
 (i32.const #pow1(i32))
+(i32.const #pow(i32) -Int 1)
 (i32.div_s)
 #assertTrap "i32.div_s 4"
 
-(i32.const 5)
 (i32.const 10)
+(i32.const 5)
 (i32.div_s)
 #assertTopStack < i32 > 2 "div_s"
 
-(i32.const 0)
 (i32.const 10)
+(i32.const 0)
 (i32.rem_s)
 #assertTrap "rem_s"
 
@@ -90,62 +90,62 @@
 (i32.rem_s)
 #assertTopStack < i32 > 0 "i32.rem_s 3"
 
-(i32.const 3)
 (i32.const -10)
+(i32.const 3)
 (i32.div_s)
 #assertTopStack < i32 > -3 "i32.div_s 3"
 
-(i32.const 4)
 (i32.const -10)
+(i32.const 4)
 (i32.div_s)
 #assertTopStack < i32 > -2 "i32.div_s 4"
 
-(i32.const 5)
 (i32.const -10)
+(i32.const 5)
 (i32.div_s)
 #assertTopStack < i32 > -2 "i32.div_s 5"
 
-(i32.const 3)
 (i32.const -10)
+(i32.const 3)
 (i32.rem_s)
 #assertTopStack < i32 > -1 "i32.rem_s 4"
 
-(i32.const 4)
 (i32.const -10)
+(i32.const 4)
 (i32.rem_s)
 #assertTopStack < i32 > -2 "i32.rem_s 5"
 
-(i32.const 5)
 (i32.const -10)
+(i32.const 5)
 (i32.rem_s)
 #assertTopStack < i32 > 0 "i32.rem_s 6"
 
-(i32.const -3)
 (i32.const -10)
+(i32.const -3)
 (i32.div_s)
 #assertTopStack < i32 > 3 "i32.div_s 6"
 
-(i32.const -4)
 (i32.const -10)
+(i32.const -4)
 (i32.div_s)
 #assertTopStack < i32 > 2 "i32.div_s 7"
 
-(i32.const -5)
 (i32.const -10)
+(i32.const -5)
 (i32.div_s)
 #assertTopStack < i32 > 2 "i32.div_s 8"
 
-(i32.const -3)
 (i32.const -10)
+(i32.const -3)
 (i32.rem_s)
 #assertTopStack < i32 > -1 "i32.rem_s 7"
 
-(i32.const -4)
 (i32.const -10)
+(i32.const -4)
 (i32.rem_s)
 #assertTopStack < i32 > -2 "i32.rem_s 8"
 
-(i32.const -5)
 (i32.const -10)
+(i32.const -5)
 (i32.rem_s)
 #assertTopStack < i32 > 0 "i32.rem_s 9"

--- a/tests/simple/bitwise.wast
+++ b/tests/simple/bitwise.wast
@@ -23,8 +23,8 @@
 (i32.shl)
 #assertTopStack < i32 > 4 "shl 2"
 
-(i32.const 2)
 (i32.const #pow1(i32))
+(i32.const 2)
 (i32.shr_u)
 #assertTopStack < i32 > 2 ^Int 29 "shr_u 1"
 
@@ -33,8 +33,8 @@
 (i32.shr_u)
 #assertTopStack < i32 > 0 "shr_u 2"
 
-(i32.const 1)
 (i32.const #pow(i32) -Int 2)
+(i32.const 1)
 (i32.shr_s)
 #assertTopStack < i32 > #pow(i32) -Int 1 "shr_s 1"
 
@@ -43,13 +43,13 @@
 (i32.shr_s)
 #assertTopStack < i32 > 0 "shr_s 2"
 
-(i32.const 3)
 (i32.const #pow1(i32) +Int 2)
+(i32.const 3)
 (i32.rotl)
 #assertTopStack < i32 > 20 "rotl"
 
-(i32.const 3)
 (i32.const #pow1(i32) +Int 16)
+(i32.const 3)
 (i32.rotr)
 #assertTopStack < i32 > 2 ^Int 28 +Int 2 "rotr"
 
@@ -60,7 +60,7 @@
 #assertTopStack < i32 > 0 "clz #pow1(i32)"
 (i64.const #pow1(i64))
 (i64.clz)
-#assertTopStack < i64 > 0 "clz #pow1(i32)"
+#assertTopStack < i64 > 0 "clz #pow1(i62)"
 
 (i32.const 0)
 (i32.clz)

--- a/tests/simple/comparison.wast
+++ b/tests/simple/comparison.wast
@@ -26,38 +26,38 @@
 (i32.ne)
 #assertTopStack < i32 > 1 "ne2"
 
-(i32.const 32)
 (i32.const 2)
+(i32.const 32)
 (i32.lt_u)
 #assertTopStack < i32 > 1 "lt_u"
 
-(i32.const 32)
 (i32.const 2)
+(i32.const 32)
 (i32.gt_u)
 #assertTopStack < i32 > 0 "gt_u"
 
-(i32.const #pow1(i32) +Int 15)
 (i32.const #pow1(i32) +Int 7)
+(i32.const #pow1(i32) +Int 15)
 (i32.lt_s)
 #assertTopStack < i32 > 1 "lt_s 1"
 
-(i32.const 32)
 (i32.const -32)
+(i32.const 32)
 (i32.lt_s)
 #assertTopStack < i32 > 1 "lt_s 2"
 
-(i32.const #pow1(i32) +Int 15)
 (i32.const #pow1(i32) +Int 7)
+(i32.const #pow1(i32) +Int 15)
 (i32.gt_s)
 #assertTopStack < i32 > 0 "gt_s 1"
 
-(i32.const 32)
 (i32.const -32)
+(i32.const 32)
 (i32.gt_s)
 #assertTopStack < i32 > 0 "gt_s 2"
 
-(i32.const 32)
 (i32.const 2)
+(i32.const 32)
 (i32.le_u)
 #assertTopStack < i32 > 1 "le_u 1"
 
@@ -66,8 +66,8 @@
 (i32.le_u)
 #assertTopStack < i32 > 1 "le_u 2"
 
-(i32.const 32)
 (i32.const 2)
+(i32.const 32)
 (i32.ge_u)
 #assertTopStack < i32 > 0 "ge_u 1"
 
@@ -76,8 +76,8 @@
 (i32.ge_u)
 #assertTopStack < i32 > 1 "ge_u 2"
 
-(i32.const #pow1(i32) +Int 15)
 (i32.const #pow1(i32) +Int 7)
+(i32.const #pow1(i32) +Int 15)
 (i32.le_s)
 #assertTopStack < i32 > 1 "le_s 1"
 
@@ -86,13 +86,13 @@
 (i32.le_s)
 #assertTopStack < i32 > 1 "le_s 2"
 
-(i32.const 32)
 (i32.const -32)
+(i32.const 32)
 (i32.le_s)
 #assertTopStack < i32 > 1 "le_s 3"
 
-(i32.const #pow1(i32) +Int 15)
 (i32.const #pow1(i32) +Int 7)
+(i32.const #pow1(i32) +Int 15)
 (i32.ge_s)
 #assertTopStack < i32 > 0 "ge_s 1"
 
@@ -101,7 +101,7 @@
 (i32.ge_s)
 #assertTopStack < i32 > 1 "ge_s 2"
 
-(i32.const 32)
 (i32.const -32)
+(i32.const 32)
 (i32.ge_s)
 #assertTopStack < i32 > 0 "ge_s 3"

--- a/tests/simple/control-flow.wast
+++ b/tests/simple/control-flow.wast
@@ -133,8 +133,8 @@ block [ ]
         get_local 1
         (i32.add)
         set_local 1
-        (i32.const 1)
         get_local 0
+        (i32.const 1)
         (i32.sub)
         tee_local 0
         (i32.eqz)

--- a/tests/simple/control-flow.wast
+++ b/tests/simple/control-flow.wast
@@ -105,6 +105,17 @@ end
 
 (i32.const 1)
 (i32.const 2)
+block [ i32 ]
+    (i32.const 3)
+    (i32.const 1)
+    br_if 0
+    (i32.const 4)
+    br 0
+end
+#assertStack < i32 > 3 : < i32 > 2 : < i32 > 1 : .Stack "br_if 1 true"
+
+(i32.const 1)
+(i32.const 2)
 block [ ]
     (i32.const 3)
     (i32.const 1)
@@ -112,7 +123,7 @@ block [ ]
     (i32.const 4)
     br 0
 end
-#assertStack < i32 > 2 : < i32 > 1 : .Stack "br_if 1 true"
+#assertStack < i32 > 2 : < i32 > 1 : .Stack "br_if 2 true"
 
 ;; Conditional
 

--- a/tests/simple/functions.wast
+++ b/tests/simple/functions.wast
@@ -54,11 +54,11 @@ invoke 0
 ;; More complicated function with locals
 
 (func 1 param i64 i64 i64 result i64 local i64
-    get_local 0
-    get_local 1
-    (i64.add)
-    get_local 2
-    (i64.sub)
+        get_local 2
+          get_local 0
+          get_local 1
+        (i64.add)
+      (i64.sub)
     set_local 3
     get_local 3
     return

--- a/wasm.md
+++ b/wasm.md
@@ -117,7 +117,7 @@ When a binary operator is the next instruction, the two arguments are loaded fro
  //                | "(" FValType "." FBinOp ")" | FValType "." FBinOp Float Float
  // ------------------------------------------------------------------------------
     rule <k> ( ITYPE . BOP:IBinOp ) => ITYPE . BOP SI1 SI2 ... </k>
-         <stack> < ITYPE > SI1 : < ITYPE > SI2 : STACK => STACK </stack>
+         <stack> < ITYPE > SI2 : < ITYPE > SI1 : STACK => STACK </stack>
 ```
 
 Numeric Operators

--- a/wasm.md
+++ b/wasm.md
@@ -267,8 +267,8 @@ For each element added to `ConvOp`, function `#convSourceType` must be defined o
 ```k
     syntax Instr ::= "(" IValType "." ConvOp ")" | IValType "." ConvOp Int
  // ----------------------------------------------------------------------
-    rule <k> ( ITYPE . CONVOP:ConvOp ) => ITYPE . CONVOP SI1 ... </k>
-         <stack> < ITYPE' > SI1 : STACK => STACK </stack>
+    rule <k> ( ITYPE . CONVOP:ConvOp ) => ITYPE . CONVOP C1 ... </k>
+         <stack> < ITYPE' > C1 : STACK => STACK </stack>
       requires #convSourceType(CONVOP) ==K ITYPE'
 
     syntax IValType ::= #convSourceType ( ConvOp ) [function]

--- a/wasm.md
+++ b/wasm.md
@@ -100,8 +100,8 @@ When a unary operator is the next instruction, the single argument is loaded fro
     syntax Instr ::= "(" IValType "." IUnOp ")" | IValType "." IUnOp Int
  //                | "(" FValType "." FUnOp ")" | FValType "." FUnOp Float
  // ----------------------------------------------------------------------
-    rule <k> ( ITYPE . UOP:IUnOp ) => ITYPE . UOP SI1 ... </k>
-         <stack> < ITYPE > SI1 : STACK => STACK </stack>
+    rule <k> ( ITYPE . UOP:IUnOp ) => ITYPE . UOP C1 ... </k>
+         <stack> < ITYPE > C1 : STACK => STACK </stack>
 ```
 
 ### Binary Operators
@@ -116,8 +116,8 @@ When a binary operator is the next instruction, the two arguments are loaded fro
     syntax Instr ::= "(" IValType "." IBinOp ")" | IValType "." IBinOp Int   Int
  //                | "(" FValType "." FBinOp ")" | FValType "." FBinOp Float Float
  // ------------------------------------------------------------------------------
-    rule <k> ( ITYPE . BOP:IBinOp ) => ITYPE . BOP SI1 SI2 ... </k>
-         <stack> < ITYPE > SI2 : < ITYPE > SI1 : STACK => STACK </stack>
+    rule <k> ( ITYPE . BOP:IBinOp ) => ITYPE . BOP C1 C2 ... </k>
+         <stack> < ITYPE > C2 : < ITYPE > C1 : STACK => STACK </stack>
 ```
 
 Numeric Operators


### PR DESCRIPTION
I found this error in how we implement (and test) binary operators. The spec definition of *binop* says it first pops operand 2 from the stack, then operand 1, (page 64, currently, section 4.4.1). We were doing it the other way around.

The rule says
```
(t.const c1) (t.const c2) t.binop  ==> (t.const c)    (if c \in binop_t(c1, c2))
```
The way we build our operand stack, *c1* would be pushed first, then *c2*, which is consistent with the prose description of *t.binop*.

Note what this says about folded syntax:
`(i32.sub (i32.const 1) (i32.const 2))` unfolds to `(i32.const 1) (i32.const 2) i32.sub`, i.e., operands are evaluated in order.