### PR TITLE
Separate lemmas into own file for verification, updates to kwasm script

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,10 +1,10 @@
 ==============================================================================
-The WASM Semantics in K Release License
+The WebAssembly Semantics in K Release License
 ==============================================================================
 University of Illinois/NCSA
 Open Source License
 
-Copyright (c) 2009-2015 University of Illinois at Urbana-Champaign.
+Copyright (c) 2009-2019 University of Illinois at Urbana-Champaign.
 All rights reserved.
 
 Developed by:
@@ -14,7 +14,6 @@ Developed by:
 
       * University of Illinois at Urbana-Champaign (http://fsl.cs.illinois.edu/)
       * Runtime Verification, Inc (https://www.runtimeverification.com)
-      * University Alexandru-Ioan Cuza, Romania (https://fmse.info.uaic.ro)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal with
@@ -32,9 +31,9 @@ so, subject to the following conditions:
       documentation and/or other materials provided with the distribution.
 
     * Neither the names of the K Team, Runtime Verification, the University of
-      Illinois at Urbana-Champaign, the University Alexandru-Ioan Cuza, nor 
-      the names of its contributors may be used to endorse or promote products
-      derived from this Software without specific prior written permission.
+      Illinois at Urbana-Champaign, nor the names of its contributors may be
+      used to endorse or promote products derived from this Software without
+      specific prior written permission.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -45,16 +44,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
 SOFTWARE.
 
 ==============================================================================
-Copyrights and Licenses for Third Party Software Distributed with the WASM
+Copyrights and Licenses for Third Party Software Distributed with the WebAssembly
 Semantics in K:
 ==============================================================================
-The WASM Semantics in K software contains code written by third parties. 
-Licenses for this software can be found in the licenses directory 
+The WebAssembly Semantics in K software contains code written by third parties.
+Licenses for this software can be found in the licenses directory
 in the file as specified below. These files will describe the copyrights,
 license, and restrictions which apply to that code.
 
 The disclaimer of warranty in the University of Illinois Open Source License
-applies to all code in the WASM Semantics in K Distribution, and nothing in any of
-the other licenses gives permission to use the names of the K Team, Runtime
-Verification, the University of Illinois, or the University Alexandru-Ioan Cuza
+applies to all code in the WebAssembly Semantics in K Distribution, and nothing
+in any of the other licenses gives permission to use the names of the K Team,
+Runtime Verification, or the University of Illinois
 to endorse or promote products derived from this Software.

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ ocaml_kompiled:=$(ocaml_dir)/test-kompiled/interpreter
 
 java_dir:=$(defn_dir)/java
 java_defn:=$(patsubst %, $(java_dir)/%, $(wasm_files))
-java_kompiled:=$(java_dir)/test-kompiled/kore.txt
+java_kompiled:=$(java_dir)/test-kompiled/compiled.txt
 
 haskell_dir:=$(defn_dir)/haskell
 haskell_defn:=$(patsubst %, $(haskell_dir)/%, $(wasm_files))

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ ocaml-deps:
 # Building Definition
 # -------------------
 
-wasm_files:=test.k wasm.k data.k
+wasm_files:=test.k wasm.k data.k kwasm-lemmas.k
 
 ocaml_dir:=$(defn_dir)/ocaml
 ocaml_defn:=$(patsubst %, $(ocaml_dir)/%, $(wasm_files))
@@ -92,21 +92,24 @@ build-haskell: $(haskell_kompiled)
 
 $(ocaml_kompiled): $(ocaml_defn)
 	@echo "== kompile: $@"
-	eval $$(opam config env)                                                          \
-	    $(k_bin)/kompile -O3 --non-strict --backend ocaml                             \
-	    --directory $(ocaml_dir) --main-module WASM-TEST --syntax-module WASM-TEST $<
+	eval $$(opam config env)                                 \
+	    $(k_bin)/kompile -O3 --non-strict --backend ocaml    \
+	    --directory $(ocaml_dir) -I $(ocaml_dir)             \
+	    --main-module WASM-TEST --syntax-module WASM-TEST $<
 
 $(java_kompiled): $(java_defn)
 	@echo "== kompile: $@"
-	eval $$(opam config env)                                                         \
-	    $(k_bin)/kompile --backend java                                              \
-	    --directory $(java_dir) --main-module WASM-TEST --syntax-module WASM-TEST $<
+	eval $$(opam config env)                                 \
+	    $(k_bin)/kompile --backend java                      \
+	    --directory $(java_dir) -I $(java_dir)               \
+	    --main-module WASM-TEST --syntax-module WASM-TEST $<
 
 $(haskell_kompiled): $(haskell_defn)
 	@echo "== kompile: $@"
-	eval $$(opam config env)                                                            \
-	    $(k_bin)/kompile --backend haskell                                              \
-	    --directory $(haskell_dir) --main-module WASM-TEST --syntax-module WASM-TEST $<
+	eval $$(opam config env)                                 \
+	    $(k_bin)/kompile --backend haskell                   \
+	    --directory $(haskell_dir) -I $(haskell_dir)         \
+	    --main-module WASM-TEST --syntax-module WASM-TEST $<
 
 # Testing
 # -------

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-KWASM: Semantics of WebAssembly in K
+KWasm: Semantics of WebAssembly in K
 ====================================
 
 This repository presents a prototype formal semantics of [WebAssembly].
@@ -14,7 +14,7 @@ This repository generates the build-products for both backends in `.build/defn/j
 
 ### System Dependencies
 
-The following are needed for building/running KWASM:
+The following are needed for building/running KWasm:
 
 -   [git](https://git-scm.com/)
 -   [Pandoc >= 1.17](https://pandoc.org) is used to generate the `*.k` files from the `*.md` files.
@@ -74,14 +74,14 @@ This Repository
 
 ### Semantics Layout
 
-The following files constitute the KWASM semantics:
+The following files constitute the KWasm semantics:
 
--   [data.md](data.md) provides the (functional) data of WASM (basic types, type constructors, and values).
--   [wasm.md](wasm.md) is the main KWASM semantics, containing the configuration and transition rules of WebAssembly.
+-   [data.md](data.md) provides the (functional) data of WebAssembly (basic types, type constructors, and values).
+-   [wasm.md](wasm.md) is the main KWasm semantics, containing the configuration and transition rules of WebAssembly.
 
 These additional files extend the semantics to make the repository more useful:
 
--   [test.md](test.md) is an execution harness for KWASM, providing a simple language for describing tests/programs.
+-   [test.md](test.md) is an execution harness for KWasm, providing a simple language for describing tests/programs.
 
 ### Example usage: `./kwasm` runner script
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository generates the build-products for both backends in `.build/defn/j
 
 ### System Dependencies
 
-The following are needed for building/running KEVM:
+The following are needed for building/running KWASM:
 
 -   [git](https://git-scm.com/)
 -   [Pandoc >= 1.17](https://pandoc.org) is used to generate the `*.k` files from the `*.md` files.
@@ -74,7 +74,7 @@ This Repository
 
 ### Semantics Layout
 
-The following files constitute the KEVM semantics:
+The following files constitute the KWASM semantics:
 
 -   [data.md](data.md) provides the (functional) data of WASM (basic types, type constructors, and values).
 -   [wasm.md](wasm.md) is the main KWASM semantics, containing the configuration and transition rules of WebAssembly.

--- a/data.md
+++ b/data.md
@@ -1,5 +1,5 @@
-WASM Data
-=========
+WebAssembly Data
+================
 
 ```k
 require "domains.k"
@@ -13,7 +13,7 @@ Parsing
 
 ### Layout
 
-WASM allows for block comments using `(;` and `;)`, and line comments using `;;`.
+WebAssembly allows for block comments using `(;` and `;)`, and line comments using `;;`.
 Additionally, white-space is skipped/ignored.
 Declaring regular expressions of sort `#Layout` infroms the K lexer to drop these tokens.
 
@@ -26,7 +26,7 @@ Declaring regular expressions of sort `#Layout` infroms the K lexer to drop thes
 
 ### Identifiers
 
-As defined in the [WASM Spec], the syntax of identifiers is as follows.
+As defined in the WebAssembly spec, the syntax of identifiers is as follows.
 
 **TODO**: Unsupported characters: `.:^@`
 
@@ -35,12 +35,12 @@ As defined in the [WASM Spec], the syntax of identifiers is as follows.
  // ------------------------------------------------------------------------
 ```
 
-WASM Types
-----------
+WebAssembly Types
+-----------------
 
 ### Base Types
 
-WASM has four basic types, for 32 and 64 bit integers and floats.
+WebAssembly has four basic types, for 32 and 64 bit integers and floats.
 
 ```k
     syntax IValType ::= "i32" | "i64"
@@ -106,7 +106,7 @@ Values
 
 ### Basic Values
 
-WASM values are either integers or floating-point numbers, of 32- or 64-bit widths.
+WebAssembly values are either integers or floating-point numbers, of 32- or 64-bit widths.
 
 ```k
     syntax Number ::= Int | Float
@@ -169,7 +169,7 @@ Function `#bool` converts a `Bool` into an `Int`.
 Data Structures
 ---------------
 
-WASM is a stack-machine, so here we provide the stack to operate over.
+WebAssembly is a stack-machine, so here we provide the stack to operate over.
 Operator `_++_` implements an append operator for sort `Stack`.
 
 ```k
@@ -201,8 +201,3 @@ Operator `_++_` implements an append operator for sort `Stack`.
     rule #drop(TYPE VTYPES, < TYPE > VAL:Number : STACK) => #drop(VTYPES, STACK)
 endmodule
 ```
-
-Resources
-=========
-
-[WASM Spec]: <https://github.com/WebAssembly/design>

--- a/kwasm
+++ b/kwasm
@@ -50,7 +50,7 @@ run_proof() {
     [[ -f "$proof_file" ]] || die "$proof_file does not exist"
 
     export K_OPTS=-Xmx8G
-    kprove --directory "$backend_dir" "$proof_file" "$@"
+    kprove --directory "$backend_dir" -m KWASM-LEMMAS "$proof_file" "$@"
 }
 
 run_test() {

--- a/kwasm
+++ b/kwasm
@@ -72,34 +72,8 @@ run_test() {
     [[ -f "$expected_file" ]] \
         || die "Expected output file '$expected_file' does not exist..."
 
-    run_krun "$test_file" > "$output_file"
+    run_krun "$test_file" > "$output_file" || true
     pretty_diff "$expected_file" "$output_file"
-}
-
-run_test_profile() {
-    local test_file exit_status
-    local output_log_dir stdout_log stderr_log
-
-    test_file="$1" ; shift
-
-    output_log_dir="$test_logs/$(dirname -- "$test_file")"
-    stdout_log="$test_logs/$test_file.stdout"
-    stderr_log="$test_logs/$test_file.stderr"
-    [[ -d "$output_log_dir" ]] || mkdir -p "$output_log_dir"
-
-    exit_status='0'
-    `which time` --quiet --format '%x %es %Us %Ss %MKB %C' --output "$test_log" --append \
-        bash -c "$0 --backend "$backend" test $test_file $@" \
-        1> "$stdout_log" 2> "$stderr_log" \
-        || exit_status="$?"
-
-    if [[ "$exit_status" == '0' ]]; then
-        progress "passed test: $test_file"
-    else
-        die "failed test: $test_file"
-    fi
-
-    exit "$exit_status"
 }
 
 # Main
@@ -122,20 +96,17 @@ backend_dir="$defn_dir/$backend"
 case "$run_command-$backend" in
 
     # Running
-    run-@(ocaml|java|haskell) )          run_krun         "$@" ;;
-    prove-@(java|haskell)     )          run_proof        "$@" ;;
-
-    test-@(ocaml|java|haskell)         ) run_test         "$@" ;;
-    test-profile-@(ocaml|java|haskell) ) run_test_profile "$@" ;;
+    run-@(ocaml|java|haskell)  ) run_krun  "$@" ;;
+    prove-@(java|haskell)      ) run_proof "$@" ;;
+    test-@(ocaml|java|haskell) ) run_test  "$@" ;;
 
     *) echo "
