### PR TITLE
Table initialization and call_indirect

### DIFF
--- a/data.md
+++ b/data.md
@@ -40,10 +40,15 @@ Also we use `#freshId ( Int )` to generate a fresh identifier based on the eleme
 ### Text Format Indices
 
 Indices in the text format could be either an `address` or an `identifier.
+When we are initializing a table with element segment, we need to define a list of Text Format Indices and calculate the length of it.
 
 ```k
     syntax TextFormatIdx ::= Int | Identifier
- // -----------------------------------------
+    syntax ElemSegment   ::= List{TextFormatIdx, ""}
+    syntax Int ::= #lengthElemSegment (ElemSegment) [function]
+ // ----------------------------------------------------------
+    rule #lengthElemSegment(.ElemSegment) => 0
+    rule #lengthElemSegment(TFIDX     ES) => 1 +Int #lengthElemSegment(ES)
 ```
 
 WebAssembly Types

--- a/data.md
+++ b/data.md
@@ -44,7 +44,7 @@ When we are initializing a table with element segment, we need to define a list 
 
 ```k
     syntax TextFormatIdx ::= Int | Identifier
-    syntax ElemSegment   ::= List{TextFormatIdx, ""}
+    syntax ElemSegment   ::= List{TextFormatIdx, ""} [klabel(listTextFormatIdx)]
     syntax Int ::= #lengthElemSegment (ElemSegment) [function]
  // ----------------------------------------------------------
     rule #lengthElemSegment(.ElemSegment) => 0

--- a/test.md
+++ b/test.md
@@ -179,9 +179,9 @@ This asserts related operation about tables.
            ...
          </tabs>
 
-    syntax Assertion ::= "#assertTableData" "(" Int "," Int ")" String
+    syntax Assertion ::= "#assertTableElem" "(" Int "," Int ")" String
  // ------------------------------------------------------------------
-    rule <k> #assertTableData (KEY , VAL) MSG => . ... </k>
+    rule <k> #assertTableElem (KEY , VAL) MSG => . ... </k>
          <tabIndices> 0 |-> ADDR </tabIndices>
          <tabs>
            <tabInst>

--- a/test.md
+++ b/test.md
@@ -179,8 +179,8 @@ This asserts related operation about tables.
            ...
          </tabs>
 
-    syntax Assertion ::= "#assertTableElem" "(" Int "," Int ")" String
- // ------------------------------------------------------------------
+    syntax Assertion ::= "#assertTableElem" "(" Int "," TextFormatIdx ")" String
+ // ----------------------------------------------------------------------------
     rule <k> #assertTableElem (KEY , VAL) MSG => . ... </k>
          <tabIndices> 0 |-> ADDR </tabIndices>
          <tabs>

--- a/test.md
+++ b/test.md
@@ -178,6 +178,19 @@ This asserts related operation about tables.
            )
            ...
          </tabs>
