### PR TITLE
Revert "Makefile: skip haskell backend by default"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,14 +26,11 @@ clean:
 # Build Dependencies (K Submodule)
 # --------------------------------
 
-haskell_backend_skip=-Dhaskell.backend.skip
-haskell-deps: deps
-haskell-deps: haskell_backend_skip=
 deps: $(k_submodule)/make.timestamp $(pandoc_tangle_submodule)/make.timestamp ocaml-deps
 
 $(k_submodule)/make.timestamp:
 	git submodule update --init --recursive
-	cd $(k_submodule) && mvn package -DskipTests -Dllvm.backend.skip ${haskell_backend_skip}
+	cd $(k_submodule) && mvn package -DskipTests -Dllvm.backend.skip
 	touch $(k_submodule)/make.timestamp
 
 $(pandoc_tangle_submodule)/make.timestamp:


### PR DESCRIPTION
I have the Haskell build working on my end now. Do we want to put it back in by default? Or better to leave it out while it's neither the default concrete or symbolic backend?