### PR TITLE
kwasm: updates pulled over from KEVM

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,6 +57,15 @@ pipeline {
             '''
           }
         }
+        stage('KLab Proofs Java') {
+          steps {
+            sh '''
+              nprocs=$(nproc)
+              [ "$nprocs" -gt '4' ] && nprocs=4
+              make test-klab-prove -j"$nprocs"
+            '''
+          }
+        }
       }
     }
     stage('KNinja-based') {

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ export LUA_PATH
         deps ocaml-deps haskell-deps \
         defn defn-ocaml defn-java defn-haskell \
         build build-ocaml defn-haskell build-haskell \
-        test test-execution test-simple test-prove \
+        test test-execution test-simple test-prove test-klab-prove \
         media presentations reports
 
 all: build
@@ -160,6 +160,10 @@ parse-conformance: $(conformance_tests:=.parse)
 proof_tests:=$(wildcard tests/proofs/*-spec.k)
 
 test-prove: $(proof_tests:=.prove)
+
+### KLab interactive
+
+test-klab-prove: $(proof_tests:=.klab-prove)
 
 # Presentation
 # ------------

--- a/Makefile
+++ b/Makefile
@@ -126,8 +126,8 @@ test: test-execution test-prove
 # Generic Test Harnesses
 
 tests/%.run: tests/%
-	$(TEST) run --backend $(TEST_CONCRETE_BACKEND) $< > tests/$*.$(TEST_CONCRETE_BACKEND)-out \
-	    || $(CHECK) tests/templates/output-success-$(TEST_CONCRETE_BACKEND).json tests/$*.$(TEST_CONCRETE_BACKEND)-out
+	$(TEST) run --backend $(TEST_CONCRETE_BACKEND) $< > tests/$*.$(TEST_CONCRETE_BACKEND)-out
+	$(CHECK) tests/success-$(TEST_CONCRETE_BACKEND).out tests/$*.$(TEST_CONCRETE_BACKEND)-out
 	rm -rf tests/$*.$(TEST_CONCRETE_BACKEND)-out
 
 tests/%.parse: tests/%

--- a/Makefile
+++ b/Makefile
@@ -110,20 +110,36 @@ $(haskell_kompiled): $(haskell_defn)
 # Testing
 # -------
 
-TEST_CONCRETE_BACKEND=ocaml
-TEST_SYMBOLIC_BACKEND=java
-TEST=./kwasm
+TEST_CONCRETE_BACKEND:=ocaml
+TEST_SYMBOLIC_BACKEND:=java
+TEST:=./kwasm
+KPROVE_MODULE:=KWASM-LEMMAS
+CHECK:=git --no-pager diff --no-index --ignore-all-space
 
-tests/%.test: tests/%
-	 $(TEST) test --backend $(TEST_CONCRETE_BACKEND) $<
-
-tests/%.parse: tests/%
-	 $(TEST) kast --backend $(TEST_CONCRETE_BACKEND) $<
-
-tests/%.prove: tests/%
-	$(TEST) prove --backend $(TEST_SYMBOLIC_BACKEND) $<
+tests/%/make.timestamp:
+	@echo "== submodule: $@"
+	git submodule update --init -- tests/$*
+	touch $@
 
 test: test-execution test-prove
+
+# Generic Test Harnesses
+
+tests/%.run: tests/%
+	$(TEST) run --backend $(TEST_CONCRETE_BACKEND) $< > tests/$*.$(TEST_CONCRETE_BACKEND)-out \
+	    || $(CHECK) tests/templates/output-success-$(TEST_CONCRETE_BACKEND).json tests/$*.$(TEST_CONCRETE_BACKEND)-out
+	rm -rf tests/$*.$(TEST_CONCRETE_BACKEND)-out
+
+tests/%.parse: tests/%
+	$(TEST) kast --backend $(TEST_CONCRETE_BACKEND) $< kast > $@-out
+	$(CHECK) $@-expected $@-out
+	rm -rf $@-out
+
+tests/%.prove: tests/%
+	$(TEST) prove --backend $(TEST_SYMBOLIC_BACKEND) $< --format-failures --def-module $(KPROVE_MODULE)
+
+tests/%.klab-prove: tests/%
+	$(TEST) klab-prove --backend $(TEST_SYMBOLIC_BACKEND) $< --format-failures --def-module $(KPROVE_MODULE)
 
 ### Execution Tests
 
@@ -131,7 +147,7 @@ test-execution: test-simple
 
 simple_tests:=$(wildcard tests/simple/*.wast)
 
-test-simple: $(simple_tests:=.test)
+test-simple: $(simple_tests:=.run)
 
 ### Conformance Tests
 

--- a/README.md
+++ b/README.md
@@ -110,24 +110,18 @@ Run the file `tests/simple/arithmetic.wast`:
 ./kwasm run tests/simple/arithmetic.wast
 ```
 
-Run the same file as a test:
-
-```sh
-./kwasm test tests/simple/arithmetic.wast
-```
-
-To run proofs, you can similarly use `./kwasm`.
+To run proofs, you can similarly use `./kwasm`, but most specify the module to use for proving.
 For example, to prove the specification `tests/proofs/simple-arithmetic-spec.k`:
 
 ```sh
-./kwasm prove tests/proofs/simple-arithmetic-spec.k
+./kwasm prove tests/proofs/simple-arithmetic-spec.k -m KWASM-LEMMAS
 ```
 
 You can optionally override the default backend using the `--backend BACKEND` flag:
 
 ```sh
 ./kwasm run   --backend java    tests/simple/arithmetic.wast
-./kwasm prove --backend haskell tests/proofs/simple-arithmetic-spec.k
+./kwasm prove --backend haskell tests/proofs/simple-arithmetic-spec.k -m KWASM-LEMMAS
 ```
 
 Testing

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Run the file `tests/simple/arithmetic.wast`:
 ./kwasm run tests/simple/arithmetic.wast
 ```
 
-To run proofs, you can similarly use `./kwasm`, but most specify the module to use for proving.
+To run proofs, you can similarly use `./kwasm`, but must specify the module to use for proving.
 For example, to prove the specification `tests/proofs/simple-arithmetic-spec.k`:
 
 ```sh

--- a/build
+++ b/build
@@ -50,7 +50,7 @@ def test_proof(glob, defn, backend):
     return defn.proofs( glob = glob
                       , alias = 'test-prove-' + backend
                       , default = False
-                      , flags = ['--def-module', 'KWASM-LEMMAS']
+                      , flags = '--def-module KWASM-LEMMAS'
                       )
 
 test_simple_java  = test_exec('simple', 'tests/simple/*.wast', wasm_java,  'java')

--- a/build
+++ b/build
@@ -50,6 +50,7 @@ def test_proof(glob, defn, backend):
     return defn.proofs( glob = glob
                       , alias = 'test-prove-' + backend
                       , default = False
+                      , flags = ['--def-module', 'KWASM-LEMMAS']
                       )
 
 test_simple_java  = test_exec('simple', 'tests/simple/*.wast', wasm_java,  'java')

--- a/kwasm
+++ b/kwasm
@@ -94,19 +94,6 @@ view_klab() {
     node --stack-size=$KLAB_NODE_STACK_SIZE $(dirname $(which klab))/../libexec/klab-debug "$klab_log"
 }
 
-    if [[ -f "$test_file.out" ]]; then
-        expected_file="$test_file.out"
-    else
-        expected_file="tests/success-$backend.out"
-    fi
-
-    [[ -f "$expected_file" ]] \
-        || die "Expected output file '$expected_file' does not exist..."
-
-    run_krun "$test_file" > "$output_file" || true
-    pretty_diff "$expected_file" "$output_file"
-}
-
 # Main
 # ----
 
@@ -123,7 +110,6 @@ if [[ "$run_command" == 'help' ]]; then
 
        $0 run   : Run a single WebAssembly program
        $0 kast  : Parse a single WebAssembly program and output it in supported format
-       $0 test  : Run a single WebAssembly program like it's a test
        $0 prove : Run a WebAssembly K proof
        $0 klab-(run|prove) : Run or prove a spec and dump StateLogs which KLab can read
        $0 klab-view : Launch KLab on the StateLog associated with the given program/spec.
@@ -159,7 +145,6 @@ case "$run_command-$backend" in
     run-@(ocaml|java|haskell)  ) run_krun                        "$@" ;;
     kast-@(ocaml|java)         ) run_kast                        "$@" ;;
     prove-@(java|haskell)      ) run_proof                       "$@" ;;
-    test-@(ocaml|java|haskell) ) run_test                        "$@" ;;
     klab-@(run|prove)-java     ) run_klab "${run_command#klab-}" "$@" ;;
     klab-view-java             ) view_klab                       "$@" ;;
     *) $0 help ; fatal "Unknown command on backend: $run_command $backend" ;;

--- a/kwasm
+++ b/kwasm
@@ -130,8 +130,8 @@ fi
 backend="ocaml"
 [[ ! "$run_command" == 'prove' ]] || backend='java'
 [[ ! "$run_command" =~ klab*   ]] || backend='java'
-if [[ $# -gt 0 ]] && [[ $1 == '--backend' ]]; then
-    backend="$2"
+if [[ $# -gt 1 ]] && [[ $1 == '--backend' ]] || [[ $1 == '--definition' ]]; then
+    backend="${2#wasm-}"
     shift 2
 fi
 backend_dir="$defn_dir/$backend"

--- a/kwasm
+++ b/kwasm
@@ -144,7 +144,7 @@ run_file="$curdir/$1" ; shift
 case "$run_command-$backend" in
     run-@(ocaml|java|haskell)  ) run_krun                        "$@" ;;
     kast-@(ocaml|java)         ) run_kast                        "$@" ;;
-    prove-@(java|haskell)      ) run_proof                       "$@" ;;
+    prove-@(java|haskell)      ) run_prove                       "$@" ;;
     klab-@(run|prove)-java     ) run_klab "${run_command#klab-}" "$@" ;;
     klab-view-java             ) view_klab                       "$@" ;;
     *) $0 help ; fatal "Unknown command on backend: $run_command $backend" ;;

--- a/kwasm
+++ b/kwasm
@@ -3,6 +3,9 @@
 set -euo pipefail
 shopt -s extglob
 
+curdir="$(pwd)"
+
+# https://stackoverflow.com/questions/59895/getting-the-source-directory-of-a-bash-script-from-within
 kwasm_script="$0"
 while [[ -h "$kwasm_script" ]]; do
     kwasm_dir="$(cd -P "$(dirname "$kwasm_script")" && pwd)"
@@ -12,90 +15,84 @@ done
 kwasm_dir="$(cd -P "$(dirname "$kwasm_script")" && pwd)"
 
 build_dir="$kwasm_dir/.build"
-release_dir="$build_dir/k/k-distribution/target/release/k"
 defn_dir="$build_dir/defn"
+lib_dir="$build_dir/local/lib"
+
+k_submodule="$kwasm_dir/.build/k"
+release_dir="${K_BIN:-$k_submodule/k-distribution/target/release/k}"
 
 export PATH="$release_dir/lib/native/linux:$release_dir/lib/native/linux64:$release_dir/bin/:$PATH"
+export LD_LIBRARY_PATH="$release_dir/lib/native/linux64:$lib_dir:${LD_LIBRARY_PATH:-}"
 
 test_logs="$build_dir/logs"
-test_log="$test_logs/tests.log"
 mkdir -p "$test_logs"
+test_log="$test_logs/tests.log"
 
-klab_dir="$build_dir/klab"
-klab_node_stack_size="${KLAB_NODE_STACK_SIZE:-30000}"
+KLAB_OUT="${KLAB_OUT:-$build_dir/klab}"
+KLAB_NODE_STACK_SIZE="${KLAB_NODE_STACK_SIZE:-30000}"
+export KLAB_OUT
 
 # Utilities
 # ---------
 
-progress() { echo "== $@" >&2 ; }
-die()      { echo -e "FATAL:" "$@" >&2 ; exit 1 ; }
+notif() { echo "== $@" >&2 ; }
+fatal() { echo "[FATAL] $@" ; exit 1 ; }
 
 pretty_diff() {
-    git --no-pager diff --no-index "$@"
+    git --no-pager diff --no-index --ignore-all-space "$@"
 }
 
 # Runners
 # -------
 
 run_krun() {
-    local run_file
-
-    run_file="$1" ; shift
-
     export K_OPTS=-Xss500m
     krun --directory "$backend_dir" "$run_file" "$@"
 }
 
 run_kast() {
-    local run_file
+    local output_mode
 
-    run_file="$1" ; shift
+    output_mode="${1:-kast}" ; shift
 
-    export K_OPTS=-Xss500m
-    kast --directory "$backend_dir" "$run_file" "$@"
+    case "$run_file-$output_mode" in
+        *-kore) kast --directory "$backend_dir" "$run_file" --kore                  "$@" ;;
+        *)      kast --directory "$backend_dir" "$run_file" --output "$output_mode" "$@" ;;
+    esac
 }
 
-run_proof() {
-    local proof_file
-
-    proof_file="$1" ; shift
-    [[ -f "$proof_file" ]] || die "$proof_file does not exist"
-
+run_prove() {
     export K_OPTS=-Xmx8G
-    kprove --directory "$backend_dir" -m KWASM-LEMMAS "$proof_file" "$@"
+    kprove --directory "$backend_dir" "$run_file" "$@"
 }
 
 run_klab() {
-    local run_mode run_file
+    local run_mode rel_run_file klab_log
 
     run_mode="$1" ; shift
-    run_file="$1" ; shift
+    rel_run_file="${run_file#$curdir}"
+    klab_log="$(basename "${rel_run_file%-spec.k}")"
 
-    $0 "$run_mode" --backend java "$run_file" \
-        --state-log --state-log-path "$klab_dir/data" --state-log-id klab-statelog \
+    "$0" "$run_mode" --backend java "$rel_run_file" \
+        --state-log --state-log-path "$KLAB_OUT/data" --state-log-id "$klab_log" \
         --state-log-events OPEN,EXECINIT,SEARCHINIT,REACHINIT,REACHTARGET,REACHPROVED,NODE,RULE,SRULE,RULEATTEMPT,IMPLICATION,Z3QUERY,Z3RESULT,CLOSE \
         --output-flatten "_Map_ #And" \
         --output-tokenize "listInstr <_>_ i32_WASM-DATA i64_WASM-DATA _:__WASM-DATA" \
         --no-alpha-renaming --restore-original-names --no-sort-collections \
         --output json \
-        "$@" \
-        >/dev/null || true
-
-    export KLAB_OUT="$klab_dir"
-    # klab often runs out of stack space when running long-running KEVM programs
-    # klab debug klab-statelog
-    node --stack-size="$klab_node_stack_size" $(dirname $(which klab))/../libexec/klab-debug klab-statelog
+        "$@"
 }
 
-run_test() {
-    local test_file expected_file output_file
+view_klab() {
+    local rel_run_file
 
-    test_file="$1" ; shift
+    rel_run_file="${run_file#$curdir}"
+    klab_log="$(basename "${rel_run_file%-spec.k}")"
 
-    test_log_name="$test_logs/$test_file"
-    mkdir -p "$(dirname "$test_log_name")"
-
-    output_file="$test_log_name.out"
+    # klab often runs out of stack space when running long-running KEVM programs
+    # klab debug "$klab_log"
+    node --stack-size=$KLAB_NODE_STACK_SIZE $(dirname $(which klab))/../libexec/klab-debug "$klab_log"
+}
 
     if [[ -f "$test_file.out" ]]; then
         expected_file="$test_file.out"
@@ -113,46 +110,57 @@ run_test() {
 # Main
 # ----
 
-cd "$(dirname $0)"
-
-# main functionality
 run_command="$1" ; shift
 
+if [[ "$run_command" == 'help' ]]; then
+    echo "
+    usage: $0 (run|test)       [--backend (ocaml|java|haskell)] <pgm>  <K args>*
+           $0 kast             [--backend (ocaml|java)]         <pgm>  <K args>*
+           $0 prove            [--backend (java|haskell)]       <spec> <K args>* -m <def_module>
+           $0 klab-run                                          <pgm>  <K arg>*
+           $0 klab-prove                                        <spec> <K arg>* -m <def_module>
+           $0 klab-view                                         [<pgm>|<spec>]
+
+       $0 run   : Run a single WebAssembly program
+       $0 kast  : Parse a single WebAssembly program and output it in supported format
+       $0 test  : Run a single WebAssembly program like it's a test
+       $0 prove : Run a WebAssembly K proof
+       $0 klab-(run|prove) : Run or prove a spec and dump StateLogs which KLab can read
+       $0 klab-view : Launch KLab on the StateLog associated with the given program/spec.
+
+           $0 klab-(run|prove) : Run program or prove spec and dump StateLogs which KLab can read
+
+       Note: <pgm> is a path to a file containing a WebAssembly program.
+             <spec> is a K specification to be proved.
+             <K args> are any arguments you want to pass to K when executing/proving.
+             <output format> is the format for Kast to output the term in.
+             <def_module> is the module to take as axioms when doing verification.
+
+       KLab: Make sure that the 'klab/bin' directory is on your PATH to use this option.
+"
+    exit 0
+fi
+
 backend="ocaml"
-[[ ! "$run_command" == prove ]] || backend='java'
-[[ ! "$run_command" =~ klab* ]] || backend='java'
+[[ ! "$run_command" == 'prove' ]] || backend='java'
+[[ ! "$run_command" =~ klab*   ]] || backend='java'
 if [[ $# -gt 0 ]] && [[ $1 == '--backend' ]]; then
     backend="$2"
     shift 2
 fi
-backend_dir="$defn_dir/$backend"
+backend_dir="$build_dir/$backend"
 [[ ! "$backend" == "ocaml" ]] || eval $(opam config env)
 
-case "$run_command-$backend" in
+# get the run file
+run_file="$curdir/$1" ; shift
+[[ -f "$run_file" ]] || fatal "File does not exist: $run_file"
 
-    # Running
+case "$run_command-$backend" in
     run-@(ocaml|java|haskell)  ) run_krun                        "$@" ;;
     kast-@(ocaml|java)         ) run_kast                        "$@" ;;
     prove-@(java|haskell)      ) run_proof                       "$@" ;;
     test-@(ocaml|java|haskell) ) run_test                        "$@" ;;
     klab-@(run|prove)-java     ) run_klab "${run_command#klab-}" "$@" ;;
-
-    *) echo "
-    usage: $0 (run|test)       [--backend (ocaml|java|haskell)] <pgm>  <K args>*
-           $0 kast             [--backend (ocaml|java)]         <pgm>  <K args>*
-           $0 prove            [--backend (java|haskell)]       <spec> <K args>*
-           $0 klab-(run|prove)                                  <spec> <K args>*
-
-       $0 run   : Run a single WebAssembly program
-       $0 kast  : Parse a single WebAssembly program
-       $0 test  : Run a single WebAssembly program like it's a test
-       $0 prove : Run a WebAssembly K proof
-       $0 klab-(run|prove) : Run or prove a spec and launch KLab on the execution graph.
-
-       Note: <pgm> is a path to a file containing a WebAssembly program.
-             <spec> is a K specification to be proved.
-             <K args> are any arguments you want to pass to K when executing/proving.
-
-       KLab: Make sure that the 'klab/bin' directory is on your PATH to use this option.
-" ; exit ;;
+    klab-view-java             ) view_klab                       "$@" ;;
+    *) $0 help ; fatal "Unknown command on backend: $run_command $backend" ;;
 esac

--- a/kwasm
+++ b/kwasm
@@ -101,8 +101,8 @@ run_command="$1" ; shift
 
 if [[ "$run_command" == 'help' ]]; then
     echo "
-    usage: $0 (run|test)       [--backend (ocaml|java|haskell)] <pgm>  <K args>*
-           $0 kast             [--backend (ocaml|java)]         <pgm>  <K args>*
+    usage: $0 run              [--backend (ocaml|java|haskell)] <pgm>  <K args>*
+           $0 kast             [--backend (ocaml|java)]         <pgm>  <output format> <K args>*
            $0 prove            [--backend (java|haskell)]       <spec> <K args>* -m <def_module>
            $0 klab-run                                          <pgm>  <K arg>*
            $0 klab-prove                                        <spec> <K arg>* -m <def_module>
@@ -114,13 +114,11 @@ if [[ "$run_command" == 'help' ]]; then
        $0 klab-(run|prove) : Run or prove a spec and dump StateLogs which KLab can read
        $0 klab-view : Launch KLab on the StateLog associated with the given program/spec.
 
-           $0 klab-(run|prove) : Run program or prove spec and dump StateLogs which KLab can read
-
        Note: <pgm> is a path to a file containing a WebAssembly program.
              <spec> is a K specification to be proved.
              <K args> are any arguments you want to pass to K when executing/proving.
              <output format> is the format for Kast to output the term in.
-             <def_module> is the module to take as axioms when doing verification.
+             <def_module> is the module to take as axioms for verification.
 
        KLab: Make sure that the 'klab/bin' directory is on your PATH to use this option.
 "

--- a/kwasm
+++ b/kwasm
@@ -134,7 +134,7 @@ if [[ $# -gt 0 ]] && [[ $1 == '--backend' ]]; then
     backend="$2"
     shift 2
 fi
-backend_dir="$build_dir/$backend"
+backend_dir="$defn_dir/$backend"
 [[ ! "$backend" == "ocaml" ]] || eval $(opam config env)
 
 # get the run file

--- a/wasm.md
+++ b/wasm.md
@@ -89,7 +89,7 @@ WebAssembly instructions are space-separated lists of instructions.
  // -----------------------------------------------------
     rule          <k> .Instrs           => .       ... </k>
     rule          <k> I:Instr .Instrs   => I       ... </k>
-    rule [step] : <k> I:Instr IS:Instrs => I ~> IS ... </k> requires IS =/=K .List
+    rule [step] : <k> I:Instr IS:Instrs => I ~> IS ... </k> requires IS =/=K .Instrs
 ```
 
 ### Traps


### PR DESCRIPTION
-   Separate out the step which actually launches KLab from `./kwasm klab-(run|prove)` into new command `./kwasm klab-view`, which allows asynchronously calling them.
-   Use the filename of the spec/program being proved to decide `--state-log-id`, so that many proofs can be run/viewed at once using KLab without overwriting each others results.
-   Add test `test-klab-prove` to make sure that `./kwasm klab-prove` isn't accidentally borked.
-   All testing is handled directly by `Makefile`, instead of relying on `./kwasm test`.
-   Eliminate an unneeded source of branching in the semantics due to bug in rule.