### PR TITLE
Categorizing declarations for a better program structure

### DIFF
--- a/test.md
+++ b/test.md
@@ -16,17 +16,18 @@ Assertions
 These assertions will check the supplied property, and then clear that state from the configuration.
 In this way, tests can be written as a serious of setup, execute, assert cycles which leaves the configuration empty on success.
 
-We'll make `Assertion` a subsort of `Instr`, so that we can easily consume `Instr` with `trap`s, but not consume `Assertion`s.
+We'll make `Assertion` a subsort of `Auxil`, so that we can easily consume `Instr` with `trap`s, but not consume `Assertion`s.
 This will allow `trap` to "bubble up" (more correctly, to "consume the continuation") until it reaches its paired `#assertTrap_` statement.
 
 ```k
-    syntax Instr ::= Assertion
+    syntax Decl  ::= Auxil
+    syntax Auxil ::= Assertion
  // --------------------------
     rule <k> trap ~> (L:Label => .) ... </k>
     rule <k> trap ~> (.Instrs => .) ... </k>
-    rule <k> trap ~> (I:Instr => .) ... </k> requires notBool isAssertion(I)
+    rule <k> trap ~> (I:Instr => .) ... </k>
 
-    rule <k> trap ~> (I:Instr IS:Instrs => I ~> IS) ... </k>
+    rule <k> trap ~> (D:Decl DS:Decls => D ~> DS) ... </k>
 ```
 
 ### Trap Assertion
@@ -86,7 +87,7 @@ The operator `#assertLocal`/`#assertGlobal` operators perform a check for a loca
 `init_global` is a helper function that helps us to declare a new global variable.
 
 ```k
-    syntax Instr ::= "init_global" Int Int
+    syntax Auxil ::= "init_global" Int Int
  // --------------------------------------
     rule <k> init_global INDEX GADDR => . ... </k>
          <globalIndices> GADDRS => GADDRS [ INDEX <- GADDR ] </globalIndices>
@@ -216,7 +217,7 @@ Clear Module Instances
 The modules are cleaned all together after the test file is executed.
 
 ```k
-    syntax Instr ::= "#clearModules"
+    syntax Auxil ::= "#clearModules"
  // --------------------------------
     rule <k> #clearModules => . ... </k>
          <nextFreshId> _ => 0 </nextFreshId>
@@ -241,7 +242,7 @@ Function Invocation
 We allow to `invoke` a function by its exported name in the test code.
 
 ```k
-    syntax Instr ::= "(" "invoke" String ")"
+    syntax Auxil ::= "(" "invoke" String ")"
  // ----------------------------------------
     rule <k> ( invoke ENAME:String ) => ( call TFIDX ) ... </k>
          <exports> ... ENAME |-> TFIDX ... </exports>

--- a/test.md
+++ b/test.md
@@ -10,6 +10,16 @@ module WASM-TEST
     imports WASM
 ```
 
+Auxiliary
+---------
+
+Here we extend the sort `Stmt` by adding a new subsort called `Auxil`.
+This subsort contains Auxiliary functions that only used in our KWASM semantics but not in the official specification including assertions, initializing a global variable and the invocation of a function by exported name.
+
+```k
+    syntax Stmt ::= Auxil
+```
+
 Assertions
 ----------
 
@@ -20,14 +30,13 @@ We'll make `Assertion` a subsort of `Auxil`, so that we can easily consume `Inst
 This will allow `trap` to "bubble up" (more correctly, to "consume the continuation") until it reaches its paired `#assertTrap_` statement.
 
 ```k
-    syntax Decl  ::= Auxil
     syntax Auxil ::= Assertion
  // --------------------------
     rule <k> trap ~> (L:Label => .) ... </k>
     rule <k> trap ~> (.Instrs => .) ... </k>
     rule <k> trap ~> (I:Instr => .) ... </k>
 
-    rule <k> trap ~> (D:Decl DS:Decls => D ~> DS) ... </k>
+    rule <k> trap ~> (S:Stmt SS:Stmts => S ~> SS) ... </k>
 ```
 
 ### Trap Assertion