-    usage: $0 (run|test|test-profile) [--backend (ocaml|java|haskell)] <pgm>  <K args>*
-           $0 prove                   [--backend (java|haskell)]       <spec> <K args>*
+    usage: $0 (run|test) [--backend (ocaml|java|haskell)] <pgm>  <K args>*
+           $0 prove      [--backend (java|haskell)]       <spec> <K args>*
 
-       $0 run          : Run a single WASM program
-       $0 test         : Run a single WASM program like it's a test
-       $0 test-profile : Additionally record timing and memory usage to '${test_log#$(pwd)/}'
-       $0 prove        : Run a WASM K proof
+       $0 run   : Run a single WASM program
+       $0 test  : Run a single WASM program like it's a test
+       $0 prove : Run a WASM K proof
 
        Note: <pgm> is a path to a file containing a WASM program.
              <spec> is a K specification to be proved.

--- a/kwasm
+++ b/kwasm
@@ -104,11 +104,11 @@ case "$run_command-$backend" in
     usage: $0 (run|test) [--backend (ocaml|java|haskell)] <pgm>  <K args>*
            $0 prove      [--backend (java|haskell)]       <spec> <K args>*
 
-       $0 run   : Run a single WASM program
-       $0 test  : Run a single WASM program like it's a test
-       $0 prove : Run a WASM K proof
+       $0 run   : Run a single WebAssembly program
+       $0 test  : Run a single WebAssembly program like it's a test
+       $0 prove : Run a WebAssembly K proof
 
