### PR TITLE
Memory bugfixes

### DIFF
--- a/data.md
+++ b/data.md
@@ -183,11 +183,11 @@ Some operations extend integers from 1, 2, or 4 bytes, so a special function wit
     rule #unsigned(ITYPE, N) => N +Int #pow(ITYPE) requires N  <Int 0
     rule #unsigned(ITYPE, N) => N                  requires 0 <=Int N
 
-    rule #signedWidth(8,  N) => N            requires 0     <=Int N andBool N <Int 128
-    rule #signedWidth(8,  N) => N -Int 256   requires 128   <=Int N andBool N <Int 256
-    rule #signedWidth(16, N) => N            requires 0     <=Int N andBool N <Int 32768
-    rule #signedWidth(16, N) => N -Int 65536 requires 32768 <=Int N andBool N <Int 65536
-    rule #signedWidth(32, N) => #signed(i32, N)
+    rule #signedWidth(1,  N) => N            requires 0     <=Int N andBool N <Int 128
+    rule #signedWidth(1,  N) => N -Int 256   requires 128   <=Int N andBool N <Int 256
+    rule #signedWidth(2, N) => N            requires 0     <=Int N andBool N <Int 32768
+    rule #signedWidth(2, N) => N -Int 65536 requires 32768 <=Int N andBool N <Int 65536
+    rule #signedWidth(4, N) => #signed(i32, N)
 ```
 
 ### Boolean Interpretation

--- a/data.md
+++ b/data.md
@@ -183,8 +183,8 @@ Some operations extend integers from 1, 2, or 4 bytes, so a special function wit
     rule #unsigned(ITYPE, N) => N +Int #pow(ITYPE) requires N  <Int 0
     rule #unsigned(ITYPE, N) => N                  requires 0 <=Int N
 
-    rule #signedWidth(1,  N) => N            requires 0     <=Int N andBool N <Int 128
-    rule #signedWidth(1,  N) => N -Int 256   requires 128   <=Int N andBool N <Int 256
+    rule #signedWidth(1, N) => N            requires 0     <=Int N andBool N <Int 128
+    rule #signedWidth(1, N) => N -Int 256   requires 128   <=Int N andBool N <Int 256
     rule #signedWidth(2, N) => N            requires 0     <=Int N andBool N <Int 32768
     rule #signedWidth(2, N) => N -Int 65536 requires 32768 <=Int N andBool N <Int 65536
     rule #signedWidth(4, N) => #signed(i32, N)
@@ -299,7 +299,7 @@ The function interprets the range of bytes as little-endian.
     rule #lookup(               M, KEY ) => 0 requires notBool KEY in_keys(M) [concrete]
 ```
 
-`#clearRange(MAP, START, END)` removes all entries from the map from `START` to `END`, exclusive.
+`#clearRange(MAP, START, END)` removes all entries in the map from `START` (inclusive) to `END` (exclusive).
 
 ```k
     syntax Map ::= #clearRange(Map, Int, Int) [function]

--- a/data.md
+++ b/data.md
@@ -299,7 +299,7 @@ The function interprets the range of bytes as little-endian.
     rule #lookup(               M, KEY ) => 0 requires notBool KEY in_keys(M) [concrete]
 ```
 
-`#clearRange(MAP, START, END)` removes all entries from the map from `START` to `END`, inclusive.
+`#clearRange(MAP, START, END)` removes all entries from the map from `START` to `END`, exclusive.
 
 ```k
     syntax Map ::= #clearRange(Map, Int, Int) [function]

--- a/tests/simple/memory.wast
+++ b/tests/simple/memory.wast
@@ -108,4 +108,13 @@
 (i32.store8  (i32.const 2) (i32.const 0))
 #assertEmptyMemory 1 .MaxBound "Zero updates erases memory"
 
+(memory 1)
+(i64.store (i32.const 1) (i64.const #pow(i64) -Int 1))
+(i32.store8 (i32.const 2) (i32.const 0))
+(i32.store (i32.const 4) (i32.const 0))
+#assertMemoryData (1, 255) ""
+#assertMemoryData (3, 255) ""
+#assertMemoryData (8, 255) ""
+#assertEmptyMemory 1 .MaxBound "Zero updates don't over-erase"
+
 #clearModules

--- a/wasm.md
+++ b/wasm.md
@@ -944,7 +944,7 @@ The value is encoded as bytes and stored at the "effective address", which is th
            <mdata>   DATA => #clearRange(DATA, EA, EA +Int WIDTH -Int 1) [EA := VAL ] </mdata>
            ...
          </memInst>
-         requires (EA +Int WIDTH /Int 8) <=Int (SIZE *Int #pageSize())
+         requires (EA +Int WIDTH) <=Int (SIZE *Int #pageSize())
 
     rule <k> store { WIDTH  EA  _ } => trap ... </k>
          <memIndices> 0 |-> ADDR </memIndices>
@@ -953,14 +953,14 @@ The value is encoded as bytes and stored at the "effective address", which is th
            <msize>   SIZE </msize>
            ...
          </memInst>
-         requires (EA +Int WIDTH /Int 8) >Int (SIZE *Int #pageSize())
+         requires (EA +Int WIDTH) >Int (SIZE *Int #pageSize())
 
     syntax StoreOp ::= "store" | "store8" | "store16" | "store32"
  // -------------------------------------------------------------
     rule <k> ITYPE . store   EA VAL => store { #numBytes(ITYPE) EA VAL            } ... </k>
-    rule <k> _     . store8  EA VAL => store { 8                EA #wrap(8,  VAL) } ... </k>
-    rule <k> _     . store16 EA VAL => store { 16               EA #wrap(16, VAL) } ... </k>
-    rule <k> i64   . store32 EA VAL => store { 32               EA #wrap(32, VAL) } ... </k>
+    rule <k> _     . store8  EA VAL => store { 1                EA #wrap(8,  VAL) } ... </k>
+    rule <k> _     . store16 EA VAL => store { 2                EA #wrap(16, VAL) } ... </k>
+    rule <k> i64   . store32 EA VAL => store { 4                EA #wrap(32, VAL) } ... </k>
 ```
 
 The assorted load operations take an address of type `i32`.