+
+    syntax Assertion ::= "#assertTableData" "(" Int "," Int ")" String
+ // ------------------------------------------------------------------
+    rule <k> #assertTableData (KEY , VAL) MSG => . ... </k>
+         <tabIndices> 0 |-> ADDR </tabIndices>
+         <tabs>
+           <tabInst>
+             <tAddr> ADDR </tAddr>
+             <tdata> ...  KEY |-> VAL => .Map ... </tdata>
+               ...
+           </tabInst>
+           ...
+         </tabs>
 ```
 
 ### Memory Assertions

--- a/tests/simple/table.wast
+++ b/tests/simple/table.wast
@@ -7,4 +7,16 @@
 ( table 14 21 funcref )
 #assertEmptyTable 14 21 "table initial 3"
 
+( table funcref (elem $f $g $k))
+#assertTableElem (0, $f) "table elem 0"
+#assertTableElem (1, $g) "table elem 1"
+#assertTableElem (2, $k) "table elem 2"
+#assertEmptyTable 3 3 "should be empty now"
+
+( table 4 funcref)
+(elem 0 (i32.const 1) $f $g)
+#assertTableElem (1, $f) "table elem 1"
+#assertTableElem (2, $g) "table elem 2"
+#assertEmptyTable 4 .MaxBound "should be empty now"
+
 #clearModules

--- a/tests/simple/table.wast
+++ b/tests/simple/table.wast
@@ -19,4 +19,39 @@
 #assertTableElem (2, $g) "table elem 2"
 #assertEmptyTable 4 .MaxBound "should be empty now"
 
+(module
+  (type $out-i32 (func (result i32)))
+  (table 10 funcref)
+  (elem (i32.const 8) $const-i32-a)
+  (elem (i32.const 9) $const-i32-b)
+  (func $const-i32-a (type $out-i32) (i32.const 65))
+  (func $const-i32-b (type $out-i32) (i32.const 66))
+  (func (export "call-7") (type $out-i32)
+    (call_indirect (type $out-i32) (i32.const 7))
+  )
+  (func (export "call-8") (type $out-i32)
+    (call_indirect (type $out-i32) (i32.const 8))
+  )
+  (func (export "call-9") (type $out-i32)
+    (call_indirect (type $out-i32) (i32.const 9))
+  )
+)
+
+(invoke "call-8")
+
+#assertTopStack < i32> 65 "call_indirect_result1"
+
+(invoke "call-9")
+
+#assertTopStack < i32> 66 "call_indirect_result2"
+
+#assertFunction $const-i32-a [ ] -> [ i32 ] [ ] "call function 1 exists"
+#assertFunction $const-i32-b [ ] -> [ i32 ] [ ] "call function 2 exists"
+#assertFunction 2 [ ] -> [ i32 ] [ ] "call function 3 exists"
+#assertFunction 3 [ ] -> [ i32 ] [ ] "call function 4 exists"
+#assertFunction 4 [ ] -> [ i32 ] [ ] "call function 5 exists"
+#assertTableElem (8, $const-i32-a) "table elem 8"
+#assertTableElem (9, $const-i32-b) "table elem 9"
+#assertEmptyTable 10 .MaxBound "should be empty now"
+
 #clearModules

--- a/tests/simple/table.wast
+++ b/tests/simple/table.wast
@@ -1,10 +1,10 @@
-( table )
+( table funcref )
 #assertEmptyTable 0 .MaxBound "table initial 1"
 
-( table 4)
+( table 4 funcref)
 #assertEmptyTable 4 .MaxBound "table initial 2"
 
-( table 14 21 )
+( table 14 21 funcref )
 #assertEmptyTable 14 21 "table initial 3"
 
 #clearModules

--- a/wasm.md
+++ b/wasm.md
@@ -873,6 +873,7 @@ The only allowed `TableElemType` is "funcref", so we ignore this term in the red
     syntax TableDefn ::= "(" "table"                  TableElemType ")"
                        | "(" "table"     Int          TableElemType ")" // Size only
                        | "(" "table"     Int Int      TableElemType ")" // Min and max.
+                       | "(" "table" "(" "elem" ElemSegment ")" ")"
                        |     "table" "{" Int MaxBound "}"
  // -----------------------------------------------------
     rule <k> ( table                 funcref )       => table { 0   .MaxBound } ... </k>
@@ -881,6 +882,9 @@ The only allowed `TableElemType` is "funcref", so we ignore this term in the red
     rule <k> ( table MIN:Int MAX:Int funcref )       => table { MIN MAX       } ... </k>
       requires MIN <=Int #maxTableSize()
        andBool MAX <=Int #maxTableSize()
+    rule <k> ( table ( elem ES ) )
+          =>  table { #lengthElemSegment(ES) #lengthElemSegment(ES) }
+          ~> ( elem (i32.const 0) ES ) ... </k>
 
     rule <k> table { _ _ } => trap ... </k>
          <tabIndices> MAP </tabIndices> requires MAP =/=K .Map

--- a/wasm.md
+++ b/wasm.md
@@ -856,26 +856,29 @@ Now it contains only Function exports. The exported functions should be able to 
 Table
 -----
 
-When implementing a table, we need a `FuncElem` type to define the type of elements inside a `tableinst`.
+When implementing a table, we first need to define the `TableElemType` type to define the type of elements inside a `tableinst`.
+Currently there is only one possiblt value for it which is "funcref".
 
 ```k