-       Note: <pgm> is a path to a file containing a WASM program.
+       Note: <pgm> is a path to a file containing a WebAssembly program.
              <spec> is a K specification to be proved.
              <K args> are any arguments you want to pass to K when executing/proving.
 " ; exit ;;

--- a/kwasm-lemmas.md
+++ b/kwasm-lemmas.md
@@ -1,7 +1,7 @@
 KWASM Lemmas
 ============
 
-These lemmas aid in verifying WASM programs behavior.
+These lemmas aid in verifying WebAssembly programs behavior.
 They are part of the *trusted* base, and so should be scrutinized carefully.
 
 ```k

--- a/kwasm-lemmas.md
+++ b/kwasm-lemmas.md
@@ -1,0 +1,21 @@
+KWASM Lemmas
+============
+
+These lemmas aid in verifying WASM programs behavior.
+They are part of the *trusted* base, and so should be scrutinized carefully.
+
+```k
+module KWASM-LEMMAS
+    imports WASM
+```
+
+When reasoning about `#chop`, it's often the case that the precondition to the proof contains the information needed to indicate no overflow.
+In this case, it's simpler (and safe) to simply discard the `#chop`, instead of evaluating it.
+
+```k
+    rule #chop(< ITYPE:IValType > N) => < ITYPE > N requires N <Int #pow(ITYPE)
+```
+
+```k
+endmodule
+```

