### PR TITLE
Registering modules

### DIFF
--- a/test.md
+++ b/test.md
@@ -265,13 +265,15 @@ These assertions act on the last module defined.
 
 ```k
     syntax Assertion ::= "#assertUnnamedModule"
+    syntax Assertion ::= "#assertUnnamedModuleAux" Int
     syntax Assertion ::= "#assertNamedModule" Identifier
  // ----------------------------------------------------
-    rule <k> #assertUnnamedModule => . ... </k>
+    rule <k> #assertUnnamedModule => #assertUnnamedModuleAux NEXT ... </k>
          <nextModuleIdx> NEXT => NEXT -Int 1 </nextModuleIdx>
+    rule <k> #assertUnnamedModuleAux IDX => . ... </k>
          <moduleInstances>
            ( <moduleInst>
-               <modIdx> NEXT -Int 1 </modIdx>
+               <modIdx> IDX </modIdx>
                ...
              </moduleInst>
           => .Bag

--- a/test.md
+++ b/test.md
@@ -50,7 +50,7 @@ We will reference modules by name in imports.
  // --------------------------------------------------------
     rule <k> ( register S ) => ( register S (NEXT -Int 1) )... </k> // Register last instantiated module.
          <nextModuleIdx> NEXT </nextModuleIdx>
-         requires NEXT >Int 0
+      requires NEXT >Int 0
     rule <k> ( register S ID:Identifier ) => ( register S IDX ) ... </k>
          <moduleIds> ... ID |-> IDX ... </moduleIds>
     rule <k> ( register S:String IDX:Int ) => . ... </k>

--- a/test.md
+++ b/test.md
@@ -244,6 +244,10 @@ The modules are cleaned all together after the test file is executed.
            <globalIndices> _ => .Map </globalIndices>
            <exports>       _ => .Map </exports>
          </moduleInst>
+         <moduleIds> _ => .Map </moduleIds>
+         <nextModuleIdx> _ => 0 </nextModuleIdx>
+         <moduleInstances> _ => .Map </moduleInstances>
+         <moduleRegistry> _ => .Map </moduleRegistry>
 ```
 
 Official Test Assertions
@@ -265,6 +269,17 @@ We allow to `invoke` a function by its exported name in the test code.
 
 ### Registering Modules
 
+We first define how modules get stored away.
+
+```k
+    rule <k> #storeInstance => . ... </k>
+         <moduleInst> INST </moduleInst>
+         <nextModuleIdx> NEXT => NEXT +Int 1 </nextModuleIdx>
+         <moduleInstances> ... .Map => NEXT |-> INST ... </moduleInstances>
+```
+
+We will reference modules by name in imports.
+`register` is the instruction that allows us to associate a name with a module.
 
 ```k
     syntax Assertion ::= "(" "register" String            ")"

--- a/test.md
+++ b/test.md
@@ -246,8 +246,13 @@ The modules are cleaned all together after the test file is executed.
          </moduleInst>
 ```
 