--- a/test.md
+++ b/test.md
@@ -32,10 +32,10 @@ This will allow `trap` to "bubble up" (more correctly, to "consume the continuat
 ```k
     syntax Auxil ::= Assertion
  // --------------------------
-    rule <k> trap ~> (L:Label => .) ... </k>
-    rule <k> trap ~> (F:Frame => .) ... </k>
-    rule <k> trap ~> (.Instrs => .) ... </k>
-    rule <k> trap ~> (I:Instr => .) ... </k>
+    rule <k> trap ~> (L:Label   => .) ... </k>
+    rule <k> trap ~> (F:Frame   => .) ... </k>
+    rule <k> trap ~> (I:Instr   => .) ... </k>
+    rule <k> trap ~> (IS:Instrs => .) ... </k>
 
     rule <k> trap ~> (S:Stmt SS:Stmts => S ~> SS) ... </k>
 ```

--- a/wasm.md
+++ b/wasm.md
@@ -99,8 +99,8 @@ In this file we define 3 types of statements:
     syntax Stmt   ::= Instr | Defn 
     syntax Instrs ::= List{Instr, ""}
     syntax Defns  ::= List{Defn , ""}
-    syntax Stmts  ::= List{Stmt , ""}
- // ---------------------------------
+    syntax Stmts  ::= List{Stmt , ""} [klabel(listStmt)]
+ // ----------------------------------------------------
     rule          <k> .Stmts     :Stmts  => .       ... </k>
     rule          <k> (S .Stmts) :Stmts  => S       ... </k>
     rule [step] : <k> (S SS)     :Stmts  => S ~> SS ... </k> requires SS =/=K .Stmts
@@ -504,7 +504,7 @@ Note that, unlike in the WebAssembly specification document, we do not need the 
 ```k
     syntax Instr ::= "(" "br" Int ")"
  // ---------------------------------
-    rule <k> ( br N ) ~> (IS:Instrs => .) ... </k>
+    rule <k> ( br N ) ~> (SS:Stmts => .) ... </k>
     rule <k> ( br N ) ~> label [ TYPES ] { IS } VALSTACK' => IS ... </k>
          <valstack> VALSTACK => #take(TYPES, VALSTACK) ++ VALSTACK' </valstack>
       requires N ==Int 0
@@ -820,8 +820,8 @@ Unlike labels, only one frame can be "broken" through at a time.
 
     syntax Instr ::= "(" "return" ")"
  // ---------------------------------
-    rule <k> (return) ~> (IS:Instrs => .)  ... </k>
-    rule <k> (return) ~> (L:Label   => .)  ... </k>
+    rule <k> (return) ~> (SS:Stmts => .)  ... </k>
+    rule <k> (return) ~> (L:Label  => .)  ... </k>
     rule <k> ((return) => .) ~> FR:Frame ... </k>
 ```
 

--- a/wasm.md
+++ b/wasm.md
@@ -90,9 +90,10 @@ Instructions
 
 WebAssembly code consists of sequences of statements (`Stmts`).
 In this file we define 3 types of statements:
-  - Instruction (`Instr`): Administrative or computational instructions. 
-  - Definitions (`Defn`) : The declarations of `type`, `func`, `table`, `mem` etc.
-  - The Declaration of a module.
+
+-   Instruction (`Instr`): Administrative or computational instructions. 
+-   Definitions (`Defn`) : The declarations of `type`, `func`, `table`, `mem` etc.
+-   The Declaration of a module.
 
 ```k
     syntax Stmt   ::= Instr | Defn 


### PR DESCRIPTION
Now we define 4 types of `statements` instead of considering everything as `instruction`:
  - Instruction (`Instr`): Administrative or computational instructions. 
  - Definition  (`Defn`): The declarations of `type`, `func`, `table`, `mem` etc.
  - Auxiliary   (`Auxil`): Functions that only used in our KWASM semantics but not in the official specification including assertions, invoke a function by imported name, and maybe instantiate a module?
  - The Declaration of a module.