### PR TITLE
Config fix globals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ export LUA_PATH
         deps ocaml-deps haskell-deps \
         defn defn-ocaml defn-java defn-haskell \
         build build-ocaml defn-haskell build-haskell \
-        test test-execution test-simple test-proof \
+        test test-execution test-simple test-prove \
         media presentations reports
 
 all: build
@@ -123,7 +123,7 @@ tests/%.parse: tests/%
 tests/%.prove: tests/%
 	$(TEST) prove --backend $(TEST_SYMBOLIC_BACKEND) $<
 
-test: test-execution test-proof
+test: test-execution test-prove
 
 ### Execution Tests
 

--- a/data.md
+++ b/data.md
@@ -104,6 +104,13 @@ The `#width` function returns the bit-width of a given `IValType`.
     rule #pow (i64) => 18446744073709551616
 ```
 
+### Type Mutability
+
+```k
+    syntax Mut ::= ".Mut" | "const" | "var"
+ // ---------------------------------------
+```
+
 Values
 ------
 

--- a/test.md
+++ b/test.md
@@ -10,6 +10,27 @@ module WASM-TEST
     imports WASM
 ```
 
+Helper Functions
+----------------
+
+`init_global` is a helper function that helps us to declare a new global variable.
+
+```k
+    syntax Instr ::= "init_global" Int Int
+ // --------------------------------------
+    rule <k> init_global INDEX GADDR => . ... </k>
+         <globalAddrs> GADDRS => GADDRS [ INDEX <- GADDR ] </globalAddrs>
+         <globals>
+           ( .Bag =>
+             <globalInst>
+               <gAddr> GADDR </gAddr>
+               ...
+             </globalInst>
+           )
+           ...
+         </globals>
+```
+
 Assertions
 ----------
 
@@ -70,7 +91,17 @@ The operator `#assertLocal`/`#assertGlobal` operators perform a check for a loca
          <locals> ... (INDEX |-> VALUE => .Map) ... </locals>
 
     rule <k> #assertGlobal INDEX VALUE _ => . ... </k>
-         <globals> ... (INDEX |-> VALUE => .Map) ... </globals>
+         <globalAddrs> ... (INDEX |-> GADDR => .Map) ... </globalAddrs>
+         <globals>
+           ( <globalInst>
+               <gAddr>  GADDR </gAddr>
+               <gValue> VALUE </gValue>
+               ...
+             </globalInst>
+          => .Bag
+           )
+           ...
+         </globals>
 ```
 
 ### Function Assertions

--- a/test.md
+++ b/test.md
@@ -10,27 +10,6 @@ module WASM-TEST
     imports WASM
 ```
 
-Helper Functions
-----------------
-
-`init_global` is a helper function that helps us to declare a new global variable.
-
-```k
-    syntax Instr ::= "init_global" Int Int
- // --------------------------------------
-    rule <k> init_global INDEX GADDR => . ... </k>
-         <globalAddrs> GADDRS => GADDRS [ INDEX <- GADDR ] </globalAddrs>
-         <globals>
-           ( .Bag =>
-             <globalInst>
-               <gAddr> GADDR </gAddr>
-               ...
-             </globalInst>
-           )
-           ...
-         </globals>
-```
-
 Assertions
 ----------
 
@@ -99,6 +78,24 @@ The operator `#assertLocal`/`#assertGlobal` operators perform a check for a loca
                ...
              </globalInst>
           => .Bag
+           )
+           ...
+         </globals>
+```
+
+`init_global` is a helper function that helps us to declare a new global variable.
+
+```k
+    syntax Instr ::= "init_global" Int Int
+ // --------------------------------------
+    rule <k> init_global INDEX GADDR => . ... </k>
+         <globalAddrs> GADDRS => GADDRS [ INDEX <- GADDR ] </globalAddrs>
+         <globals>
+           ( .Bag =>
+             <globalInst>
+               <gAddr> GADDR </gAddr>
+               ...
+             </globalInst>
            )
            ...
          </globals>

--- a/tests/simple/variables.wast
+++ b/tests/simple/variables.wast
@@ -19,8 +19,8 @@ init_locals < i32 > 0 : < i32 > 0 : < i32 > 0 : .Stack
 
 ;; Test globals
 
-init_global 0 < i32 > 0
-init_global 1 < i32 > 0
+init_global 0 0
+init_global 1 1
 
 (i32.const 43)
 (global.set 0)

--- a/tests/simple/variables.wast
+++ b/tests/simple/variables.wast
@@ -32,3 +32,12 @@ init_global 1 1
 #assertTopStack < i32 > 55 "set_global stack"
 #assertGlobal 1 < i32 > 55 "set_global"
 
