### PR TITLE
Bugfix: first argument to `memory` is always the initial size

### DIFF
--- a/tests/simple/memory.wast
+++ b/tests/simple/memory.wast
@@ -2,7 +2,7 @@
 #assertMemory 0 .MemBound "memory initial 1"
 
 ( memory 34)
-#assertMemory 0 34 "memory initial 2"
+#assertMemory 34 .MemBound "memory initial 2"
 
 ( memory 4 10 )
 #assertMemory 4 10 "memory initial 3"
@@ -20,10 +20,10 @@
 #assertTopStack <i32> -1 "memory grow"
 #assertMemory 10 10 "memory grown"
 
-( memory #maxMemorySize() +Int 10)
-(memory.grow (i32.const #maxMemorySize() +Int 1))
+( memory #maxMemorySize())
+(memory.grow (i32.const 1))
 #assertTopStack <i32> -1 "memory grow max too large"
-#assertMemory 0 #maxMemorySize() +Int 10 "memory grow max too large"
+#assertMemory #maxMemorySize() .MemBound "memory grow max too large"
 
 ( memory )
 (memory.grow (i32.const #maxMemorySize()))
@@ -33,3 +33,4 @@
 (memory.size)
 #assertStack <i32> #maxMemorySize() : < i32 > -1 : .Stack "memory grow unbounded"
 #assertMemory #maxMemorySize() .MemBound "memory grown unbounded"
+

--- a/wasm.md
+++ b/wasm.md
@@ -660,15 +660,15 @@ Currently, only one memory may be accessible to a module, and thus the `<memAddr
 **TODO**: There are many more valid ways to instantiate memory. Allow specifying just max or neither min or max, folded syntax, identifier, inline instantiation, and inline export and import.
 
 ```k
-    syntax Instr ::= "(" "memory"               ")"
-                   | "(" "memory" Int           ")" // Size only
-                   | "(" "memory" Int Int       ")" // Min and max.
+    syntax Instr ::= "(" "memory"                  ")"
+                   | "(" "memory"     Int          ")" // Size only
+                   | "(" "memory"     Int Int      ")" // Min and max.
                    |     "memory" "{" Int MemBound "}"
  // --------------------------------------------------
-    rule <k> ( memory                 ) => memory { 0                 .MemBound         }         ... </k>
-    rule <k> ( memory MIN:Int         ) => memory { MIN               .MemBound         }         ... </k>
+    rule <k> ( memory                 ) => memory { 0   .MemBound } ... </k>
+    rule <k> ( memory MIN:Int         ) => memory { MIN .MemBound } ... </k>
       requires MIN <=Int #maxMemorySize()
-    rule <k> ( memory MIN:Int MAX:Int ) => memory { MIN               MAX               }         ... </k>
+    rule <k> ( memory MIN:Int MAX:Int ) => memory { MIN MAX       } ... </k>
       requires MIN <=Int #maxMemorySize()
        andBool MAX <=Int #maxMemorySize()
 

--- a/wasm.md
+++ b/wasm.md
@@ -661,13 +661,16 @@ Currently, only one memory may be accessible to a module, and thus the `<memAddr
 
 ```k
     syntax Instr ::= "(" "memory"               ")"
-                   | "(" "memory" Int           ")" // Max only
+                   | "(" "memory" Int           ")" // Size only
                    | "(" "memory" Int Int       ")" // Min and max.
                    |     "memory" "{" Int MemBound "}"
  // --------------------------------------------------
-    rule <k> ( memory                 ) => memory { 0   .MemBound } ... </k>
-    rule <k> ( memory         MAX:Int ) => memory { 0   MAX       } ... </k>
-    rule <k> ( memory MIN:Int MAX:Int ) => memory { MIN MAX       } ... </k>
+    rule <k> ( memory                 ) => memory { 0                 .MemBound         }         ... </k>
+    rule <k> ( memory MIN:Int         ) => memory { MIN               .MemBound         }         ... </k>
+      requires MIN <=Int #maxMemorySize()
+    rule <k> ( memory MIN:Int MAX:Int ) => memory { MIN               MAX               }         ... </k>
+      requires MIN <=Int #maxMemorySize()
+       andBool MAX <=Int #maxMemorySize()
 
     rule <k> memory { _ _ } => trap ... </k>
          <memAddrs> MAP </memAddrs> requires MAP =/=K .Map


### PR DESCRIPTION
I found this as I was working on memories. Seems I didn't pay close enough attention when implementing the `(memory X)` instruction. Old implementation treated it as the max size, which is incorrect, it should be the initial size.

I also found some sensible validity checks were missing (not allowing any initial size or max size), so I added those.