--- a/kwasm-lemmas.md
+++ b/kwasm-lemmas.md
@@ -13,7 +13,8 @@ When reasoning about `#chop`, it's often the case that the precondition to the p
 In this case, it's simpler (and safe) to simply discard the `#chop`, instead of evaluating it.
 
 ```k
-    rule #chop(< ITYPE:IValType > N) => < ITYPE > N requires N <Int #pow(ITYPE)
+    rule #chop(< ITYPE:IValType > N) => < ITYPE > N
+      requires 0 <=Int N andBool N <Int #pow(ITYPE)
 ```
 
 ```k

--- a/test.md
+++ b/test.md
@@ -23,6 +23,7 @@ This will allow `trap` to "bubble up" (more correctly, to "consume the continuat
     syntax Instr ::= Assertion
  // --------------------------
     rule <k> trap ~> (L:Label => .) ... </k>
+    rule <k> trap ~> (.Instrs => .) ... </k>
     rule <k> trap ~> (I:Instr => .) ... </k> requires notBool isAssertion(I)
 
     rule <k> trap ~> (I:Instr IS:Instrs => I ~> IS) ... </k>

--- a/test.md
+++ b/test.md
@@ -1,4 +1,4 @@
-KWASM Testing
+KWasm Testing
 =============
 
 For testing, we augment the semantics with some helpers.

--- a/tests/proofs/simple-arithmetic-spec.k
+++ b/tests/proofs/simple-arithmetic-spec.k
@@ -3,19 +3,19 @@ requires "kwasm-lemmas.k"
 module SIMPLE-ARITHMETIC-SPEC
     imports WASM
 
-    rule <k> ( ITYPE:IValType . const X:Int ) => . </k>
+    rule <k> ( ITYPE:IValType . const X:Int ) => . ... </k>
          <stack> S:Stack => < ITYPE > X : S </stack>
       requires 0 <=Int X
 
-    rule <k> ( ITYPE:IValType . const X:Int ) => . </k>
+    rule <k> ( ITYPE:IValType . const X:Int ) => . ... </k>
          <stack> S:Stack => < ITYPE > (X +Int #pow(ITYPE)) : S </stack>
       requires X <Int 0
 
-    rule <k> ( ITYPE:IValType . const X:Int ) ( ITYPE . const Y:Int ) => . </k>
+    rule <k> ( ITYPE:IValType . const X:Int ) ( ITYPE . const Y:Int ) => . ... </k>
          <stack> S:Stack => < ITYPE > Y : < ITYPE > X : S </stack>
       requires 0 <=Int X andBool 0 <=Int Y
 
-    rule <k> ( ITYPE:IValType . const X:Int ) ( ITYPE . const Y:Int ) ( ITYPE . add ) => . </k>
+    rule <k> ( ITYPE:IValType . const X:Int ) ( ITYPE . const Y:Int ) ( ITYPE . add ) => . ... </k>
          <stack> S:Stack => < ITYPE > (X +Int Y) : S </stack>
       requires 0 <=Int X andBool 0 <=Int Y
        andBool (X +Int Y) <Int #pow(ITYPE)

--- a/tests/proofs/simple-arithmetic-spec.k
+++ b/tests/proofs/simple-arithmetic-spec.k
@@ -14,4 +14,9 @@ module SIMPLE-ARITHMETIC-SPEC
     rule <k> ( ITYPE:IValType . const X:Int ) ( ITYPE . const Y:Int ) => . </k>
          <stack> S:Stack => < ITYPE > Y : < ITYPE > X : S </stack>
       requires 0 <=Int X andBool 0 <=Int Y
+
+    rule <k> ( ITYPE:IValType . const X:Int ) ( ITYPE . const Y:Int ) ( ITYPE . add ) => . </k>
+         <stack> S:Stack => < ITYPE > (X +Int Y) : S </stack>
+      requires 0 <=Int X andBool 0 <=Int Y
+       andBool (X +Int Y) <Int #pow(ITYPE)
 endmodule

--- a/tests/proofs/simple-arithmetic-spec.k
+++ b/tests/proofs/simple-arithmetic-spec.k
@@ -19,4 +19,26 @@ module SIMPLE-ARITHMETIC-SPEC
          <stack> S:Stack => < ITYPE > (X +Int Y) : S </stack>
       requires 0 <=Int X andBool 0 <=Int Y
        andBool (X +Int Y) <Int #pow(ITYPE)
+
+    rule <k> block [ .ValTypes ]
+                 ( loop [ .ValTypes ]
+                     (local.get 0)
+                     (local.get 1)
+                     (i32.add)
+                     (local.set 1)
+                     (local.get 0)
+                     (i32.const 1)
+                     (i32.sub)
+                     (local.tee 0)
+                     (i32.eqz)
+                     (br_if 1)
+                 )
+             end
+          => .
+          ...
+         </k>
+         <locals>
+           0 |-> < i32 > (10 => 0)
+           1 |-> < i32 > (0 => 55)
+         </locals>
 endmodule

--- a/tests/proofs/simple-arithmetic-spec.k
+++ b/tests/proofs/simple-arithmetic-spec.k
@@ -1,3 +1,5 @@
+requires "kwasm-lemmas.k"
+
 module SIMPLE-ARITHMETIC-SPEC
     imports WASM
 

--- a/wasm.md
+++ b/wasm.md
@@ -49,10 +49,8 @@ WASM instructions are space-separated lists of instructions.
 ```k
     syntax Instrs ::= List{Instr, ""} [klabel(listInstr)]
  // -----------------------------------------------------
