### PR TITLE
Put trap semantics into WASM module now that we can do it properly

### DIFF
--- a/test.md
+++ b/test.md
@@ -26,8 +26,7 @@ Assertions
 These assertions will check the supplied property, and then clear that state from the configuration.
 In this way, tests can be written as a serious of setup, execute, assert cycles which leaves the configuration empty on success.
 
-We'll make `Assertion` a subsort of `Auxil`, so that we can easily consume `Instr` with `trap`s, but not consume `Assertion`s.
-This will allow `trap` to "bubble up" (more correctly, to "consume the continuation") until it reaches its paired `#assertTrap_` statement.
+We'll make `Assertion` a subsort of `Auxil`, since it is a form of top-level embedder instrucion.
 
 ```k
     syntax Auxil ::= Assertion

--- a/test.md
+++ b/test.md
@@ -18,6 +18,7 @@ This subsort contains Auxiliary functions that only used in our KWASM semantics 
 
 ```k
     syntax Stmt ::= Auxil
+ // ---------------------
 ```
 
 Assertions
@@ -30,6 +31,7 @@ We'll make `Assertion` a subsort of `Auxil`, since it is a form of top-level emb
 
 ```k
     syntax Auxil ::= Assertion
+ // --------------------------
 ```
 
 ### Trap Assertion

--- a/test.md
+++ b/test.md
@@ -31,13 +31,6 @@ This will allow `trap` to "bubble up" (more correctly, to "consume the continuat
 
 ```k
     syntax Auxil ::= Assertion
- // --------------------------
-    rule <k> trap ~> (L:Label   => .) ... </k>
-    rule <k> trap ~> (F:Frame   => .) ... </k>
-    rule <k> trap ~> (I:Instr   => .) ... </k>
-    rule <k> trap ~> (IS:Instrs => .) ... </k>
-
-    rule <k> trap ~> (S:Stmt SS:Stmts => S ~> SS) ... </k>
 ```
 
 ### Trap Assertion

--- a/wasm.md
+++ b/wasm.md
@@ -138,7 +138,6 @@ Thus, a `trap` "bubbles up" (more correctly, to "consumes the continuation") unt
     rule <k> trap ~> (IS:Instrs    => .) ... </k>
     rule <k> trap ~> (D:Defn       => .) ... </k>
     rule <k> trap ~> (DS:Defns     => .) ... </k>
-    rule <k> trap ~> ((module  _)  => .) ... </k>
 
     rule <k> trap ~> (S:Stmt SS:Stmts => S ~> SS) ... </k>
 ```

--- a/wasm.md
+++ b/wasm.md
@@ -132,12 +132,12 @@ Thus, a `trap` "bubbles up" (more correctly, to "consumes the continuation") unt
 ```k
     syntax Instr ::= "trap"
  // -----------------------
-    rule <k> trap ~> (L:Label      => .) ... </k>
-    rule <k> trap ~> (F:Frame      => .) ... </k>
-    rule <k> trap ~> (I:Instr      => .) ... </k>
-    rule <k> trap ~> (IS:Instrs    => .) ... </k>
-    rule <k> trap ~> (D:Defn       => .) ... </k>
-    rule <k> trap ~> (DS:Defns     => .) ... </k>
+    rule <k> trap ~> (L:Label   => .) ... </k>
+    rule <k> trap ~> (F:Frame   => .) ... </k>
+    rule <k> trap ~> (I:Instr   => .) ... </k>
+    rule <k> trap ~> (IS:Instrs => .) ... </k>
+    rule <k> trap ~> (D:Defn    => .) ... </k>
+    rule <k> trap ~> (DS:Defns  => .) ... </k>
 
     rule <k> trap ~> (S:Stmt SS:Stmts => S ~> SS) ... </k>
 ```


### PR DESCRIPTION
The fact that `trap` eats up execution is really part of the Wasm semantics. I want to be as principled as possible about the `WASM` module to contain the full Wasm semantics, and to keep embedder stuff located outside. 

Now that we have this nice sort hierarchy, we can finally put `trap` semantics in `WASM`. Do you agree?