-    syntax FuncElem ::= ".FuncElem" | Int
- // -------------------------------------
+    syntax TableElemType ::= "funcref"
+ // ----------------------------------
 ```
 
-The allocation of a new `tableinst`. Currently at most one table may be defined or imported in a single module.
+The allocation of a new `tableinst`.
+Currently at most one table may be defined or imported in a single module.
+The only allowed `TableElemType` is "funcref", so we ignore this term in the reducted sort.
 
 ```k
     syntax Defn      ::= TableDefn
-    syntax TableDefn ::= "(" "table"                  ")"
-                       | "(" "table"     Int          ")" // Size only
-                       | "(" "table"     Int Int      ")" // Min and max.
-                       |     "table" "{" Int MaxBound "}"
- // -----------------------------------------------------
-    rule <k> ( table                 )       => table { 0   .MaxBound } ... </k>
-    rule <k> ( table MIN:Int         ):Defn  => table { MIN .MaxBound } ... </k>
+    syntax TableDefn ::= "(" "table"                  TableElemType ")"
+                       | "(" "table"     Int          TableElemType ")" // Size only
+                       | "(" "table"     Int Int      TableElemType ")" // Min and max.
+                       |     "table" "{" Int MaxBound TableElemType "}"
+ // -------------------------------------------------------------------
+    rule <k> ( table                 funcref )       => table { 0   .MaxBound } ... </k>
+    rule <k> ( table MIN:Int         funcref ):Defn  => table { MIN .MaxBound } ... </k>
       requires MIN <=Int #maxTableSize()
-    rule <k> ( table MIN:Int MAX:Int )       => table { MIN MAX       } ... </k>
+    rule <k> ( table MIN:Int MAX:Int funcref )       => table { MIN MAX       } ... </k>
       requires MIN <=Int #maxTableSize()
        andBool MAX <=Int #maxTableSize()
 