-    rule <k> .Instrs                       => .             ... </k>
-    rule <k> I:Instr IS:Instrs             => I ~> IS       ... </k>
-    rule <k> I:Instr ~> .Instrs            => I             ... </k>
-    rule <k> I:Instr ~> I':Instr IS:Instrs => I ~> I' ~> IS ... </k>
+    rule <k> .Instrs           => .       ... </k>
+    rule <k> I:Instr IS:Instrs => I ~> IS ... </k>
 ```
 
 ### Traps
@@ -426,7 +424,7 @@ Note that, unlike in the WASM specification document, we do not need the special
 ```k
     syntax Instr ::= "(" "br" Int ")"
  // ---------------------------------
-    rule <k> ( br N ) ~> (I:Instr => .) ... </k>
+    rule <k> ( br N ) ~> (IS:Instrs => .) ... </k>
     rule <k> ( br N ) ~> L:Label => #if N ==Int 0 #then L #else ( br N -Int 1 ) #fi ... </k>
 
     syntax Instr ::= "(" "br_if" Int ")"
@@ -633,8 +631,8 @@ Unlike labels, only one frame can be "broken" through at a time.
 
     syntax Instr ::= "return"
  // -------------------------
-    rule <k> return ~> (I:Instr => .)  ... </k>
-    rule <k> return ~> (L:Label => .)  ... </k>
+    rule <k> return ~> (IS:Instrs => .)  ... </k>
+    rule <k> return ~> (L:Label   => .)  ... </k>
     rule <k> (return => .) ~> FR:Frame ... </k>
 ```
 

--- a/wasm.md
+++ b/wasm.md
@@ -47,8 +47,8 @@ Instructions
 WASM instructions are space-separated lists of instructions.
 
 ```k
