### PR TITLE
Add support for KLab in `kwasm` runner script.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,6 @@ RUN    cd /home/user \
 
 ENV LC_ALL=C.UTF-8
 ADD --chown=user:user .build/k/haskell-backend/src/main/native/haskell-backend/stack.yaml /home/user/.tmp-haskell/
-ADD --chown=user:user .build/k/haskell-backend/src/main/native/haskell-backend/src/main/haskell/kore/package.yaml /home/user/.tmp-haskell/src/main/haskell/kore/
+ADD --chown=user:user .build/k/haskell-backend/src/main/native/haskell-backend/kore/package.yaml /home/user/.tmp-haskell/kore/
 RUN    cd /home/user/.tmp-haskell \
     && stack build --only-snapshot --test --bench --haddock --library-profiling

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ ENV LC_ALL=C.UTF-8
 ADD --chown=user:user .build/k/haskell-backend/src/main/native/haskell-backend/stack.yaml /home/user/.tmp-haskell/
 ADD --chown=user:user .build/k/haskell-backend/src/main/native/haskell-backend/kore/package.yaml /home/user/.tmp-haskell/kore/
 RUN    cd /home/user/.tmp-haskell \
-    && stack build --only-snapshot --test --bench --haddock --library-profiling
+    && stack build --only-snapshot --test --bench --no-haddock-deps --haddock --library-profiling

--- a/kwasm
+++ b/kwasm
@@ -132,6 +132,7 @@ case "$run_command-$backend" in
        $0 run   : Run a single WebAssembly program
        $0 test  : Run a single WebAssembly program like it's a test
        $0 prove : Run a WebAssembly K proof
+       $0 klab-(run|prove) : Run or prove a spec and launch KLab on the execution graph.
 
        Note: <pgm> is a path to a file containing a WebAssembly program.
              <spec> is a K specification to be proved.

--- a/kwasm
+++ b/kwasm
@@ -65,6 +65,7 @@ run_klab() {
         --state-log --state-log-path "$klab_dir/data" --state-log-id klab-statelog \
         --state-log-events OPEN,EXECINIT,SEARCHINIT,REACHINIT,REACHTARGET,REACHPROVED,NODE,RULE,SRULE,RULEATTEMPT,IMPLICATION,Z3QUERY,Z3RESULT,CLOSE \
         --output-flatten "_Map_ #And" \
+        --output-tokenize "listInstr" \
         --no-alpha-renaming --restore-original-names --no-sort-collections \
         --output json \
         "$@" \

--- a/kwasm
+++ b/kwasm
@@ -53,6 +53,21 @@ run_proof() {
     kprove --directory "$backend_dir" -m KWASM-LEMMAS "$proof_file" "$@"
 }
 
+run_klab() {
+    local run_mode run_file
+
+    run_mode="$1" ; shift
+    run_file="$1" ; shift
+
+    $0 $run_mode --backend java $run_file \
+        --state-log --state-log-path /tmp/klab --state-log-id wasmtest \
+        --state-log-events OPEN,EXECINIT,SEARCHINIT,REACHINIT,REACHTARGET,REACHPROVED,NODE,RULE,SRULE,RULEATTEMPT,IMPLICATION,Z3QUERY,Z3RESULT,CLOSE \
+        --output json \
+        >/dev/null
+
+    progress 'Run `TMPDIR=/tmp KLAB_EVMS_PATH=foo klab debugg wasmtest` to explore execution trace.'
+}
+
 run_test() {
     local test_file expected_file output_file
 
@@ -85,7 +100,8 @@ cd "$(dirname $0)"
 run_command="$1" ; shift
 
 backend="ocaml"
-[[ ! "$run_command" == 'prove' ]] || backend='java'
+[[ ! "$run_command" == prove ]] || backend='java'
+[[ ! "$run_command" =~ klab* ]] || backend='java'
 if [[ $# -gt 0 ]] && [[ $1 == '--backend' ]]; then
     backend="$2"
     shift 2
@@ -96,13 +112,15 @@ backend_dir="$defn_dir/$backend"
 case "$run_command-$backend" in
 
     # Running
-    run-@(ocaml|java|haskell)  ) run_krun  "$@" ;;
-    prove-@(java|haskell)      ) run_proof "$@" ;;
-    test-@(ocaml|java|haskell) ) run_test  "$@" ;;
+    run-@(ocaml|java|haskell)  ) run_krun                        "$@" ;;
+    prove-@(java|haskell)      ) run_proof                       "$@" ;;
+    test-@(ocaml|java|haskell) ) run_test                        "$@" ;;
+    klab-@(run|prove)-java     ) run_klab "${run_command#klab-}" "$@" ;;
 
     *) echo "
     usage: $0 (run|test) [--backend (ocaml|java|haskell)] <pgm>  <K args>*
            $0 prove      [--backend (java|haskell)]       <spec> <K args>*
+           $0 klab-(run|prove)                            <spec> <K args>*
 
        $0 run   : Run a single WebAssembly program
        $0 test  : Run a single WebAssembly program like it's a test