--- a/wasm.md
+++ b/wasm.md
@@ -925,7 +925,9 @@ The only allowed `TableElemType` is "funcref", so we ignore this term in the red
        andBool MAX <=Int #maxTableSize()
     rule <k> ( table funcref ( elem ES ) )
           =>  table { #lengthElemSegment(ES) #lengthElemSegment(ES) }
-          ~> ( elem (i32.const 0) ES ) ... </k>
+          ~> ( elem (i32.const 0) ES )
+          ...
+         </k>
 
     rule <k> table { _ _ } => trap ... </k>
          <tabIndices> MAP </tabIndices> requires MAP =/=K .Map
@@ -1211,6 +1213,7 @@ A table index is optional and will be default to zero.
     rule <k> elem { TABIDX ELEMSEGMENT } => #initElements ( ADDR, OFFSET, ELEMSEGMENT ) ... </k>
          <valstack> < i32 > OFFSET : STACK => STACK </valstack>
          <tabIndices> TABIDX |-> ADDR </tabIndices>
+
     rule <k> #initElements ( ADDR, OFFSET, .ElemSegment ) => . ... </k>
     rule <k> #initElements ( ADDR, OFFSET,  E ES        ) => #initElements ( ADDR, OFFSET +Int 1, ES ) ... </k>
          <tabInst>

--- a/wasm.md
+++ b/wasm.md
@@ -841,6 +841,30 @@ Unlike labels, only one frame can be "broken" through at a time.
          <funcIndices> ... #ContextLookup(IDS , TFIDX) |-> FADDR ... </funcIndices>
 ```
 
+```k
+    syntax Instr ::= "(" "call_indirect" TypeUse ")"
+    syntax Instr ::= "(" "call_indirect" TypeUse Instrs ")"
+ // -------------------------------------------------------
+    rule <k> ( call_indirect TUSE:TypeUse IS:Instrs ) => IS ~> ( call_indirect TUSE ) ... </k>
+    rule <k> ( call_indirect TUSE:TypeUse           ) => ( invoke FADDR )             ... </k>
+         <typeIds> TYPEIDS </typeIds>
+         <types>   TYPES   </types>
+         <valstack> < i32 > IDX : VALSTACK => VALSTACK </valstack>
+         <tabIndices> 0 |-> ADDR </tabIndices>
+         <tabInst>
+           <tAddr> ADDR </tAddr>
+           <tdata> ... IDX |-> TFIDX ... </tdata>
+           ...
+         </tabInst>
+         <funcIds> IDS </funcIds>
+         <funcIndices> ... #ContextLookup(IDS , TFIDX) |-> FADDR ... </funcIndices>
+         <funcDef>
+           <fAddr> FADDR </fAddr>
+           <fType> FTYPE </fType>
+           ...
+         </funcDef> requires asFuncType(TYPEIDS, TYPES, TUSE) ==K FTYPE
+```
+
 ### Export
 
 Now it contains only Function exports. The exported functions should be able to called using `invoke String` by its assigned name.

--- a/wasm.md
+++ b/wasm.md
@@ -926,7 +926,7 @@ Currently, only one memory may be accessible to a module, and thus the `<mAddr>`
        andBool MAX <=Int #maxMemorySize()
     rule <k> ( memory ( data DS ) )
           =>  memory { #lengthDataPages(DS) #lengthDataPages(DS) }
-          ~> ( data (i32.const 0) .Instrs DS ) ... </k>
+          ~> ( data (i32.const 0) DS ) ... </k>
       requires #lengthDataPages(DS) <=Int #maxMemorySize()
 
     rule <k> memory { _ _ } => trap ... </k>
@@ -1141,8 +1141,8 @@ This is not optional.
 The offset can either be specified explicitly with the `offset` key word, or be a single instruction.
 
 ```k
-    syntax Offset ::= "(" "offset" Instrs ")"
-                    | Instrs
+    syntax Offset ::= "(" "offset" Instr ")"
+                    | Instr
 ```
 
 ### Element Segments
@@ -1161,7 +1161,7 @@ A table index is optional and will be default to zero.
  // --------------------------------------------------------------------------
     // Default to table with index 0.
     rule <k> ( elem        OFFSET      FUNCINDICES ) =>     ( elem 0 OFFSET FUNCINDICES ) ... </k>
-    rule <k> ( elem TABIDX IS:Instrs   FUNCINDICES ) => IS ~> elem { TABIDX FUNCINDICES } ... </k>
+    rule <k> ( elem TABIDX IS:Instr    FUNCINDICES ) => IS ~> elem { TABIDX FUNCINDICES } ... </k>
     rule <k> ( elem TABIDX (offset IS) FUNCINDICES ) => IS ~> elem { TABIDX FUNCINDICES } ... </k>
 
     rule <k> elem { TABIDX FUNCINDICES } => #initElements ( ADDR, OFFSET, FUNCINDICES ) ... </k>
@@ -1189,7 +1189,7 @@ The `data` initializer simply puts these bytes into the specified memory, starti
  // -----------------------------------------------------------------------
     // Default to memory 0.
     rule <k> ( data       OFFSET      STRINGS ) =>     ( data 0 OFFSET STRINGS ) ... </k>
-    rule <k> ( data MEMID IS:Instrs   STRINGS ) => IS ~> data { MEMID  STRINGS } ... </k>
+    rule <k> ( data MEMID IS:Instr    STRINGS ) => IS ~> data { MEMID  STRINGS } ... </k>
     rule <k> ( data MEMID (offset IS) STRINGS ) => IS ~> data { MEMID  STRINGS } ... </k>
 
     // For now, deal only with memory 0.

--- a/wasm.md
+++ b/wasm.md
@@ -873,8 +873,8 @@ The only allowed `TableElemType` is "funcref", so we ignore this term in the red
     syntax TableDefn ::= "(" "table"                  TableElemType ")"
                        | "(" "table"     Int          TableElemType ")" // Size only
                        | "(" "table"     Int Int      TableElemType ")" // Min and max.
-                       |     "table" "{" Int MaxBound TableElemType "}"
- // -------------------------------------------------------------------
+                       |     "table" "{" Int MaxBound "}"
+ // -----------------------------------------------------
     rule <k> ( table                 funcref )       => table { 0   .MaxBound } ... </k>
     rule <k> ( table MIN:Int         funcref ):Defn  => table { MIN .MaxBound } ... </k>
       requires MIN <=Int #maxTableSize()


### PR DESCRIPTION
`elem` is used to add new elements to an empty table (just like the official test cases).
`call_indirect` is used to call a function in a table, with the index at the top of the stack.

The newly added test case is copied from /tests/wasm-tests/test/core/elem.wast.