### PR TITLE
Disambiguate Stmts/Instrs in proof

### DIFF
--- a/tests/proofs/simple-arithmetic-spec.k
+++ b/tests/proofs/simple-arithmetic-spec.k
@@ -4,20 +4,20 @@ module SIMPLE-ARITHMETIC-SPEC
     imports WASM
     imports KWASM-LEMMAS
 
-    rule <k> ( ITYPE:IValType . const X:Int ) => . ... </k>
+    rule <k> ( ITYPE:IValType . const X:Int ):Stmt => . ... </k>
          <valstack> S:ValStack => < ITYPE > X : S </valstack>
       requires #inUnsignedRange(ITYPE, X)
 
-    rule <k> ( ITYPE:IValType . const X:Int ) => . ... </k>
+    rule <k> ( ITYPE:IValType . const X:Int ):Stmt => . ... </k>
          <valstack> S:ValStack => < ITYPE > (X +Int #pow(ITYPE)) : S </valstack>
       requires (#minSigned(ITYPE) <=Int X) andBool (X <Int 0)
 
-    rule <k> ( ITYPE:IValType . const X:Int ) ( ITYPE . const Y:Int ) => . ... </k>
+    rule <k> ( ITYPE:IValType . const X:Int ):Stmt ( ITYPE . const Y:Int ) => . ... </k>
          <valstack> S:ValStack => < ITYPE > Y : < ITYPE > X : S </valstack>
       requires #inUnsignedRange(ITYPE, X)
        andBool #inUnsignedRange(ITYPE, Y)
 
-    rule <k> ( ITYPE:IValType . const X:Int ) ( ITYPE . const Y:Int ) ( ITYPE . add ) => . ... </k>
+    rule <k> ( ITYPE:IValType . const X:Int ):Stmt ( ITYPE . const Y:Int ) ( ITYPE . add ) => . ... </k>
          <valstack> S:ValStack => < ITYPE > (X +Int Y) : S </valstack>
       requires 0 <=Int X andBool 0 <=Int Y
        andBool (X +Int Y) <Int #pow(ITYPE)


### PR DESCRIPTION
I'm getting warnings about parser ambiguity from `simple-arithmetic-spec.k`. This fixes it. Slightly annoying to have to do, but I guess it's worth it for the separation of sorts.