--- a/kwasm
+++ b/kwasm
@@ -65,7 +65,7 @@ run_klab() {
         --state-log --state-log-path "$klab_dir/data" --state-log-id klab-statelog \
         --state-log-events OPEN,EXECINIT,SEARCHINIT,REACHINIT,REACHTARGET,REACHPROVED,NODE,RULE,SRULE,RULEATTEMPT,IMPLICATION,Z3QUERY,Z3RESULT,CLOSE \
         --output-flatten "_Map_ #And" \
-        --output-tokenize "listInstr" \
+        --output-tokenize "listInstr <_>_ i32_WASM-DATA i64_WASM-DATA _:__WASM-DATA" \
         --no-alpha-renaming --restore-original-names --no-sort-collections \
         --output json \
         "$@" \

--- a/kwasm
+++ b/kwasm
@@ -21,6 +21,8 @@ test_logs="$build_dir/logs"
 test_log="$test_logs/tests.log"
 mkdir -p "$test_logs"
 
+klab_dir="$build_dir/klab"
+
 # Utilities
 # ---------
 
@@ -59,13 +61,18 @@ run_klab() {
     run_mode="$1" ; shift
     run_file="$1" ; shift
 
-    $0 $run_mode --backend java $run_file \
-        --state-log --state-log-path /tmp/klab --state-log-id wasmtest \
+    $0 "$run_mode" --backend java "$run_file" \
+        --state-log --state-log-path "$klab_dir/data" --state-log-id klab-statelog \
         --state-log-events OPEN,EXECINIT,SEARCHINIT,REACHINIT,REACHTARGET,REACHPROVED,NODE,RULE,SRULE,RULEATTEMPT,IMPLICATION,Z3QUERY,Z3RESULT,CLOSE \
+        --output-flatten "_Map_ #And" \
+        --no-alpha-renaming --restore-original-names --no-sort-collections \
         --output json \
-        >/dev/null
+        "$@" \
+        >/dev/null || true
 
-    progress 'Run `TMPDIR=/tmp KLAB_EVMS_PATH=foo klab debugg wasmtest` to explore execution trace.'
+    export KLAB_OUT="$klab_dir"
+    export PATH=$HOME/src/klab/bin:$PATH
+    klab debug klab-statelog
 }
 
 run_test() {

--- a/kwasm
+++ b/kwasm
@@ -72,7 +72,6 @@ run_klab() {
         >/dev/null || true
 
     export KLAB_OUT="$klab_dir"
-    export PATH=$HOME/src/klab/bin:$PATH
     klab debug klab-statelog
 }
 
@@ -138,5 +137,7 @@ case "$run_command-$backend" in
        Note: <pgm> is a path to a file containing a WebAssembly program.
              <spec> is a K specification to be proved.
              <K args> are any arguments you want to pass to K when executing/proving.
+
+       KLab: Make sure that the 'klab/bin' directory is on your PATH to use this option.
 " ; exit ;;
 esac

--- a/tests/proofs/simple-arithmetic-spec.k
+++ b/tests/proofs/simple-arithmetic-spec.k
@@ -2,6 +2,7 @@ requires "kwasm-lemmas.k"
 
 module SIMPLE-ARITHMETIC-SPEC
     imports WASM
+    imports KWASM-LEMMAS
 
     rule <k> ( ITYPE:IValType . const X:Int ) => . ... </k>
          <stack> S:Stack => < ITYPE > X : S </stack>

--- a/wasm.md
+++ b/wasm.md
@@ -64,7 +64,8 @@ WebAssembly instructions are space-separated lists of instructions.
     syntax Instrs ::= List{Instr, ""} [klabel(listInstr)]
  // -----------------------------------------------------
     rule <k> .Instrs           => .       ... </k>
-    rule <k> I:Instr IS:Instrs => I ~> IS ... </k>
+    rule <k> I:Instr .Instrs   => I       ... </k>
+    rule <k> I:Instr IS:Instrs => I ~> IS ... </k> requires IS =/=K .List
 ```
 
 ### Traps

--- a/wasm.md
+++ b/wasm.md
@@ -63,9 +63,9 @@ WebAssembly instructions are space-separated lists of instructions.
 ```k
     syntax Instrs ::= List{Instr, ""} [klabel(listInstr)]
  // -----------------------------------------------------
-    rule <k> .Instrs           => .       ... </k>
-    rule <k> I:Instr .Instrs   => I       ... </k>
-    rule <k> I:Instr IS:Instrs => I ~> IS ... </k> requires IS =/=K .List
+    rule          <k> .Instrs           => .       ... </k>
+    rule          <k> I:Instr .Instrs   => I       ... </k>
+    rule [step] : <k> I:Instr IS:Instrs => I ~> IS ... </k> requires IS =/=K .List
 ```
 
 ### Traps


### PR DESCRIPTION
@hjorthjort if you could test that `./kwasm klab-run tests/simple/arithmetic.wast` and `./kwasm klab-prove tests/proofs/simple-arithmetic-spec.k` work if you put `klab/bin` on your PATH externally, I would appreciate it. If so, let's get this merged.

Remember you need to use `rad-rewrite` branch of KLab.

@mhhf you may be interested as well.