### PR TITLE
Bugfix: implement correct branching and label semantics

### DIFF
--- a/tests/proofs/simple-arithmetic-spec.k
+++ b/tests/proofs/simple-arithmetic-spec.k
@@ -34,6 +34,7 @@ module SIMPLE-ARITHMETIC-SPEC
                      (local.tee 0)
                      (i32.eqz)
                      (br_if 1)
+                     (br 0)
                  )
              end
           => .

--- a/tests/simple/control-flow.wast
+++ b/tests/simple/control-flow.wast
@@ -165,19 +165,16 @@ end
 ;; Looping
 
 init_locals < i32 > 10 : < i32 > 0 : .ValStack
-block [ ]
-    loop [ ]
-        (local.get 0)
-        (local.get 1)
-        (i32.add)
-        (local.set 1)
-        (local.get 0)
-        (i32.const 1)
-        (i32.sub)
-        (local.tee 0)
-        (i32.eqz)
-        (br_if 1)
-    end
+loop [ ]
+    (local.get 0)
+    (local.get 1)
+    (i32.add)
+    (local.set 1)
+    (local.get 0)
+    (i32.const 1)
+    (i32.sub)
+    (local.tee 0)
+    (br_if 0)
 end
 #assertLocal 0 < i32 > 0  "sum 1 -> 10 loop"
 #assertLocal 1 < i32 > 55 "sum 1 -> 10 loop"
@@ -195,6 +192,7 @@ block [ ]
         (local.tee 0)
         (i32.eqz)
         (br_if 1)
+        (br 0)
     )
 end
 #assertLocal 0 < i32 > 0  "sum 1 -> 10 loop concrete syntax"

--- a/wasm.md
+++ b/wasm.md
@@ -487,8 +487,12 @@ Note that, unlike in the WebAssembly specification document, we do not need the 
 
     syntax Instr ::= "(" "br_if" Int ")"
  // ------------------------------------
-    rule <k> ( br_if N ) => #if VAL =/=Int 0 #then ( br N ) #else .K #fi ... </k>
+    rule <k> ( br_if N ) => ( br N ) ... </k>
          <valstack> < TYPE > VAL : VALSTACK => VALSTACK </valstack>
+         requires VAL =/=Int 0
+    rule <k> ( br_if N ) => . ... </k>
+         <valstack> < TYPE > VAL : VALSTACK => VALSTACK </valstack>
+         requires VAL  ==Int 0
 ```
 
 Finally, we have the conditional and loop instructions.

--- a/wasm.md
+++ b/wasm.md
@@ -455,7 +455,7 @@ It simply executes the block then records a label with an empty continuation.
 ```k
     syntax Label ::= "label" VecType "{" Instrs "}" ValStack
  // --------------------------------------------------------
-    rule <k> label [ TYPES ] { IS } VALSTACK' => IS ... </k>
+    rule <k> label [ TYPES ] { _ } VALSTACK' => . ... </k>
          <valstack> VALSTACK => #take(TYPES, VALSTACK) ++ VALSTACK' </valstack>
 
     syntax Instr ::= "(" "block" FuncDecls Instrs ")"
@@ -479,7 +479,11 @@ Note that, unlike in the WebAssembly specification document, we do not need the 
     syntax Instr ::= "(" "br" Int ")"
  // ---------------------------------
     rule <k> ( br N ) ~> (IS:Instrs => .) ... </k>
-    rule <k> ( br N ) ~> L:Label => #if N ==Int 0 #then L #else ( br N -Int 1 ) #fi ... </k>
+    rule <k> ( br N ) ~> label [ TYPES ] { IS } VALSTACK' => IS ... </k>
+         <valstack> VALSTACK => #take(TYPES, VALSTACK) ++ VALSTACK' </valstack>
+      requires N ==Int 0
+    rule <k> ( br N ) ~> L:Label => ( br N -Int 1 ) ... </k>
+      requires N >Int 0
 
     syntax Instr ::= "(" "br_if" Int ")"
  // ------------------------------------


### PR DESCRIPTION
Fixes #79 

Previously, we always grabbed the continuation whenever we encountered a
label. However, the correct semantics is that you grab the continuation
when *branching* to a label. When it is encountered without a branch,
it's discarded.

The correct way to write an infinite loop in wasm is

```
loop
  (nop) ;; or whatever
  (br 0)
end
```

but before this fix, the following was also an infinite loop

```
loop
  (nop) ;; or whatever
end
```