+;; Test global folded forms
+
+init_global 0 0
+(global.set 0 (i32.const 77))
+init_global 1 1
+(global.set 1 (i32.const 99))
+
+#assertGlobal 1 < i32 > 99 "set_global folded"
+#assertGlobal 1 < i32 > 77 "set_global folded 2"

--- a/tests/simple/variables.wast
+++ b/tests/simple/variables.wast
@@ -40,4 +40,4 @@ init_global 1 1
 (global.set 1 (i32.const 99))
 
 #assertGlobal 1 < i32 > 99 "set_global folded"
-#assertGlobal 1 < i32 > 77 "set_global folded 2"
+#assertGlobal 0 < i32 > 77 "set_global folded 2"

--- a/tests/success-haskell.out
+++ b/tests/success-haskell.out
@@ -9,13 +9,13 @@
     .Stack
   </stack>
   <curFrame>
-    <addrs>
-      .Map
-    </addrs>
     <locals>
       .Map
     </locals>
     <moduleInst>
+      <funcAddrs>
+        .Map
+      </funcAddrs>
       <globals>
         .Map
       </globals>

--- a/tests/success-haskell.out
+++ b/tests/success-haskell.out
@@ -22,6 +22,9 @@
       <memAddrs>
         .Map
       </memAddrs>
+      <globalAddrs>
+        .Map
+      </globalAddrs>
     </moduleInst>
   </curFrame>
   <mainStore>
@@ -34,5 +37,8 @@
     <mems>
       .MemInstCellMap
     </mems>
+    <globals>
+      .GlobalInstCellMap
+    </globals>
   </mainStore>
 </generatedTop>

--- a/tests/success-java.out
+++ b/tests/success-java.out
@@ -9,13 +9,13 @@
     .Stack
   </stack>
   <curFrame>
-    <addrs>
-      .Map
-    </addrs>
     <locals>
       .Map
     </locals>
     <moduleInst>
+      <funcAddrs>
+        .Map
+      </funcAddrs>
       <globals>
         .Map
       </globals>

--- a/tests/success-java.out
+++ b/tests/success-java.out
@@ -16,12 +16,12 @@
       <funcAddrs>
         .Map
       </funcAddrs>
-      <globals>
-        .Map
-      </globals>
       <memAddrs>
         .Map
       </memAddrs>
+      <globalAddrs>
+        .Map
+      </globalAddrs>
     </moduleInst>
   </curFrame>
   <mainStore>
@@ -34,5 +34,8 @@
     <mems>
       .Map
     </mems>
+    <globals>
+      .Map
+    </globals>
   </mainStore>
 </generatedTop>

--- a/tests/success-ocaml.out
+++ b/tests/success-ocaml.out
@@ -16,12 +16,12 @@
       <funcAddrs>
         .Map
       </funcAddrs>
-      <globals>
-        .Map
-      </globals>
       <memAddrs>
         .Map
       </memAddrs>
+      <globalAddrs>
+        .Map
+      </globalAddrs>
     </moduleInst>
   </curFrame>
   <mainStore>
@@ -34,5 +34,8 @@
     <mems>
       .MemInstCellMap
     </mems>
+    <globals>
+      .GlobalInstCellMap
+    </globals>
   </mainStore>
 </generatedTop>

--- a/tests/success-ocaml.out
+++ b/tests/success-ocaml.out
@@ -9,13 +9,13 @@
     .Stack
   </stack>
   <curFrame>
-    <addrs>
-      .Map
-    </addrs>
     <locals>
       .Map
     </locals>
     <moduleInst>
+      <funcAddrs>
+        .Map
+      </funcAddrs>
       <globals>
         .Map
       </globals>

--- a/wasm.md
+++ b/wasm.md
@@ -535,6 +535,7 @@ The `*_local` instructions are defined here.
 ```k
     syntax Instr ::= "(" "global.get" Int ")"
                    | "(" "global.set" Int ")"
+                   | "(" "global.set" Int Instr ")"
  // -----------------------------------------
     rule <k> ( global.get INDEX ) => . ... </k>
          <stack> STACK => VALUE : STACK </stack>
@@ -553,6 +554,8 @@ The `*_local` instructions are defined here.
            <gValue> _ => VALUE </gValue>
            ...
          </globalInst>
+
+    rule <k> ( global.set INDEX INSTR ) => INSTR ~> ( global.set INDEX ) ... </k>
 ```
 
 Function Declaration and Invocation