-Function Invocation
--------------------
+Official Test Assertions
+------------------------
+
+The official test suite contains some special auxillary instructions outside of the standard Wasm semantics.
+The reference interpreter is a particular embedder with auxillary instructions, specified in [spec interpreter](https://github.com/WebAssembly/spec/blob/master/interpreter/README.md).
+
+### Function Invocation
 
 We allow to `invoke` a function by its exported name in the test code.
 
@@ -256,6 +261,24 @@ We allow to `invoke` a function by its exported name in the test code.
  // ----------------------------------------
     rule <k> ( invoke ENAME:String ) => ( call TFIDX ) ... </k>
          <exports> ... ENAME |-> TFIDX ... </exports>
+```
+
+### Registering Modules
+
+
+```k
+    syntax Assertion ::= "(" "register" String            ")"
+                       | "(" "register" String Identifier ")"
+                       |     "register" String Int
+ // ----------------------------------------------
+    rule <k> ( register S ) => register S (NEXT -Int 1) ... </k> // Register last module.
+         <nextModuleIdx> NEXT </nextModuleIdx>
+         requires NEXT >Int 0
+    rule <k> ( register S ID:Identifier ) => register S IDX ... </k>
+         <moduleIds> ... ID |-> IDX ... </moduleIds>
+    rule <k> register S:String IDX:Int => . ... </k>
+         <moduleInstances> ... IDX |-> INST ... </moduleInstances>
+         <moduleRegistry> ... .Map => S |-> INST ... </moduleRegistry>
 ```
 
 ```k

--- a/test.md
+++ b/test.md
@@ -118,7 +118,12 @@ The operator `#assertLocal`/`#assertGlobal` operators perform a check for a loca
          <locals> ... (INDEX |-> VALUE => .Map) ... </locals>
 
     rule <k> #assertGlobal INDEX VALUE _ => . ... </k>
-         <globalIndices> ... INDEX |-> GADDR ... </globalIndices>
+         <curModIdx> CUR </curModIdx>
+         <moduleInst>
+           <modIdx> CUR </modIdx>
+           <globalIndices> ... INDEX |-> GADDR ... </globalIndices>
+           ...
+         </moduleInst>
          <globals>
            ( <globalInst>
                <gAddr>  GADDR </gAddr>
@@ -137,7 +142,12 @@ The operator `#assertLocal`/`#assertGlobal` operators perform a check for a loca
     syntax Auxil ::= "init_global" Int Int
  // --------------------------------------
     rule <k> init_global INDEX GADDR => . ... </k>
-         <globalIndices> GADDRS => GADDRS [ INDEX <- GADDR ] </globalIndices>
+         <curModIdx> CUR </curModIdx>
+         <moduleInst>
+           <modIdx> CUR </modIdx>
+           <globalIndices> GADDRS => GADDRS [ INDEX <- GADDR ] </globalIndices>
+           ...
+         </moduleInst>
          <globals>
            ( .Bag =>
              <globalInst>
@@ -159,10 +169,20 @@ The operator `#assertLocal`/`#assertGlobal` operators perform a check for a loca
                        | "#assertNextTypeIdx" Int
  // ---------------------------------------------
     rule <k> #assertType TFIDX FTYPE => . ... </k>
-         <typeIds> IDS </typeIds>
-         <types> ... #ContextLookup(IDS , TFIDX) |-> FTYPE ... </types>
+         <curModIdx> CUR </curModIdx>
+         <moduleInst>
+           <modIdx> CUR </modIdx>
+           <typeIds> IDS </typeIds>
+           <types> ... #ContextLookup(IDS , TFIDX) |-> FTYPE ... </types>
+           ...
+         </moduleInst>
     rule <k> #assertNextTypeIdx IDX => . ... </k>
-         <nextTypeIdx> IDX </nextTypeIdx>
+         <curModIdx> CUR </curModIdx>
+         <moduleInst>
+           <modIdx> CUR </modIdx>
+           <nextTypeIdx> IDX </nextTypeIdx>
+           ...
+         </moduleInst>
 ```
 
 ### Function Assertions
@@ -173,8 +193,13 @@ This simply checks that the given function exists in the `<funcs>` cell and has 
     syntax Assertion ::= "#assertFunction" TextFormatIdx FuncType VecType String
  // ----------------------------------------------------------------------------
     rule <k> #assertFunction TFIDX FTYPE LTYPE _ => . ... </k>
-         <funcIds> IDS </funcIds>
-         <funcIndices> ... #ContextLookup(IDS , TFIDX) |-> FADDR ... </funcIndices>
+         <curModIdx> CUR </curModIdx>
+         <moduleInst>
+           <modIdx> CUR </modIdx>
+           <funcIds> IDS </funcIds>
+           <funcIndices> ... #ContextLookup(IDS , TFIDX) |-> FADDR ... </funcIndices>
+           ...
+         </moduleInst>
          <nextFuncAddr> NEXT => NEXT -Int 1 </nextFuncAddr>
          <funcs>
            ( <funcDef>
@@ -201,7 +226,12 @@ This asserts related operation about tables.
          <nextTabAddr> NEXT </nextTabAddr>
 
     rule <k> #assertEmptyTableAux ADDR SIZE MAX _ => .  ... </k>
-         <tabIndices> ( 0 |-> ADDR ) => .Map </tabIndices>
+         <curModIdx> CUR </curModIdx>
+         <moduleInst>
+           <modIdx> CUR </modIdx>
+           <tabIndices> ( 0 |-> ADDR ) => .Map </tabIndices>
+           ...
+         </moduleInst>
          <nextTabAddr> NEXT => NEXT -Int 1 </nextTabAddr>
          <tabs>
            ( <tabInst>
@@ -229,7 +259,12 @@ This checks that the last allocated memory has the given size and max value.
          <nextMemAddr> NEXT </nextMemAddr>
 
     rule <k> #assertEmptyMemoryAux ADDR SIZE MAX _ => .  ... </k>
-         <memIndices> ( 0 |-> ADDR ) => .Map </memIndices>
+         <curModIdx> CUR </curModIdx>
+         <moduleInst>
+           <modIdx> CUR </modIdx>
+           <memIndices> ( 0 |-> ADDR ) => .Map </memIndices>
+           ...
+         </moduleInst>
          <nextMemAddr> NEXT => NEXT -Int 1 </nextMemAddr>
          <mems>
            ( <memInst>
@@ -247,7 +282,12 @@ This checks that the last allocated memory has the given size and max value.
     syntax Assertion ::= "#assertMemoryData" "(" Int "," Int ")" String
  // -------------------------------------------------------------------
     rule <k> #assertMemoryData (KEY , VAL) MSG => . ... </k>
-         <memIndices> 0 |-> ADDR </memIndices>
+         <curModIdx> CUR </curModIdx>
+         <moduleInst>
+           <modIdx> CUR </modIdx>
+           <memIndices> 0 |-> ADDR </memIndices>
+           ...
+         </moduleInst>
          <mems>
            <memInst>
              <mAddr> ADDR </mAddr>
@@ -268,7 +308,12 @@ These assertions act on the last module defined.
     syntax Assertion ::= "#assertUnnamedModuleAux" Int
     syntax Assertion ::= "#assertNamedModule" Identifier
  // ----------------------------------------------------
-    rule <k> #assertUnnamedModule => #assertUnnamedModuleAux NEXT ... </k>
+    rule <k> #assertUnnamedModule => #assertUnnamedModuleAux CUR ... </k>
+         <curModIdx> CUR </curModIdx>
+         <moduleInst>
+           <modIdx> CUR </modIdx>
+           ...
+         </moduleInst>
          <nextModuleIdx> NEXT => NEXT -Int 1 </nextModuleIdx>
     rule <k> #assertUnnamedModuleAux IDX => . ... </k>
          <moduleInstances>

--- a/test.md
+++ b/test.md
@@ -321,7 +321,7 @@ We will reference modules by name in imports.
          <moduleIds> ... ID |-> IDX ... </moduleIds>
     rule <k> register S:String IDX:Int => . ... </k>
          <moduleInstances> ... IDX |-> INST ... </moduleInstances>
-         <moduleRegistry> ... .Map => S |-> INST ... </moduleRegistry>
+         <moduleRegistry> ... .Map => S |-> IDX ... </moduleRegistry>
 ```
 
 ```k

--- a/test.md
+++ b/test.md
@@ -221,6 +221,22 @@ This checks that the last allocated memory has the given size and max value.
          </mems>
 ```
 
+### Module Assertions
+
+These assertions test (and delete) module instances.
+These assertions act on the last module defined.
+
+```k
+    syntax Assertion ::= "#assertUnnamedModule"
+    syntax Assertion ::= "#assertNamedModule" Identifier
+ // ----------------------------------------------------
+    rule <k> #assertUnnamedModule => . ... </k>
+         <nextModuleIdx> NEXT => NEXT -Int 1 </nextModuleIdx>
+         <moduleInstances> ... NEXT -Int 1 |-> _ => .Map ... </moduleInstances>
+    rule <k> #assertNamedModule NAME => #assertUnnamedModule ... </k>
+         <moduleIds> ... NAME |-> _ => .Map ... </moduleIds>
+```
+
 Clear Module Instances
 ----------------------
 
@@ -244,14 +260,25 @@ The modules are cleaned all together after the test file is executed.
            <globalIndices> _ => .Map </globalIndices>
            <exports>       _ => .Map </exports>
          </moduleInst>
-         <moduleIds> _ => .Map </moduleIds>
-         <nextModuleIdx> _ => 0 </nextModuleIdx>
-         <moduleInstances> _ => .Map </moduleInstances>
-         <moduleRegistry> _ => .Map </moduleRegistry>
 ```
 
-Official Test Assertions
-------------------------
+We also want to be able to test that the embedder's registration function is working.
+
+```k
+    syntax Assertion ::= "#assertRegistrationUnnamed" String
+    syntax Assertion ::= "#assertRegistrationNamed"   String Identifier
+ // -------------------------------------------------------------------
+    rule <k> #assertRegistrationUnnamed REGNAME => .Map ... </k>
+         <moduleInstances> ... IDX |-> _ ... </moduleInstances>
+         <moduleRegistry> ... REGNAME |-> IDX => .Map ...  </moduleRegistry>
+    rule <k> #assertRegistrationNamed REGNAME NAME => . ... </k>
+         <moduleInstances> ... IDX |-> _ ... </moduleInstances>
+         <moduleRegistry> ... REGNAME |-> IDX => .Map ...  </moduleRegistry>
+```
+
+Reference Interpreter Commands
+------------------------------
+TODO: Move this to embedder module?
 
 The official test suite contains some special auxillary instructions outside of the standard Wasm semantics.
 The reference interpreter is a particular embedder with auxillary instructions, specified in [spec interpreter](https://github.com/WebAssembly/spec/blob/master/interpreter/README.md).
@@ -282,7 +309,7 @@ We will reference modules by name in imports.
 `register` is the instruction that allows us to associate a name with a module.
 
 ```k
-    syntax Assertion ::= "(" "register" String            ")"
+    syntax Auxil ::= "(" "register" String            ")"
                        | "(" "register" String Identifier ")"
                        |     "register" String Int
  // ----------------------------------------------

--- a/test.md
+++ b/test.md
@@ -294,7 +294,7 @@ The modules are cleaned all together after the test file is executed.
  // --------------------------------
     rule <k> #clearModules => . ... </k>
          <nextFreshId> _ => 0 </nextFreshId>
-         <curModIdx> CUR </curModIdx>
+         <curModIdx> CUR => 0 </curModIdx>
          <moduleInst>
            <modIdx> CUR </modIdx>
            <typeIds> _ => .Map </typeIds>

--- a/test.md
+++ b/test.md
@@ -304,18 +304,18 @@ These assertions test (and delete) module instances.
 These assertions act on the last module defined.
 
 ```k
-    syntax Assertion ::= "#assertUnnamedModule"
-    syntax Assertion ::= "#assertUnnamedModuleAux" Int
-    syntax Assertion ::= "#assertNamedModule" Identifier
- // ----------------------------------------------------
-    rule <k> #assertUnnamedModule => #assertUnnamedModuleAux CUR ... </k>
+    syntax Assertion ::= "#assertUnnamedModule"          String
+    syntax Assertion ::= "#assertUnnamedModuleAux" Int   String
+    syntax Assertion ::= "#assertNamedModule" Identifier String
+ // -----------------------------------------------------------
+    rule <k> #assertUnnamedModule S => #assertUnnamedModuleAux CUR S ... </k>
          <curModIdx> CUR </curModIdx>
          <moduleInst>
            <modIdx> CUR </modIdx>
            ...
          </moduleInst>
          <nextModuleIdx> NEXT => NEXT -Int 1 </nextModuleIdx>
-    rule <k> #assertUnnamedModuleAux IDX => . ... </k>
+    rule <k> #assertUnnamedModuleAux IDX _ => . ... </k>
          <moduleInstances>
            ( <moduleInst>
                <modIdx> IDX </modIdx>
@@ -325,7 +325,7 @@ These assertions act on the last module defined.
            )
            ...
          </moduleInstances>
-    rule <k> #assertNamedModule NAME => #assertUnnamedModule ... </k>
+    rule <k> #assertNamedModule NAME S => #assertUnnamedModule S ... </k>
          <moduleIds> ... NAME |-> _ => .Map ... </moduleIds>
 ```
 
@@ -359,13 +359,13 @@ The modules are cleaned all together after the test file is executed.
 We also want to be able to test that the embedder's registration function is working.
 
 ```k
-    syntax Assertion ::= "#assertRegistrationUnnamed" String
-    syntax Assertion ::= "#assertRegistrationNamed"   String Identifier
- // -------------------------------------------------------------------
-    rule <k> #assertRegistrationUnnamed REGNAME => . ... </k>
+    syntax Assertion ::= "#assertRegistrationUnnamed" String            String
+    syntax Assertion ::= "#assertRegistrationNamed"   String Identifier String
+ // --------------------------------------------------------------------------
+    rule <k> #assertRegistrationUnnamed REGNAME _ => . ... </k>
          <modIdx> IDX </modIdx>
          <moduleRegistry> ... REGNAME |-> IDX => .Map ...  </moduleRegistry>
-    rule <k> #assertRegistrationNamed REGNAME NAME => . ... </k>
+    rule <k> #assertRegistrationNamed REGNAME NAME _ => . ... </k>
          <modIdx> IDX </modIdx>
          <moduleRegistry> ... REGNAME |-> IDX => .Map ...  </moduleRegistry>
 ```

--- a/test.md
+++ b/test.md
@@ -51,8 +51,10 @@ We will reference modules by name in imports.
     rule <k> ( register S ) => ( register S (NEXT -Int 1) )... </k> // Register last instantiated module.
          <nextModuleIdx> NEXT </nextModuleIdx>
       requires NEXT >Int 0
+
     rule <k> ( register S ID:Identifier ) => ( register S IDX ) ... </k>
          <moduleIds> ... ID |-> IDX ... </moduleIds>
+
     rule <k> ( register S:String IDX:Int ) => . ... </k>
          <moduleRegistry> ... .Map => S |-> IDX ... </moduleRegistry>
 ```
@@ -176,6 +178,7 @@ The operator `#assertLocal`/`#assertGlobal` operators perform a check for a loca
            <types> ... #ContextLookup(IDS , TFIDX) |-> FTYPE ... </types>
            ...
          </moduleInst>
+
     rule <k> #assertNextTypeIdx IDX => . ... </k>
          <curModIdx> CUR </curModIdx>
          <moduleInst>
@@ -305,8 +308,8 @@ These assertions act on the last module defined.
 
 ```k
     syntax Assertion ::= "#assertUnnamedModule"          String
-    syntax Assertion ::= "#assertUnnamedModuleAux" Int   String
-    syntax Assertion ::= "#assertNamedModule" Identifier String
+                       | "#assertUnnamedModuleAux" Int   String
+                       | "#assertNamedModule" Identifier String
  // -----------------------------------------------------------
     rule <k> #assertUnnamedModule S => #assertUnnamedModuleAux CUR S ... </k>
          <curModIdx> CUR => 0 </curModIdx>
@@ -315,6 +318,7 @@ These assertions act on the last module defined.
            ...
          </moduleInst>
          <nextModuleIdx> NEXT => NEXT </nextModuleIdx>
+
     rule <k> #assertUnnamedModuleAux IDX _ => . ... </k>
          <moduleInstances>
            ( <moduleInst>
@@ -325,6 +329,7 @@ These assertions act on the last module defined.
            )
            ...
          </moduleInstances>
+
     rule <k> #assertNamedModule NAME S => #assertUnnamedModuleAux IDX S ... </k>
          <moduleIds> ... NAME |-> IDX => .Map ... </moduleIds>
 ```
@@ -353,12 +358,10 @@ The modules are cleaned all together after the test file is executed.
            <globalIndices> _ => .Map </globalIndices>
            <exports>       _ => .Map </exports>
          </moduleInst>
-    rule <k> #setCurrentModule I => . ... </k>
-         <curModIdx> _ => I </curModIdx>
-    rule <k> #clearFreshId => . ... </k>
-         <nextFreshId> _ => 0 </nextFreshId>
-    rule <k> #clearModuleIdx => . ... </k>
-         <nextModuleIdx> _ => 0 </nextModuleIdx>
+
+    rule <k> #setCurrentModule I => . ... </k> <curModIdx>     _ => I </curModIdx>
+    rule <k> #clearFreshId       => . ... </k> <nextFreshId>   _ => 0 </nextFreshId>
+    rule <k> #clearModuleIdx     => . ... </k> <nextModuleIdx> _ => 0 </nextModuleIdx>
 ```
 
 Registry Assertations
@@ -368,11 +371,12 @@ We also want to be able to test that the embedder's registration function is wor
 
 ```k
     syntax Assertion ::= "#assertRegistrationUnnamed" String            String
-    syntax Assertion ::= "#assertRegistrationNamed"   String Identifier String
+                       | "#assertRegistrationNamed"   String Identifier String
  // --------------------------------------------------------------------------
     rule <k> #assertRegistrationUnnamed REGNAME _ => . ... </k>
          <modIdx> IDX </modIdx>
          <moduleRegistry> ... REGNAME |-> IDX => .Map ...  </moduleRegistry>
+
     rule <k> #assertRegistrationNamed REGNAME NAME _ => . ... </k>
          <modIdx> IDX </modIdx>
          <moduleRegistry> ... REGNAME |-> IDX => .Map ...  </moduleRegistry>

--- a/test.md
+++ b/test.md
@@ -246,7 +246,12 @@ This asserts related operation about tables.
     syntax Assertion ::= "#assertTableElem" "(" Int "," TextFormatIdx ")" String
  // ----------------------------------------------------------------------------
     rule <k> #assertTableElem (KEY , VAL) MSG => . ... </k>
-         <tabIndices> 0 |-> ADDR </tabIndices>
+         <curModIdx> CUR </curModIdx>
+         <moduleInst>
+           <modIdx> CUR </modIdx>
+           <tabIndices> 0 |-> ADDR </tabIndices>
+           ...
+         </moduleInst>
          <tabs>
            <tabInst>
              <tAddr> ADDR </tAddr>
@@ -319,12 +324,12 @@ These assertions act on the last module defined.
                        | "#assertNamedModule" Identifier String
  // -----------------------------------------------------------
     rule <k> #assertUnnamedModule S => #assertUnnamedModuleAux CUR S ... </k>
-         <curModIdx> CUR => 0 </curModIdx>
+         <curModIdx> CUR </curModIdx>
          <moduleInst>
            <modIdx> CUR </modIdx>
            ...
          </moduleInst>
-         <nextModuleIdx> NEXT => NEXT </nextModuleIdx>
+         <nextModuleIdx> NEXT => NEXT -Int 1 </nextModuleIdx>
 
     rule <k> #assertUnnamedModuleAux IDX _ => . ... </k>
          <moduleInstances>

--- a/test.md
+++ b/test.md
@@ -333,9 +333,9 @@ The modules are cleaned all together after the test file is executed.
 
 ```k
     syntax Auxil ::= "#clearCurrentModule"
-    syntax Auxil ::= "#setCurrentModule" Int
-    syntax Auxil ::= "#clearFreshId"
-    syntax Auxil ::= "#clearModuleIdx"
+                   | "#setCurrentModule" Int
+                   | "#clearFreshId"
+                   | "#clearModuleIdx"
  // ----------------------------------
     rule <k> #clearCurrentModule => . ... </k>
          <curModIdx> CUR </curModIdx>

--- a/test.md
+++ b/test.md
@@ -151,8 +151,8 @@ The operator `#assertLocal`/`#assertGlobal` operators perform a check for a loca
            ...
          </moduleInst>
          <globals>
-           ( .Bag =>
-             <globalInst>
+           ( .Bag
+          => <globalInst>
                <gAddr> GADDR </gAddr>
                ...
              </globalInst>
@@ -344,20 +344,18 @@ The modules are cleaned all together after the test file is executed.
  // ----------------------------------
     rule <k> #clearCurrentModule => . ... </k>
          <curModIdx> CUR </curModIdx>
-         <moduleInst>
-           <modIdx> CUR </modIdx>
-           <typeIds> _ => .Map </typeIds>
-           <funcIds> _ => .Map </funcIds>
-           <nextTypeIdx>   _ => 0 </nextTypeIdx>
-           <nextFuncIdx>   _ => 0 </nextFuncIdx>
-           <nextGlobalIdx> _ => 0 </nextGlobalIdx>
-           <types>         _ => .Map </types>
-           <funcIndices>   _ => .Map </funcIndices>
-           <tabIndices>    _ => .Map </tabIndices>
-           <memIndices>    _ => .Map </memIndices>
-           <globalIndices> _ => .Map </globalIndices>
-           <exports>       _ => .Map </exports>
-         </moduleInst>
+         <moduleInstances>
+           ( <moduleInst>
+               <modIdx> CUR </modIdx>
+               ...
+             </moduleInst>
+          => <moduleInst>
+               <modIdx> CUR </modIdx>
+               ...
+             </moduleInst>
+           )
+           ...
+         </moduleInstances>
 
     rule <k> #setCurrentModule I => . ... </k> <curModIdx>     _ => I </curModIdx>
     rule <k> #clearFreshId       => . ... </k> <nextFreshId>   _ => 0 </nextFreshId>

--- a/test.md
+++ b/test.md
@@ -268,7 +268,7 @@ We also want to be able to test that the embedder's registration function is wor
     syntax Assertion ::= "#assertRegistrationUnnamed" String
     syntax Assertion ::= "#assertRegistrationNamed"   String Identifier
  // -------------------------------------------------------------------
-    rule <k> #assertRegistrationUnnamed REGNAME => .Map ... </k>
+    rule <k> #assertRegistrationUnnamed REGNAME => . ... </k>
          <moduleInstances> ... IDX |-> _ ... </moduleInstances>
          <moduleRegistry> ... REGNAME |-> IDX => .Map ...  </moduleRegistry>
     rule <k> #assertRegistrationNamed REGNAME NAME => . ... </k>

--- a/test.md
+++ b/test.md
@@ -278,6 +278,7 @@ We also want to be able to test that the embedder's registration function is wor
 
 Reference Interpreter Commands
 ------------------------------
+
 TODO: Move this to embedder module?
 
 The official test suite contains some special auxillary instructions outside of the standard Wasm semantics.
@@ -310,9 +311,9 @@ We will reference modules by name in imports.
 
 ```k
     syntax Auxil ::= "(" "register" String            ")"
-                       | "(" "register" String Identifier ")"
-                       |     "register" String Int
- // ----------------------------------------------
+                   | "(" "register" String Identifier ")"
+                   |     "register" String Int
+ // ------------------------------------------
     rule <k> ( register S ) => register S (NEXT -Int 1) ... </k> // Register last module.
          <nextModuleIdx> NEXT </nextModuleIdx>
          requires NEXT >Int 0

--- a/test.md
+++ b/test.md
@@ -309,12 +309,12 @@ These assertions act on the last module defined.
     syntax Assertion ::= "#assertNamedModule" Identifier String
  // -----------------------------------------------------------
     rule <k> #assertUnnamedModule S => #assertUnnamedModuleAux CUR S ... </k>
-         <curModIdx> CUR </curModIdx>
+         <curModIdx> CUR => 0 </curModIdx>
          <moduleInst>
            <modIdx> CUR </modIdx>
            ...
          </moduleInst>
-         <nextModuleIdx> NEXT => NEXT -Int 1 </nextModuleIdx>
+         <nextModuleIdx> NEXT => NEXT </nextModuleIdx>
     rule <k> #assertUnnamedModuleAux IDX _ => . ... </k>
          <moduleInstances>
            ( <moduleInst>
@@ -325,21 +325,20 @@ These assertions act on the last module defined.
            )
            ...
          </moduleInstances>
-    rule <k> #assertNamedModule NAME S => #assertUnnamedModule S ... </k>
-         <moduleIds> ... NAME |-> _ => .Map ... </moduleIds>
+    rule <k> #assertNamedModule NAME S => #assertUnnamedModuleAux IDX S ... </k>
+         <moduleIds> ... NAME |-> IDX => .Map ... </moduleIds>
 ```
-
-Registry Assertations
----------------------
 
 The modules are cleaned all together after the test file is executed.
 
 ```k
-    syntax Auxil ::= "#clearModules"
- // --------------------------------
-    rule <k> #clearModules => . ... </k>
-         <nextFreshId> _ => 0 </nextFreshId>
-         <curModIdx> CUR => 0 </curModIdx>
+    syntax Auxil ::= "#clearCurrentModule"
+    syntax Auxil ::= "#setCurrentModule" Int
+    syntax Auxil ::= "#clearFreshId"
+    syntax Auxil ::= "#clearModuleIdx"
+ // ----------------------------------
+    rule <k> #clearCurrentModule => . ... </k>
+         <curModIdx> CUR </curModIdx>
          <moduleInst>
            <modIdx> CUR </modIdx>
            <typeIds> _ => .Map </typeIds>
@@ -354,7 +353,16 @@ The modules are cleaned all together after the test file is executed.
            <globalIndices> _ => .Map </globalIndices>
            <exports>       _ => .Map </exports>
          </moduleInst>
+    rule <k> #setCurrentModule I => . ... </k>
+         <curModIdx> _ => I </curModIdx>
+    rule <k> #clearFreshId => . ... </k>
+         <nextFreshId> _ => 0 </nextFreshId>
+    rule <k> #clearModuleIdx => . ... </k>
+         <nextModuleIdx> _ => 0 </nextModuleIdx>
 ```
+
+Registry Assertations
+---------------------
 
 We also want to be able to test that the embedder's registration function is working.
 

--- a/tests/simple/arithmetic.wast
+++ b/tests/simple/arithmetic.wast
@@ -179,4 +179,3 @@
 (i32.sub (i32.mul (i32.const 5) (i32.const 7)) (i32.const 4))
 #assertTopStack < i32 > 31 "mul nested in sub folded"
 
-#clearModules

--- a/tests/simple/bitwise.wast
+++ b/tests/simple/bitwise.wast
@@ -149,4 +149,3 @@
 (i64.popcnt)
 #assertTopStack < i64 > 64 "popcnt 2^64 - 1"
 
-#clearModules

--- a/tests/simple/comments.wast
+++ b/tests/simple/comments.wast
@@ -20,4 +20,3 @@ should be ignored
 (i32.add)
 #assertTopStack < i32 > 3 "dummy test 2"
 
-#clearModules

--- a/tests/simple/comparison.wast
+++ b/tests/simple/comparison.wast
@@ -112,4 +112,3 @@
 (i32.ge_s)
 #assertTopStack < i32 > 0 "ge_s 3"
 
-#clearModules

--- a/tests/simple/constants.wast
+++ b/tests/simple/constants.wast
@@ -75,4 +75,3 @@
 (i64.const #unsigned(i64, #signed(i64, #pow(i64) -Int 1)))
 #assertTopStack < i64 > #pow(i64) -Int 1 "#unsigned . #signed 6"
 
-#clearModules

--- a/tests/simple/control-flow.wast
+++ b/tests/simple/control-flow.wast
@@ -205,5 +205,3 @@ end
 ;; block [ i32 i32 ]
 ;;     (i32.const 7)
 ;; end
-
-#clearModules

--- a/tests/simple/conversion.wast
+++ b/tests/simple/conversion.wast
@@ -23,5 +23,3 @@
 
 (i64.extend_i32_s (i32.const 15))
 #assertTopStack < i64 > 15 "folded extend sig"
-
-#clearModules

--- a/tests/simple/data.wast
+++ b/tests/simple/data.wast
@@ -1,3 +1,5 @@
+(module)
+
 ;; Instantiating with data
 
 (memory (data 87 65 83 77 50 46 48))
@@ -34,3 +36,6 @@
 (memory (data 87))
 #assertMemoryData (0, 87) "text to ascii W"
 #assertEmptyMemory 1 1 "memorys string length"
+
+#assertUnnamedModule ""
+#clearModuleIdx

--- a/tests/simple/export.wast
+++ b/tests/simple/export.wast
@@ -1,3 +1,4 @@
+(module)
 ;; test function export
 
 (func $1 param i64 i64 i64 result i64 local i64
@@ -59,4 +60,6 @@
 
 #assertFunction 0 [ i32 i64 i64 ] -> [ i32 ] [ i32 ] "removing a function by its inner index"
 
-#clearModules
+#assertUnnamedModule ""
+#clearFreshId
+#clearModuleIdx

--- a/tests/simple/functions_call.wast
+++ b/tests/simple/functions_call.wast
@@ -1,3 +1,5 @@
+(module)
+
 ;; Simple add function
 
 (type $a-cool-type (func (param i32 i32 ) ( result i32 )))
@@ -116,6 +118,7 @@
 (func $3)
 
 #assertFunction $3 [ ] -> [ ] [ ] "no domain/range or locals"
+#assertUnnamedModule ""
 
 (module
     (func $add
@@ -162,7 +165,7 @@
 #assertFunction $mul [ i32 i32 ] -> [ i32 ] [ ] "mul function typed correctly"
 #assertFunction $xor [ i32 i32 ] -> [ i32 ] [ ] "xor function typed correctly"
 #assertNextTypeIdx 1
-#assertUnnamedModule
+#assertUnnamedModule "add-mul-xor module"
 
 (module
     (func $f1 (param i32 i32 ) (result i32) (local i32)
@@ -197,7 +200,7 @@
 #assertTopStack < i32 > 77000 "nested method call"
 #assertFunction $f2 [ i32 i32 i32 ] -> [ i32 ] [ i32 i32 ] "outer calling method"
 #assertFunction $f1 [ i32 i32     ] -> [ i32 ] [ i32     ] "inner calling method"
-#assertUnnamedModule
+#assertUnnamedModule "f1-f2 module"
 
 (module
     (func $dummy)
@@ -212,6 +215,5 @@
 
 #assertFunction $dummy [         ] -> [     ] [ ] "$dummy function in module"
 #assertFunction $add   [ i32 i32 ] -> [ i32 ] [ ] "second function in module"
-#assertUnnamedModule
-
-#clearModules
+#assertUnnamedModule "dummy-add module"
+#clearModuleIdx

--- a/tests/simple/functions_call.wast
+++ b/tests/simple/functions_call.wast
@@ -162,6 +162,7 @@
 #assertFunction $mul [ i32 i32 ] -> [ i32 ] [ ] "mul function typed correctly"
 #assertFunction $xor [ i32 i32 ] -> [ i32 ] [ ] "xor function typed correctly"
 #assertNextTypeIdx 5
+#assertUnnamedModule
 
 (module
     (func $f1 (param i32 i32 ) (result i32) (local i32)
@@ -196,6 +197,7 @@
 #assertTopStack < i32 > 77000 "nested method call"
 #assertFunction $f2 [ i32 i32 i32 ] -> [ i32 ] [ i32 i32 ] "outer calling method"
 #assertFunction $f1 [ i32 i32     ] -> [ i32 ] [ i32     ] "inner calling method"
+#assertUnnamedModule
 
 (module
     (func $dummy)
@@ -210,5 +212,6 @@
 
 #assertFunction $dummy [         ] -> [     ] [ ] "$dummy function in module"
 #assertFunction $add   [ i32 i32 ] -> [ i32 ] [ ] "second function in module"
+#assertUnnamedModule
 
 #clearModules

--- a/tests/simple/functions_call.wast
+++ b/tests/simple/functions_call.wast
@@ -161,7 +161,7 @@
 #assertFunction $add [ i32 i32 ] -> [ i32 ] [ ] "add function typed correctly"
 #assertFunction $mul [ i32 i32 ] -> [ i32 ] [ ] "mul function typed correctly"
 #assertFunction $xor [ i32 i32 ] -> [ i32 ] [ ] "xor function typed correctly"
-#assertNextTypeIdx 5
+#assertNextTypeIdx 1
 #assertUnnamedModule
 
 (module

--- a/tests/simple/identifiers.wast
+++ b/tests/simple/identifiers.wast
@@ -1,3 +1,4 @@
+(module)
 ;; tests of function identifier names
 
 (func $oeauth
@@ -66,4 +67,5 @@
 
 #assertFunction $aenuth_ae`st|23~423 [ i32 i32 ] -> [ i32 ] [ ] "identifier function name 3"
 
-#clearModules
+#assertUnnamedModule ""
+#clearModuleIdx

--- a/tests/simple/memory.wast
+++ b/tests/simple/memory.wast
@@ -1,3 +1,5 @@
+(module)
+
 ( memory )
 #assertEmptyMemory 0 .MaxBound "memory initial 1"
 
@@ -117,4 +119,5 @@
 #assertMemoryData (8, 255) ""
 #assertEmptyMemory 1 .MaxBound "Zero updates don't over-erase"
 
-#clearModules
+#assertUnnamedModule ""
+#clearModuleIdx

--- a/tests/simple/modules.wast
+++ b/tests/simple/modules.wast
@@ -1,24 +1,26 @@
 (module)
 
-#assertUnnamedModule
+#assertUnnamedModule "empty module"
 
 (module $myMod)
 
-#assertNamedModule $myMod
+#assertNamedModule $myMod "named empty module"
 
 (module)
 
 (register "a module name")
 
-#assertRegistrationUnnamed "a module name"
-#assertUnnamedModule
+#assertRegistrationUnnamed "a module name" "registration1"
+#assertUnnamedModule "registered module"
 
 (module $anotherName)
 
 (register "a module name")
 
-#assertRegistrationNamed "a module name" $anotherName
-#assertNamedModule $anotherName
+#assertRegistrationNamed "a module name" $anotherName "registration2"
+#assertNamedModule $anotherName "named registered module"
+
+#clearModuleIdx
 
 (module $myMod)
 
@@ -30,10 +32,15 @@
 (register "another module name" $myMod2)
 (register "third module name")
 
-#assertRegistrationNamed "another module name" $myMod2
-#assertRegistrationNamed "a module name" $myMod
-#assertRegistrationUnnamed "third module name"
+#assertRegistrationNamed "another module name" $myMod2 "registration3"
+#assertRegistrationNamed "a module name" $myMod "registration4"
+#assertRegistrationUnnamed "third module name" "registration5"
 
-#assertNamedModule $myMod2
-#assertUnnamedModule
-#assertNamedModule $myMod
+#setCurrentModule 2
+#assertNamedModule $myMod2 "interleaved module 3"
+#setCurrentModule 1
+#assertUnnamedModule "interleaved module 1"
+#setCurrentModule 0
+#assertNamedModule $myMod "interleaved module 0"
+
+#clearModuleIdx

--- a/tests/simple/modules.wast
+++ b/tests/simple/modules.wast
@@ -1,0 +1,39 @@
+(module)
+
+#assertUnnamedModule
+
+(module $myMod)
+
+#assertNamedModule $myMod
+
+(module)
+
+(register "a module name")
+
+#assertRegistrationUnnamed "a module name"
+#assertUnnamedModule
+
+(module $anotherName)
+
+(register "a module name")
+
+#assertRegistrationNamed "a module name" $anotherName
+#assertNamedModule $anotherName
+
+(module $myMod)
+
+(module)
+
+(module $myMod2)
+
+(register "a module name" $myMod)
+(register "another module name" $myMod2)
+(register "third module name")
+
+#assertRegistrationNamed "another module name" $myMod2
+#assertRegistrationNamed "a module name" $myMod
+#assertRegistrationUnnamed "third module name"
+
+#assertNamedModule $myMod2
+#assertUnnamedModule
+#assertNamedModule $myMod

--- a/tests/simple/polymorphic.wast
+++ b/tests/simple/polymorphic.wast
@@ -64,4 +64,3 @@
 #assertTopStack < i64 > -1 "select strict in condition"
 #assertTopStack < i64 >  1 "select strict in condition"
 
-#clearModules

--- a/tests/simple/start.wast
+++ b/tests/simple/start.wast
@@ -1,28 +1,35 @@
-(memory 1)
-(func $inc
-  (i32.store8
-    (i32.const 0)
-    (i32.add
-      (i32.load8_u (i32.const 0))
-      (i32.const 1)))
-)
-(func $main
-  (i32.store (i32.const 0) (i32.const 65))
-  (call $inc)
-  (call $inc)
-  (call $inc)
-)
-(start $main)
+;;(module)
+;;
+;;(memory 1)
+;;(func $inc
+;;  (i32.store8
+;;    (i32.const 0)
+;;    (i32.add
+;;      (i32.load8_u (i32.const 0))
+;;      (i32.const 1)))
+;;)
+;;(func $main
+;;  (i32.store (i32.const 0) (i32.const 65))
+;;  (call $inc)
+;;  (call $inc)
+;;  (call $inc)
+;;)
+;;(start $main)
+;;
+;;#assertMemoryData (0, 68) "start inc"
+;;assertFunction $inc  [ ] -> [ ] [ ] ""
+;;#assertFunction $main [ ] -> [ ] [ ] ""
+;;#assertFunction $foo  [ ] -> [ ] [ ] ""
+;;#assertEmptyMemory 1 .MaxBound ""
+;;
+;;#assertUnnamedModule ""
+;;
+;;;; (module)
+;;
+;; (func $foo (unreachable))
+;; (start $foo)
+;; #assertTrap "Trap propagates through start invocation"
+;;
+;; #assertUnnamedModule ""
 
-#assertMemoryData (0, 68) "start inc"
-
-(func $foo (unreachable))
-(start $foo)
-#assertTrap "Trap propagates thorugh start invocation"
-
-;; Cleanup
-#assertFunction $inc  [ ] -> [ ] [ ] ""
-#assertFunction $main [ ] -> [ ] [ ] ""
-#assertFunction $foo  [ ] -> [ ] [ ] ""
-#assertEmptyMemory 1 .MaxBound ""
-#clearModules
+#clearModuleIdx

--- a/tests/simple/table.wast
+++ b/tests/simple/table.wast
@@ -21,6 +21,8 @@
 #assertTableElem (2, $g) "table elem 2"
 #assertEmptyTable 4 .MaxBound "should be empty now"
 
+#assertUnnamedModule ""
+
 (module
   (type $out-i32 (func (result i32)))
   (table 10 funcref)
@@ -57,4 +59,5 @@
 #assertEmptyTable 10 .MaxBound "should be empty now"
 
 #assertUnnamedModule ""
+#clearFreshId
 #clearModuleIdx

--- a/tests/simple/table.wast
+++ b/tests/simple/table.wast
@@ -1,3 +1,5 @@
+(module)
+
 ( table )
 #assertEmptyTable 0 .MaxBound "table initial 1"
 
@@ -7,4 +9,5 @@
 ( table 14 21 )
 #assertEmptyTable 14 21 "table initial 3"
 
-#clearModules
+#assertUnnamedModule ""
+#clearModuleIdx

--- a/tests/simple/variables.wast
+++ b/tests/simple/variables.wast
@@ -1,3 +1,4 @@
+(module)
 ;; Test locals
 
 init_locals < i32 > 0 : < i32 > 0 : < i32 > 0 : .ValStack
@@ -42,4 +43,5 @@ init_global 1 1
 #assertGlobal 1 < i32 > 99 "set_global folded"
 #assertGlobal 0 < i32 > 77 "set_global folded 2"
 
-#clearModules
+#assertUnnamedModule ""
+#clearModuleIdx

--- a/tests/success-haskell.out
+++ b/tests/success-haskell.out
@@ -74,4 +74,16 @@
       .GlobalInstCellMap
     </globals>
   </mainStore>
+  <moduleIds>
+    .Map
+  </moduleIds>
+  <nextModuleIdx>
+    0
+  </nextModuleIdx>
+  <moduleInstances>
+    .Map
+  </moduleInstances>
+  <moduleRegistry>
+    .Map
+  </moduleRegistry>
 </generatedTop>

--- a/tests/success-java.out
+++ b/tests/success-java.out
@@ -74,4 +74,16 @@
       .Map
     </globals>
   </mainStore>
+  <moduleIds>
+    .Map
+  </moduleIds>
+  <nextModuleIdx>
+    0
+  </nextModuleIdx>
+  <moduleInstances>
+    .Map
+  </moduleInstances>
+  <moduleRegistry>
+    .Map
+  </moduleRegistry>
 </generatedTop>

--- a/tests/success-java.out
+++ b/tests/success-java.out
@@ -12,45 +12,25 @@
     <locals>
       .Map
     </locals>
+    <curModIdx>
+      0
+    </curModIdx>
   </curFrame>
   <nextFreshId>
     0
   </nextFreshId>
-  <moduleInst>
-    <typeIds>
-      .Map
-    </typeIds>
-    <funcIds>
-      .Map
-    </funcIds>
-    <nextTypeIdx>
-      0
-    </nextTypeIdx>
-    <nextFuncIdx>
-      0
-    </nextFuncIdx>
-    <nextGlobalIdx>
-      0
-    </nextGlobalIdx>
-    <types>
-      .Map
-    </types>
-    <funcIndices>
-      .Map
-    </funcIndices>
-    <tabIndices>
-      .Map
-    </tabIndices>
-    <memIndices>
-      .Map
-    </memIndices>
-    <globalIndices>
-      .Map
-    </globalIndices>
-    <exports>
-      .Map
-    </exports>
-  </moduleInst>
+  <moduleInstances>
+    .Map
+  </moduleInstances>
+  <moduleIds>
+    .Map
+  </moduleIds>
+  <nextModuleIdx>
+    0
+  </nextModuleIdx>
+  <moduleRegistry>
+    .Map
+  </moduleRegistry>
   <mainStore>
     <nextFuncAddr>
       0
@@ -74,16 +54,4 @@
       .Map
     </globals>
   </mainStore>
-  <moduleIds>
-    .Map
-  </moduleIds>
-  <nextModuleIdx>
-    0
-  </nextModuleIdx>
-  <moduleInstances>
-    .Map
-  </moduleInstances>
-  <moduleRegistry>
-    .Map
-  </moduleRegistry>
 </generatedTop>

--- a/tests/success-java.out
+++ b/tests/success-java.out
@@ -20,52 +20,13 @@
     0
   </nextFreshId>
   <moduleInstances>
-    <modIdx>
-      0
-    </modIdx> |-> <moduleInst>
-      <modIdx>
-        0
-      </modIdx>
-      <typeIds>
-        .Map
-      </typeIds>
-      <funcIds>
-        .Map
-      </funcIds>
-      <nextTypeIdx>
-        0
-      </nextTypeIdx>
-      <nextFuncIdx>
-        0
-      </nextFuncIdx>
-      <nextGlobalIdx>
-        0
-      </nextGlobalIdx>
-      <types>
-        .Map
-      </types>
-      <funcIndices>
-        .Map
-      </funcIndices>
-      <tabIndices>
-        .Map
-      </tabIndices>
-      <memIndices>
-        .Map
-      </memIndices>
-      <globalIndices>
-        .Map
-      </globalIndices>
-      <exports>
-        .Map
-      </exports>
-    </moduleInst>
+    .Map
   </moduleInstances>
   <moduleIds>
     .Map
   </moduleIds>
   <nextModuleIdx>
-    1
+    0
   </nextModuleIdx>
   <moduleRegistry>
     .Map

--- a/tests/success-java.out
+++ b/tests/success-java.out
@@ -20,13 +20,52 @@
     0
   </nextFreshId>
   <moduleInstances>
-    .Map
+    <modIdx>
+      0
+    </modIdx> |-> <moduleInst>
+      <modIdx>
+        0
+      </modIdx>
+      <typeIds>
+        .Map
+      </typeIds>
+      <funcIds>
+        .Map
+      </funcIds>
+      <nextTypeIdx>
+        0
+      </nextTypeIdx>
+      <nextFuncIdx>
+        0
+      </nextFuncIdx>
+      <nextGlobalIdx>
+        0
+      </nextGlobalIdx>
+      <types>
+        .Map
+      </types>
+      <funcIndices>
+        .Map
+      </funcIndices>
+      <tabIndices>
+        .Map
+      </tabIndices>
+      <memIndices>
+        .Map
+      </memIndices>
+      <globalIndices>
+        .Map
+      </globalIndices>
+      <exports>
+        .Map
+      </exports>
+    </moduleInst>
   </moduleInstances>
   <moduleIds>
     .Map
   </moduleIds>
   <nextModuleIdx>
-    0
+    1
   </nextModuleIdx>
   <moduleRegistry>
     .Map

--- a/tests/success-ocaml.out
+++ b/tests/success-ocaml.out
@@ -12,45 +12,25 @@
     <locals>
       .Map
     </locals>
+    <curModIdx>
+      0
+    </curModIdx>
   </curFrame>
   <nextFreshId>
     0
   </nextFreshId>
-  <moduleInst>
-    <typeIds>
-      .Map
-    </typeIds>
-    <funcIds>
-      .Map
-    </funcIds>
-    <nextTypeIdx>
-      0
-    </nextTypeIdx>
-    <nextFuncIdx>
-      0
-    </nextFuncIdx>
-    <nextGlobalIdx>
-      0
-    </nextGlobalIdx>
-    <types>
-      .Map
-    </types>
-    <funcIndices>
-      .Map
-    </funcIndices>
-    <tabIndices>
-      .Map
-    </tabIndices>
-    <memIndices>
-      .Map
-    </memIndices>
-    <globalIndices>
-      .Map
-    </globalIndices>
-    <exports>
-      .Map
-    </exports>
-  </moduleInst>
+  <moduleInstances>
+    .ModuleInstCellMap
+  </moduleInstances>
+  <moduleIds>
+    .Map
+  </moduleIds>
+  <nextModuleIdx>
+    0
+  </nextModuleIdx>
+  <moduleRegistry>
+    .Map
+  </moduleRegistry>
   <mainStore>
     <nextFuncAddr>
       0
@@ -74,16 +54,4 @@
       .GlobalInstCellMap
     </globals>
   </mainStore>
-  <moduleIds>
-    .Map
-  </moduleIds>
-  <nextModuleIdx>
-    0
-  </nextModuleIdx>
-  <moduleInstances>
-    .Map
-  </moduleInstances>
-  <moduleRegistry>
-    .Map
-  </moduleRegistry>
 </generatedTop>

--- a/tests/success-ocaml.out
+++ b/tests/success-ocaml.out
@@ -20,50 +20,13 @@
     0
   </nextFreshId>
   <moduleInstances>
-    <moduleInst>
-      <modIdx>
-        0
-      </modIdx>
-      <typeIds>
-        .Map
-      </typeIds>
-      <funcIds>
-        .Map
-      </funcIds>
-      <nextTypeIdx>
-        0
-      </nextTypeIdx>
-      <nextFuncIdx>
-        0
-      </nextFuncIdx>
-      <nextGlobalIdx>
-        0
-      </nextGlobalIdx>
-      <types>
-        .Map
-      </types>
-      <funcIndices>
-        .Map
-      </funcIndices>
-      <tabIndices>
-        .Map
-      </tabIndices>
-      <memIndices>
-        .Map
-      </memIndices>
-      <globalIndices>
-        .Map
-      </globalIndices>
-      <exports>
-        .Map
-      </exports>
-    </moduleInst>
+    .ModuleInstCellMap
   </moduleInstances>
   <moduleIds>
     .Map
   </moduleIds>
   <nextModuleIdx>
-    1
+    0
   </nextModuleIdx>
   <moduleRegistry>
     .Map

--- a/tests/success-ocaml.out
+++ b/tests/success-ocaml.out
@@ -74,4 +74,16 @@
       .GlobalInstCellMap
     </globals>
   </mainStore>
+  <moduleIds>
+    .Map
+  </moduleIds>
+  <nextModuleIdx>
+    0
+  </nextModuleIdx>
+  <moduleInstances>
+    .Map
+  </moduleInstances>
+  <moduleRegistry>
+    .Map
+  </moduleRegistry>
 </generatedTop>

--- a/tests/success-ocaml.out
+++ b/tests/success-ocaml.out
@@ -20,13 +20,50 @@
     0
   </nextFreshId>
   <moduleInstances>
-    .ModuleInstCellMap
+    <moduleInst>
+      <modIdx>
+        0
+      </modIdx>
+      <typeIds>
+        .Map
+      </typeIds>
+      <funcIds>
+        .Map
+      </funcIds>
+      <nextTypeIdx>
+        0
+      </nextTypeIdx>
+      <nextFuncIdx>
+        0
+      </nextFuncIdx>
+      <nextGlobalIdx>
+        0
+      </nextGlobalIdx>
+      <types>
+        .Map
+      </types>
+      <funcIndices>
+        .Map
+      </funcIndices>
+      <tabIndices>
+        .Map
+      </tabIndices>
+      <memIndices>
+        .Map
+      </memIndices>
+      <globalIndices>
+        .Map
+      </globalIndices>
+      <exports>
+        .Map
+      </exports>
+    </moduleInst>
   </moduleInstances>
   <moduleIds>
     .Map
   </moduleIds>
   <nextModuleIdx>
-    0
+    1
   </nextModuleIdx>
   <moduleRegistry>
     .Map

--- a/wasm.md
+++ b/wasm.md
@@ -1202,7 +1202,11 @@ The surronding `module` tag is discarded, and the inner portions are run like th
 
 ```k
     syntax Stmt ::= "(" "module" Defns ")"
- // --------------------------------------
+                  | "(" "module" Identifier Defns ")"
+ // -------------------------------------------------
+    rule <k> ( module ID:Identifier DEFNS ) => ( module DEFNS ) ... </k>
+         <moduleIds> ... .Map => ID |-> NEXT ... </moduleIds>
+         <nextModuleIdx> NEXT </nextModuleIdx>
     rule <k> ( module DEFNS ) => DEFNS ~> #storeInstance ... </k>
 ```
 

--- a/wasm.md
+++ b/wasm.md
@@ -70,6 +70,10 @@ Configuration
           </globalInst>
         </globals>
       </mainStore>
+      <moduleIds> .Map </moduleIds>
+      <nextModuleIdx> 0 </nextModuleIdx>
+      <moduleInstances> .Map </moduleInstances>
+      <moduleRegistry> .Map </moduleRegistry>
 ```
 
 ### Assumptions and invariants

--- a/wasm.md
+++ b/wasm.md
@@ -814,10 +814,11 @@ Here, we allow for an "abstract" function declaration using syntax `func_::___`,
          <funcs>
            ( .Bag
           => <funcDef>
-               <fAddr>  NEXTADDR                             </fAddr>
-               <fCode>  INSTRS                               </fCode>
-               <fType>  asFuncType  ( TYPEIDS, TYPES, TUSE ) </fType>
-               <fLocal> asLocalType ( LDECLS )               </fLocal>
+               <fAddr>    NEXTADDR                             </fAddr>
+               <fCode>    INSTRS                               </fCode>
+               <fType>    asFuncType  ( TYPEIDS, TYPES, TUSE ) </fType>
+               <fLocal>   asLocalType ( LDECLS )               </fLocal>
+               <fModInst> CUR                                  </fModInst>
                ...
              </funcDef>
            )
@@ -832,30 +833,30 @@ Similar to labels, they sit on the instruction stack (the `<k>` cell), and `retu
 Unlike labels, only one frame can be "broken" through at a time.
 
 ```k
-    syntax Frame ::= "frame" ValTypes ValStack Map
- // ----------------------------------------------
-    rule <k> frame TRANGE VALSTACK' LOCAL' => . ... </k>
+    syntax Frame ::= "frame" Int ValTypes ValStack Map
+ // --------------------------------------------------
+    rule <k> frame MODIDX' TRANGE VALSTACK' LOCAL' => . ... </k>
          <valstack> VALSTACK => #take(TRANGE, VALSTACK) ++ VALSTACK' </valstack>
          <locals> _ => LOCAL' </locals>
+         <curModIdx> _ => MODIDX' </curModIdx>
 
     syntax Instr ::= "(" "invoke" Int ")"
  // -------------------------------------
     rule <k> ( invoke FADDR )
           => init_locals #take(TDOMAIN, VALSTACK) ++ #zero(TLOCALS)
           ~> INSTRS
-          ~> frame TRANGE #drop(TDOMAIN, VALSTACK) LOCAL
+          ~> frame MODIDX TRANGE #drop(TDOMAIN, VALSTACK) LOCAL
           ...
           </k>
          <valstack>  VALSTACK => .ValStack </valstack>
-         <curFrame>
-           <locals> LOCAL => .Map </locals>
-           ...
-         </curFrame>
+         <locals> LOCAL => .Map </locals>
+         <curModIdx> MODIDX => MODIDX' </curModIdx>
          <funcDef>
-           <fAddr>  FADDR                     </fAddr>
-           <fCode>  INSTRS                    </fCode>
-           <fType>  [ TDOMAIN ] -> [ TRANGE ] </fType>
-           <fLocal> [ TLOCALS ]               </fLocal>
+           <fAddr>   FADDR                     </fAddr>
+           <fCode>   INSTRS                    </fCode>
+           <fType>   [ TDOMAIN ] -> [ TRANGE ] </fType>
+           <fLocal>  [ TLOCALS ]               </fLocal>
+           <fModIdx> MODIDX'                   </fModIdx>
            ...
          </funcDef>
 

--- a/wasm.md
+++ b/wasm.md
@@ -18,21 +18,28 @@ Configuration
       <valstack> .ValStack </valstack>
       <curFrame>
         <locals> .Map </locals>
+        <curModIdx> 0 </curModIdx>
       </curFrame>
       <nextFreshId> 0 </nextFreshId>
-      <moduleInst>
-        <typeIds>       .Map </typeIds>
-        <funcIds>       .Map </funcIds> //this is mapping from identifier to index
-        <nextTypeIdx>   0    </nextTypeIdx>
-        <nextFuncIdx>   0    </nextFuncIdx>
-        <nextGlobalIdx> 0    </nextGlobalIdx>
-        <types>         .Map </types>
-        <funcIndices>   .Map </funcIndices> //this is mapping from index to address
-        <tabIndices>    .Map </tabIndices>
-        <memIndices>    .Map </memIndices>
-        <globalIndices> .Map </globalIndices>
-        <exports>       .Map </exports>
-      </moduleInst>
+      <moduleInstances>
+        <moduleInst multiplicity="*" type="Map">
+/*TODO */ <modIdx>        0    </modIdx>
+/*TODO */ <typeIds>       .Map </typeIds>
+/*TODO */ <funcIds>       .Map </funcIds> //this is mapping from identifier to index
+/*TODO */ <nextTypeIdx>   0    </nextTypeIdx>
+/*TODO */ <nextFuncIdx>   0    </nextFuncIdx>
+/*TODO */ <nextGlobalIdx> 0    </nextGlobalIdx>
+/*TODO */ <types>         .Map </types>
+/*TODO */ <funcIndices>   .Map </funcIndices> //this is mapping from index to address
+/*TODO */ <tabIndices>    .Map </tabIndices>
+/*TODO */ <memIndices>    .Map </memIndices>
+/*TODO */ <globalIndices> .Map </globalIndices>
+/*TODO */ <exports>       .Map </exports>
+        </moduleInst>
+      </moduleInstances>
+      <moduleIds> .Map </moduleIds>
+      <nextModuleIdx> 0 </nextModuleIdx>
+      <moduleRegistry> .Map </moduleRegistry>
       <mainStore>
         <nextFuncAddr> 0 </nextFuncAddr>
         <funcs>
@@ -70,10 +77,6 @@ Configuration
           </globalInst>
         </globals>
       </mainStore>
-      <moduleIds> .Map </moduleIds>
-      <nextModuleIdx> 0 </nextModuleIdx>
-      <moduleInstances> .Map </moduleInstances>
-      <moduleRegistry> .Map </moduleRegistry>
 ```
 
 ### Assumptions and invariants

--- a/wasm.md
+++ b/wasm.md
@@ -1214,7 +1214,8 @@ After a module is instantiated, it should be saved somewhere.
 How this is done is up to the embedder.
 
 ```k
-   syntax Stmt ::= "#storeInstance"
+    syntax Stmt ::= "#storeInstance"
+ // --------------------------------
 ```
 
 ```k

--- a/wasm.md
+++ b/wasm.md
@@ -23,7 +23,7 @@ Configuration
       <nextFreshId> 0 </nextFreshId>
       <moduleInstances>
         <moduleInst multiplicity="*" type="Map">
-/*TODO */ <modIdx>        0    </modIdx>
+          <modIdx>        0    </modIdx>
 /*TODO */ <typeIds>       .Map </typeIds>
 /*TODO */ <funcIds>       .Map </funcIds> //this is mapping from identifier to index
 /*TODO */ <nextTypeIdx>   0    </nextTypeIdx>
@@ -1197,11 +1197,11 @@ Start Function
          <funcIndices> ... #ContextLookup(IDS , TFIDX) |-> FADDR ... </funcIndices>
 ```
 
-Module Declaration
-------------------
+Module Instantiation
+--------------------
 
-Currently, we support a single module.
-The surrounding `module` tag is discarded, and the inner portions are run like they are instructions.
+A new module instance gets allocated.
+Then, the surrounding `module` tag is discarded, and the definitions are executed, putting them into the module currently being defined.
 
 ```k
     syntax Stmt ::= "(" "module" Defns ")"
@@ -1211,16 +1211,32 @@ The surrounding `module` tag is discarded, and the inner portions are run like t
     rule <k> ( module ID:Identifier DEFNS ) => ( module DEFNS ) ... </k>
          <moduleIds> ... .Map => ID |-> NEXT ... </moduleIds>
          <nextModuleIdx> NEXT </nextModuleIdx>
-    rule <k> ( module DEFNS ) => DEFNS ~> #storeInstance ... </k>
+    rule <k> ( module DEFNS ) => DEFNS ... </k>
+         <curModIdx> _ => NEXT </curModIdx>
+         <nextModuleIdx> NEXT => NEXT +Int 1 </nextModuleIdx>
+         <moduleInstances>
+           (.Bag =>
+             <moduleInst>
+               <modIdx>        NEXT    </modIdx>
+               <typeIds>       .Map </typeIds>
+               <funcIds>       .Map </funcIds>
+               <nextTypeIdx>   0    </nextTypeIdx>
+               <nextFuncIdx>   0    </nextFuncIdx>
+               <nextGlobalIdx> 0    </nextGlobalIdx>
+               <types>         .Map </types>
+               <funcIndices>   .Map </funcIndices>
+               <tabIndices>    .Map </tabIndices>
+               <memIndices>    .Map </memIndices>
+               <globalIndices> .Map </globalIndices>
+               <exports>       .Map </exports>
+             </moduleInst>
+           )
+           ...
+         </moduleInstances>
 ```
 
 After a module is instantiated, it should be saved somewhere.
 How this is done is up to the embedder.
-
-```k
-    syntax Stmt ::= "#storeInstance"
- // --------------------------------
-```
 
 ```k
 endmodule

--- a/wasm.md
+++ b/wasm.md
@@ -1203,7 +1203,14 @@ The surronding `module` tag is discarded, and the inner portions are run like th
 ```k
     syntax Stmt ::= "(" "module" Defns ")"
  // --------------------------------------
-    rule <k> ( module DEFNS ) => DEFNS ... </k>
+    rule <k> ( module DEFNS ) => DEFNS ~> #storeInstance ... </k>
+```
+
+After a module is instantiated, it should be saved somewhere.
+How this is done is up to the embedder.
+
+```k
+   syntax Stmt ::= "#storeInstance"
 ```
 
 ```k

--- a/wasm.md
+++ b/wasm.md
@@ -1333,6 +1333,32 @@ Then, the surrounding `module` tag is discarded, and the definitions are execute
          </moduleInstances>
 ```
 
+Note that we want to always have a module available, for execution Statements outside of modules.
+We do this with a small hack to ensure that a first module is always created when needed, if not available.
+
+```k
+    rule <curModIdx> _ => NEXT </curModIdx>
+         <nextModuleIdx> NEXT => NEXT +Int 1 </nextModuleIdx>
+         <moduleInstances>
+           (.Bag =>
+             <moduleInst>
+               <modIdx>        NEXT    </modIdx>
+               <typeIds>       .Map </typeIds>
+               <funcIds>       .Map </funcIds>
+               <nextTypeIdx>   0    </nextTypeIdx>
+               <nextFuncIdx>   0    </nextFuncIdx>
+               <nextGlobalIdx> 0    </nextGlobalIdx>
+               <types>         .Map </types>
+               <funcIndices>   .Map </funcIndices>
+               <tabIndices>    .Map </tabIndices>
+               <memIndices>    .Map </memIndices>
+               <globalIndices> .Map </globalIndices>
+               <exports>       .Map </exports>
+             </moduleInst>
+           )
+         </moduleInstances>
+```
+
 After a module is instantiated, it should be saved somewhere.
 How this is done is up to the embedder.
 

--- a/wasm.md
+++ b/wasm.md
@@ -1306,10 +1306,10 @@ Then, the surrounding `module` tag is discarded, and the definitions are execute
     syntax Stmt ::= "(" "module" Defns ")"
                   | "(" "module" Identifier Defns ")"
  // -------------------------------------------------
- // Map the given id to the next available module number, and then define the module as usual.
     rule <k> ( module ID:Identifier DEFNS ) => ( module DEFNS ) ... </k>
          <moduleIds> ... .Map => ID |-> NEXT ... </moduleIds>
          <nextModuleIdx> NEXT </nextModuleIdx>
+
     rule <k> ( module DEFNS ) => DEFNS ... </k>
          <curModIdx> _ => NEXT </curModIdx>
          <nextModuleIdx> NEXT => NEXT +Int 1 </nextModuleIdx>

--- a/wasm.md
+++ b/wasm.md
@@ -710,9 +710,10 @@ Type could be declared explicitly and could optionally bind with an identifier.
          <moduleInst>
            <modIdx> CUR </modIdx>
            <nextTypeIdx> NEXTIDX => NEXTIDX +Int 1 </nextTypeIdx>
-           <types>       TYPES   => TYPES [NEXTIDX <- asFuncType(TDECLS)]   </types>
+           <types>       TYPES   => TYPES [NEXTIDX <- asFuncType(TDECLS)] </types>
            ...
          </moduleInst>
+
     rule <k> (type ID:Identifier (func TDECLS:TypeDecls)) => . ... </k>
          <curModIdx> CUR </curModIdx>
          <moduleInst>
@@ -992,7 +993,7 @@ Currently, only one memory may be accessible to a module, and thus the `<mAddr>`
            <memIndices> MAP </memIndices>
            ...
          </moduleInst>
-         requires MAP =/=K .Map
+      requires MAP =/=K .Map
 
     rule <k> memory { MIN MAX } => . ... </k>
          <curModIdx> CUR </curModIdx>
@@ -1313,20 +1314,10 @@ Then, the surrounding `module` tag is discarded, and the definitions are execute
          <curModIdx> _ => NEXT </curModIdx>
          <nextModuleIdx> NEXT => NEXT +Int 1 </nextModuleIdx>
          <moduleInstances>
-           (.Bag =>
-             <moduleInst>
-               <modIdx>        NEXT    </modIdx>
-               <typeIds>       .Map </typeIds>
-               <funcIds>       .Map </funcIds>
-               <nextTypeIdx>   0    </nextTypeIdx>
-               <nextFuncIdx>   0    </nextFuncIdx>
-               <nextGlobalIdx> 0    </nextGlobalIdx>
-               <types>         .Map </types>
-               <funcIndices>   .Map </funcIndices>
-               <tabIndices>    .Map </tabIndices>
-               <memIndices>    .Map </memIndices>
-               <globalIndices> .Map </globalIndices>
-               <exports>       .Map </exports>
+           ( .Bag
+          => <moduleInst>
+               <modIdx> NEXT </modIdx>
+               ...
              </moduleInst>
            )
            ...

--- a/wasm.md
+++ b/wasm.md
@@ -1333,32 +1333,6 @@ Then, the surrounding `module` tag is discarded, and the definitions are execute
          </moduleInstances>
 ```
 
-Note that we want to always have a module available, for execution Statements outside of modules.
-We do this with a small hack to ensure that a first module is always created when needed, if not available.
-
-```k
-    rule <curModIdx> _ => NEXT </curModIdx>
-         <nextModuleIdx> NEXT => NEXT +Int 1 </nextModuleIdx>
-         <moduleInstances>
-           (.Bag =>
-             <moduleInst>
-               <modIdx>        NEXT    </modIdx>
-               <typeIds>       .Map </typeIds>
-               <funcIds>       .Map </funcIds>
-               <nextTypeIdx>   0    </nextTypeIdx>
-               <nextFuncIdx>   0    </nextFuncIdx>
-               <nextGlobalIdx> 0    </nextGlobalIdx>
-               <types>         .Map </types>
-               <funcIndices>   .Map </funcIndices>
-               <tabIndices>    .Map </tabIndices>
-               <memIndices>    .Map </memIndices>
-               <globalIndices> .Map </globalIndices>
-               <exports>       .Map </exports>
-             </moduleInst>
-           )
-         </moduleInstances>
-```
-
 After a module is instantiated, it should be saved somewhere.
 How this is done is up to the embedder.
 

--- a/wasm.md
+++ b/wasm.md
@@ -1198,7 +1198,7 @@ Module Declaration
 ------------------
 
 Currently, we support a single module.
-The surronding `module` tag is discarded, and the inner portions are run like they are instructions.
+The surrounding `module` tag is discarded, and the inner portions are run like they are instructions.
 
 ```k
     syntax Stmt ::= "(" "module" Defns ")"

--- a/wasm.md
+++ b/wasm.md
@@ -852,11 +852,11 @@ Unlike labels, only one frame can be "broken" through at a time.
          <locals> LOCAL => .Map </locals>
          <curModIdx> MODIDX => MODIDX' </curModIdx>
          <funcDef>
-           <fAddr>   FADDR                     </fAddr>
-           <fCode>   INSTRS                    </fCode>
-           <fType>   [ TDOMAIN ] -> [ TRANGE ] </fType>
-           <fLocal>  [ TLOCALS ]               </fLocal>
-           <fModIdx> MODIDX'                   </fModIdx>
+           <fAddr>    FADDR                     </fAddr>
+           <fCode>    INSTRS                    </fCode>
+           <fType>    [ TDOMAIN ] -> [ TRANGE ] </fType>
+           <fLocal>   [ TLOCALS ]               </fLocal>
+           <fModInst> MODIDX'                   </fModInst>
            ...
          </funcDef>
 

--- a/wasm.md
+++ b/wasm.md
@@ -1204,6 +1204,7 @@ The surrounding `module` tag is discarded, and the inner portions are run like t
     syntax Stmt ::= "(" "module" Defns ")"
                   | "(" "module" Identifier Defns ")"
  // -------------------------------------------------
+ // Map the given id to the next available module number, and then define the module as usual.
     rule <k> ( module ID:Identifier DEFNS ) => ( module DEFNS ) ... </k>
          <moduleIds> ... .Map => ID |-> NEXT ... </moduleIds>
          <nextModuleIdx> NEXT </nextModuleIdx>

--- a/wasm.md
+++ b/wasm.md
@@ -837,7 +837,6 @@ Here, we allow for an "abstract" function declaration using syntax `func_::___`,
                <fType>    asFuncType  ( TYPEIDS, TYPES, TUSE ) </fType>
                <fLocal>   asLocalType ( LDECLS )               </fLocal>
                <fModInst> CUR                                  </fModInst>
-               ...
              </funcDef>
            )
            ...
@@ -875,7 +874,6 @@ Unlike labels, only one frame can be "broken" through at a time.
            <fType>    [ TDOMAIN ] -> [ TRANGE ] </fType>
            <fLocal>   [ TLOCALS ]               </fLocal>
            <fModInst> MODIDX'                   </fModInst>
-           ...
          </funcDef>
 
     syntax Instr ::= "(" "return" ")"
@@ -908,17 +906,22 @@ Unlike labels, only one frame can be "broken" through at a time.
  // -------------------------------------------------------
     rule <k> ( call_indirect TUSE:TypeUse IS:Instrs ) => IS ~> ( call_indirect TUSE ) ... </k>
     rule <k> ( call_indirect TUSE:TypeUse           ) => ( invoke FADDR )             ... </k>
-         <typeIds> TYPEIDS </typeIds>
-         <types>   TYPES   </types>
+         <curModIdx> CUR </curModIdx>
          <valstack> < i32 > IDX : VALSTACK => VALSTACK </valstack>
-         <tabIndices> 0 |-> ADDR </tabIndices>
+         <moduleInst>
+           <modIdx> CUR </modIdx>
+           <typeIds> TYPEIDS </typeIds>
+           <types> TYPES </types>
+           <tabIndices> 0 |-> ADDR </tabIndices>
+           <funcIds> IDS </funcIds>
+           <funcIndices> ... #ContextLookup(IDS , TFIDX) |-> FADDR ... </funcIndices>
+           ...
+         </moduleInst>
          <tabInst>
            <tAddr> ADDR </tAddr>
            <tdata> ... IDX |-> TFIDX ... </tdata>
            ...
          </tabInst>
-         <funcIds> IDS </funcIds>
-         <funcIndices> ... #ContextLookup(IDS , TFIDX) |-> FADDR ... </funcIndices>
          <funcDef>
            <fAddr> FADDR </fAddr>
            <fType> FTYPE </fType>
@@ -1307,8 +1310,13 @@ A table index is optional and will be default to zero.
     rule <k> ( elem TABIDX (offset IS) ELEMSEGMENT ) => IS ~> elem { TABIDX ELEMSEGMENT } ... </k>
 
     rule <k> elem { TABIDX ELEMSEGMENT } => #initElements ( ADDR, OFFSET, ELEMSEGMENT ) ... </k>
+         <curModIdx> CUR </curModIdx>
          <valstack> < i32 > OFFSET : STACK => STACK </valstack>
-         <tabIndices> TABIDX |-> ADDR </tabIndices>
+         <moduleInst>
+           <modIdx> CUR </modIdx>
+           <tabIndices> TABIDX |-> ADDR </tabIndices>
+           ...
+         </moduleInst>
 
     rule <k> #initElements ( ADDR, OFFSET, .ElemSegment ) => . ... </k>
     rule <k> #initElements ( ADDR, OFFSET,  E ES        ) => #initElements ( ADDR, OFFSET +Int 1, ES ) ... </k>


### PR DESCRIPTION
We will need this for imports.

I started working on adding more `Auxil` instructions from the official interpreter and started with `register`. This way of storing allocated modules is roughly what we discussed, IIRC.

One thing I want to discuss is whether we want to have a separate "embedder" module, which would imitate the reference interpreter, and have `test.md` be our own tests, that could optionally be discarded after we pass the official tests. Now I'm keeping them in the same file, which seems wrong. But that refactoring can be done at a later point.

I'd argue this fixes #99, because that issue is mostly about registering modules. We haven't started on imports yet, but I conjecture they would be pretty straightforward with this configuration.