-    syntax Instrs ::= List{Instr, ""}
- // ---------------------------------
+    syntax Instrs ::= List{Instr, ""} [klabel(listInstr)]
+ // -----------------------------------------------------
     rule <k> .Instrs                       => .             ... </k>
     rule <k> I:Instr IS:Instrs             => I ~> IS       ... </k>
     rule <k> I:Instr ~> .Instrs            => I             ... </k>
@@ -543,8 +543,8 @@ Here, we allow for an "abstract" function declaration using syntax `func_::___`,
     syntax FuncDecl  ::= "(" FuncDecl ")"     [bracket]
                        | TypeKeyWord ValTypes
                        | "export" FunctionName
-    syntax FuncDecls ::= List{FuncDecl, ""}
- // ---------------------------------------
+    syntax FuncDecls ::= List{FuncDecl, ""} [klabel(listFuncDecl)]
+ // --------------------------------------------------------------
 
     syntax Instr ::= "(" "func"              FuncDecls Instrs ")"
                    | "(" "func" FunctionName FuncDecls Instrs ")"

--- a/wasm.md
+++ b/wasm.md
@@ -1,5 +1,5 @@
-WASM State and Semantics
-========================
+WebAssembly State and Semantics
+===============================
 
 ```k
 require "data.k"
@@ -44,7 +44,7 @@ Instructions
 
 ### Sequencing
 
-WASM instructions are space-separated lists of instructions.
+WebAssembly instructions are space-separated lists of instructions.
 
 ```k
     syntax Instrs ::= List{Instr, ""} [klabel(listInstr)]
@@ -419,7 +419,7 @@ It simply executes the block then records a label with an empty continuation.
 The `br*` instructions search through the instruction stack (the `<k>` cell) for the correct label index.
 Upon reaching it, the label itself is executed.
 
-Note that, unlike in the WASM specification document, we do not need the special "context" operator here because the value and instruction stacks are separate.
+Note that, unlike in the WebAssembly specification document, we do not need the special "context" operator here because the value and instruction stacks are separate.
 
 ```k
     syntax Instr ::= "(" "br" Int ")"


### PR DESCRIPTION
@hjorthjort this PR introduces the file `kwasm-lemmas.md`, where you can place facts about WASM simplification which probably shouldn't be directly in the semantics.

Note that we have few semantics which we use for commercial verification (KEVM being one of them), so it's not entirely clear where the "correct" place to put these lemmas is (whether in the definition or not).

Also, we add a couple more proofs to `simple-arithmetic-spec.k`. Feel free to add more if you feel adventurous.