@@ -984,8 +984,8 @@ The value is fethced from the "effective address", which is the address given on
 
     rule <k> load { ITYPE WIDTH EA SIGN }
           => < ITYPE > #if SIGN ==K Signed
-                           #then #signedWidth(WIDTH, #range(DATA, EA, WIDTH /Int 8))
-                           #else #range(DATA, EA, WIDTH /Int 8)
+                           #then #signedWidth(WIDTH, #range(DATA, EA, WIDTH))
+                           #else #range(DATA, EA, WIDTH)
                        #fi
          ...
          </k>
@@ -996,7 +996,7 @@ The value is fethced from the "effective address", which is the address given on
            <mdata>   DATA </mdata>
            ...
          </memInst>
-      requires (EA +Int WIDTH /Int 8) <=Int (SIZE *Int #pageSize())
+      requires (EA +Int WIDTH) <=Int (SIZE *Int #pageSize())
 
     rule <k> load { _ WIDTH EA _ } => trap ... </k>
          <memIndices> 0 |-> ADDR </memIndices>
@@ -1005,19 +1005,19 @@ The value is fethced from the "effective address", which is the address given on
            <msize>   SIZE </msize>
            ...
          </memInst>
-      requires (EA +Int WIDTH /Int 8) >Int (SIZE *Int #pageSize())
+      requires (EA +Int WIDTH) >Int (SIZE *Int #pageSize())
 
     syntax LoadOp ::= "load"
                     | "load8_u" | "load16_u" | "load32_u"
                     | "load8_s" | "load16_s" | "load32_s"
  // -----------------------------------------------------
     rule <k> ITYPE . load     EA:Int => load { ITYPE #numBytes(ITYPE) EA Unsigned } ... </k>
-    rule <k> ITYPE . load8_u  EA:Int => load { ITYPE 8                EA Unsigned } ... </k>
-    rule <k> ITYPE . load16_u EA:Int => load { ITYPE 16               EA Unsigned } ... </k>
-    rule <k> i64   . load32_u EA:Int => load { i64   32               EA Unsigned } ... </k>
-    rule <k> ITYPE . load8_s  EA:Int => load { ITYPE 8                EA Signed   } ... </k>
-    rule <k> ITYPE . load16_s EA:Int => load { ITYPE 16               EA Signed   } ... </k>
-    rule <k> i64   . load32_s EA:Int => load { i64   32               EA Signed   } ... </k>
+    rule <k> ITYPE . load8_u  EA:Int => load { ITYPE 1                EA Unsigned } ... </k>
+    rule <k> ITYPE . load16_u EA:Int => load { ITYPE 2                EA Unsigned } ... </k>
+    rule <k> i64   . load32_u EA:Int => load { i64   4                EA Unsigned } ... </k>
+    rule <k> ITYPE . load8_s  EA:Int => load { ITYPE 1                EA Signed   } ... </k>
+    rule <k> ITYPE . load16_s EA:Int => load { ITYPE 2                EA Signed   } ... </k>
+    rule <k> i64   . load32_s EA:Int => load { i64   4                EA Signed   } ... </k>
 ```
 
 `MemArg`s can optionally be passed to `load` and `store` operations.

--- a/wasm.md
+++ b/wasm.md
@@ -941,7 +941,7 @@ The value is encoded as bytes and stored at the "effective address", which is th
          <memInst>
            <mAddr>   ADDR </mAddr>
            <msize>   SIZE </msize>
-           <mdata>   DATA => #clearRange(DATA, EA, EA +Int WIDTH -Int 1) [EA := VAL ] </mdata>
+           <mdata>   DATA => #clearRange(DATA, EA, EA +Int WIDTH) [EA := VAL ] </mdata>
            ...
          </memInst>
          requires (EA +Int WIDTH) <=Int (SIZE *Int #pageSize())
@@ -1137,7 +1137,7 @@ The `data` initializer simply puts these bytes into the specified memory, starti
          <memInst>
            <mAddr> ADDR </mAddr>
            <mdata>   DATA
-                  => #clearRange(DATA, OFFSET, OFFSET +Int #dataStringsLength(STRING) -Int 1) [ OFFSET := #dataStrings2int(STRING)]
+                  => #clearRange(DATA, OFFSET, OFFSET +Int #dataStringsLength(STRING)) [ OFFSET := #dataStrings2int(STRING)]
            </mdata>
            ...
          </memInst>

--- a/wasm.md
+++ b/wasm.md
@@ -965,7 +965,7 @@ The value is encoded as bytes and stored at the "effective address", which is th
 
 The assorted load operations take an address of type `i32`.
 The `loadX_sx` operations loads `X` bits from memory, and extend it to the right length for the return value, interpreting the bytes as either signed or unsigned according to `sx`.
-The value is fethced from the "effective address", which is the address given on the stack plus offset.
+The value is fetched from the "effective address", which is the address given on the stack plus offset.
 
 ```k
     syntax Instr ::= "(" IValType  "." LoadOpM Instr ")" | "(" IValType  "." LoadOpM ")"


### PR DESCRIPTION
There was confusion as to whether `WIDTH` was bit or byte width, and `#clearRange` was called incorrectly. This slipped through because the test only checked memory was cleared in the end, but with `WIDTH` being to large it hid the `#clearRange` bug.