--- a/wasm.md
+++ b/wasm.md
@@ -19,9 +19,9 @@ Configuration
       <curFrame>
         <locals> .Map </locals>
         <moduleInst>
-          <funcAddrs> .Map </funcAddrs>
-          <globals>   .Map </globals>
-          <memAddrs>  .Map </memAddrs>
+          <funcAddrs>   .Map </funcAddrs>
+          <memAddrs>    .Map </memAddrs>
+          <globalAddrs> .Map </globalAddrs>
         </moduleInst>
       </curFrame>
       <mainStore>
@@ -43,6 +43,13 @@ Configuration
             <mdata>   .Map      </mdata>
           </memInst>
         </mems>
+        <globals>
+          <globalInst multiplicity="*" type="Map">
+            <gAddr>  0         </gAddr>
+            <gValue> undefined </gValue>
+            <gMut>   .Mut      </gMut>
+          </globalInst>
+        </globals>
       </mainStore>
 ```
 
@@ -526,20 +533,26 @@ The `*_local` instructions are defined here.
 ### Globals
 
 ```k
-    syntax Instr ::= "init_global" Int Val
-                   | "(" "global.get" Int ")"
+    syntax Instr ::= "(" "global.get" Int ")"
                    | "(" "global.set" Int ")"
  // -----------------------------------------
-    rule <k> init_global INDEX VALUE => . ... </k>
-         <globals> GLOBALS => GLOBALS [ INDEX <- VALUE ] </globals>
-
     rule <k> ( global.get INDEX ) => . ... </k>
          <stack> STACK => VALUE : STACK </stack>
-         <globals> ... INDEX |-> VALUE ... </globals>
+         <globalAddrs> ... INDEX |-> GADDR ... </globalAddrs>
+         <globalInst>
+           <gAddr>  GADDR </gAddr>
+           <gValue> VALUE </gValue>
+           ...
+         </globalInst>
 
     rule <k> ( global.set INDEX ) => . ... </k>
          <stack> VALUE : STACK => STACK </stack>
-         <globals> ... INDEX |-> (_ => VALUE) ... </globals>
+         <globalAddrs> ... INDEX |-> GADDR ... </globalAddrs>
+         <globalInst>
+           <gAddr>  GADDR      </gAddr>
+           <gValue> _ => VALUE </gValue>
+           ...
+         </globalInst>
 ```
 
 Function Declaration and Invocation

--- a/wasm.md
+++ b/wasm.md
@@ -533,10 +533,10 @@ The `*_local` instructions are defined here.
 ### Globals
 
 ```k
-    syntax Instr ::= "(" "global.get" Int ")"
-                   | "(" "global.set" Int ")"
+    syntax Instr ::= "(" "global.get" Int       ")"
+                   | "(" "global.set" Int       ")"
                    | "(" "global.set" Int Instr ")"
- // -----------------------------------------
+ // -----------------------------------------------
     rule <k> ( global.get INDEX ) => . ... </k>
          <stack> STACK => VALUE : STACK </stack>
          <globalAddrs> ... INDEX |-> GADDR ... </globalAddrs>

--- a/wasm.md
+++ b/wasm.md
@@ -17,11 +17,11 @@ Configuration
       <deterministicMemoryGrowth> true </deterministicMemoryGrowth>
       <stack> .Stack </stack>
       <curFrame>
-        <addrs>  .Map </addrs>
         <locals> .Map </locals>
         <moduleInst>
-          <globals>  .Map  </globals>
-          <memAddrs> .Map  </memAddrs>
+          <funcAddrs> .Map </funcAddrs>
+          <globals>   .Map </globals>
+          <memAddrs>  .Map </memAddrs>
         </moduleInst>
       </curFrame>
       <mainStore>
@@ -635,8 +635,11 @@ Unlike labels, only one frame can be "broken" through at a time.
           </k>
          <stack>  STACK => .Stack </stack>
          <curFrame>
-           <addrs> _ => ADDRS </addrs>
            <locals> LOCAL => .Map </locals>
+           <moduleInst>
+             <funcAddrs> _ => ADDRS </funcAddrs>
+             ...
+           </moduleInst>
            ...
          </curFrame>
          <funcDef>


### PR DESCRIPTION
1. added another sort: syntax Mut ::= ".Mut" | "const" | "var"
2. globals now moved into <mainStore>, and <moduleInst> now has a <globalAddrs> for global addresses.
3. "init_global" is moved to test.md because it is used only for test. Maybe "init_locals" should also be moved to test.md in the future.
4. definition for init_global now changed to "init_global" INDEX GADDR. The test code also changed accordingly.