### PR TITLE
Conformance assert_return and assert_trap

### DIFF
--- a/data.md
+++ b/data.md
@@ -155,7 +155,7 @@ We also add `token` as a value in order to implement some test assertions.
 ```k
     syntax Val ::= "undefined"
                  | "token"
- // --------------------------
+ // ----------------------
 ```
 
 ### Value Operations

--- a/data.md
+++ b/data.md
@@ -150,9 +150,11 @@ Proper values are numbers annotated with their types.
 ```
 
 We also add `undefined` as a value, which makes many partial functions in the semantics total.
+We also add `token` as a value in order to implement some test assertions.
 
 ```k
     syntax Val ::= "undefined"
+                 | "token"
  // --------------------------
 ```
 

--- a/data.md
+++ b/data.md
@@ -150,12 +150,10 @@ Proper values are numbers annotated with their types.
 ```
 
 We also add `undefined` as a value, which makes many partial functions in the semantics total.
-We also add `token` as a value in order to implement some test assertions.
 
 ```k
     syntax Val ::= "undefined"
-                 | "token"
- // ----------------------
+ // --------------------------
 ```
 
 ### Value Operations

--- a/test.md
+++ b/test.md
@@ -82,6 +82,19 @@ We will reference modules by name in imports.
          <moduleRegistry> ... .Map => S |-> IDX ... </moduleRegistry>
 ```
 
+### Addtional Module Syntax
+
+The conformance test cases contain the syntax of declaring modules in the format of `(module binary <string>*)` and `(module quote <string>*)`. In order to parse the conformance test cases, we handle these declarations here and just reduce them to empty.
+
+**TODO**: Implement `(module binary <string>*)` and put it into `wasm.md`.
+
+```k
+    syntax DefnStrings ::= List{String, ""}
+    syntax ModuleDecl  ::= "(" "module" "quote" DefnStrings ")"
+ // -----------------------------------------------------------
+    rule <k> ( module quote  _ ) => . ... </k>
+```
+
 Assertions for KWasm tests
 --------------------------
 
@@ -109,7 +122,7 @@ Here we inplement the conformance assertions specified in [spec interpreter] inc
   ( assert_trap <module> <failure> )         ;; assert module traps on instantiation
 ```
 
-**TODO**: implement them.
+Except `assert_return` and `assert_trap`, the remaining rules are directly reduced to empty. We are not planning to implement them and these rules are only used to make it easier to parse conformance tests.
 
 ```k
     syntax Assertion ::= "(" "assert_return"                Action     Instr  ")"

--- a/test.md
+++ b/test.md
@@ -82,6 +82,42 @@ We'll make `Assertion` a subsort of `Auxil`, since it is a form of top-level emb
     syntax Auxil ::= Assertion
  // --------------------------
 ```
+### Conformance Assertions
+
+Here we inplement the conformance assertions specified in [spec interpreter] including:
+
+```
+  ( assert_return <action> <expr>* )         ;; assert action has expected results. Sometimes <expr>* is just empty.
+  ( assert_return_canonical_nan <action> )   ;; assert action results in NaN in a canonical form
+  ( assert_return_arithmetic_nan <action> )  ;; assert action results in NaN with 1 in MSB of fraction field
+  ( assert_trap <action> <failure> )         ;; assert action traps with given failure string
+  ( assert_malformed <module> <failure> )    ;; assert module cannot be decoded with given failure string
+  ( assert_invalid <module> <failure> )      ;; assert module is invalid with given failure string
+  ( assert_unlinkable <module> <failure> )   ;; assert module fails to link
+  ( assert_trap <module> <failure> )         ;; assert module traps on instantiation
+```
+
+** TODO **: implement them.
+
+```k
+    syntax Assertion ::= "(" "assert_return"                Action     Instrs ")"
+                       | "(" "assert_return_canonical_nan"  Action            ")"
+                       | "(" "assert_return_arithmetic_nan" Action            ")"
+                       | "(" "assert_trap"                  Action     String ")"
+                       | "(" "assert_malformed"             ModuleDecl String ")"
+                       | "(" "assert_invalid"               ModuleDecl String ")"
+                       | "(" "assert_unlinkable"            ModuleDecl String ")"
+                       | "(" "assert_trap"                  ModuleDecl String ")"
+ // -----------------------------------------------------------------------------
+    rule <k> (assert_return ACT INSTRS)              => ACT ~> INSTRS ... </k>
+    rule <k> (assert_return_canonical_nan  ACT)      => . ... </k>
+    rule <k> (assert_return_arithmetic_nan ACT)      => . ... </k>
+    rule <k> (assert_trap       ACT:Action     DESC) => . ... </k>
+    rule <k> (assert_malformed  MOD            DESC) => . ... </k>
+    rule <k> (assert_invalid    MOD            DESC) => . ... </k>
+    rule <k> (assert_unlinkable MOD            DESC) => . ... </k>
+    rule <k> (assert_trap       MOD:ModuleDecl DESC) => . ... </k>
+```
 
 ### Trap Assertion
 

--- a/test.md
+++ b/test.md
@@ -116,11 +116,11 @@ Here we inplement the conformance assertions specified in [spec interpreter] inc
          <valstack> VALSTACK => token : VALSTACK </valstack>
     rule <k> (assert_return_canonical_nan  ACT)      => . ... </k>
     rule <k> (assert_return_arithmetic_nan ACT)      => . ... </k>
-    rule <k> (assert_trap       ACT:Action     DESC) => . ... </k>
+    rule <k> (assert_trap       ACT:Action     DESC) => ACT ~> #assertTrap DESC ... </k>
     rule <k> (assert_malformed  MOD            DESC) => . ... </k>
     rule <k> (assert_invalid    MOD            DESC) => . ... </k>
     rule <k> (assert_unlinkable MOD            DESC) => . ... </k>
-    rule <k> (assert_trap       MOD:ModuleDecl DESC) => . ... </k>
+    rule <k> (assert_trap       MOD:ModuleDecl DESC) => MOD ~> #assertTrap DESC ... </k>
 ```
 
 And we implement some helper assertions to help testing.

--- a/test.md
+++ b/test.md
@@ -21,6 +21,13 @@ This subsort contains Auxiliary functions that only used in our KWASM semantics 
  // ---------------------
 ```
 
+We also add `token` as a value in order to implement some test assertions.
+
+```k
+    syntax Val ::= "token"
+ // ----------------------
+```
+
 Reference Interpreter Commands
 ------------------------------
 
@@ -36,7 +43,7 @@ We allow 2 kinds of actions:
 -   We allow to `invoke` a function by its exported name.
 -   We allow to `get` a global export.
 
-** TODO **: implement "get".
+**TODO**: implement "get".
 
 ```k
     syntax Auxil  ::= Action
@@ -102,7 +109,7 @@ Here we inplement the conformance assertions specified in [spec interpreter] inc
   ( assert_trap <module> <failure> )         ;; assert module traps on instantiation
 ```
 
-** TODO **: implement them.
+**TODO**: implement them.
 
 ```k
     syntax Assertion ::= "(" "assert_return"                Action     Instr  ")"

--- a/test.md
+++ b/test.md
@@ -100,7 +100,8 @@ Here we inplement the conformance assertions specified in [spec interpreter] inc
 ** TODO **: implement them.
 
 ```k
-    syntax Assertion ::= "(" "assert_return"                Action     Instrs ")"
+    syntax Assertion ::= "(" "assert_return"                Action     Instr  ")"
+                       | "(" "assert_return"                Action            ")"
                        | "(" "assert_return_canonical_nan"  Action            ")"
                        | "(" "assert_return_arithmetic_nan" Action            ")"
                        | "(" "assert_trap"                  Action     String ")"
@@ -109,7 +110,10 @@ Here we inplement the conformance assertions specified in [spec interpreter] inc
                        | "(" "assert_unlinkable"            ModuleDecl String ")"
                        | "(" "assert_trap"                  ModuleDecl String ")"
  // -----------------------------------------------------------------------------
-    rule <k> (assert_return ACT INSTRS)              => ACT ~> INSTRS ... </k>
+    rule <k> (assert_return ACT INSTR)               => ACT ~> INSTR ~> #assertAndRemoveEqual ~> #assertAndRemoveToken ... </k>
+         <valstack> VALSTACK => token : VALSTACK </valstack>
+    rule <k> (assert_return ACT)                     => ACT                                   ~> #assertAndRemoveToken ... </k>
+         <valstack> VALSTACK => token : VALSTACK </valstack>
     rule <k> (assert_return_canonical_nan  ACT)      => . ... </k>
     rule <k> (assert_return_arithmetic_nan ACT)      => . ... </k>
     rule <k> (assert_trap       ACT:Action     DESC) => . ... </k>
@@ -117,6 +121,18 @@ Here we inplement the conformance assertions specified in [spec interpreter] inc
     rule <k> (assert_invalid    MOD            DESC) => . ... </k>
     rule <k> (assert_unlinkable MOD            DESC) => . ... </k>
     rule <k> (assert_trap       MOD:ModuleDecl DESC) => . ... </k>
+```
+
+And we implement some helper assertions to help testing.
+
+```k
+    syntax Assertion ::= "#assertAndRemoveEqual"
+                       | "#assertAndRemoveToken"
+ // --------------------------------------------
+    rule <k> #assertAndRemoveEqual   => #assertTopStack V "" ~> ( drop ) ... </k>
+         <valstack> V : VALSTACK     => VALSTACK </valstack>
+    rule <k> #assertAndRemoveToken   => . ... </k>
+         <valstack> token : VALSTACK => VALSTACK </valstack>
 ```
 
 ### Trap Assertion

--- a/test.md
+++ b/test.md
@@ -29,14 +29,24 @@ TODO: Move this to a separate `EMBEDDER` module?
 The official test suite contains some special auxillary instructions outside of the standard Wasm semantics.
 The reference interpreter is a particular embedder with auxillary instructions, specified in [spec interpreter](https://github.com/WebAssembly/spec/blob/master/interpreter/README.md).
 
-### Function Invocation
+### Actions
 
-We allow to `invoke` a function by its exported name in the test code.
+We allow 2 kinds of actions:
+
+-   We allow to `invoke` a function by its exported name.
+-   We allow to `get` a global export.
+
+** TODO **: implement "get".
 
 ```k
-    syntax Auxil ::= "(" "invoke" String ")"
- // ----------------------------------------
-    rule <k> ( invoke ENAME:String ) => ( call TFIDX ) ... </k>
+    syntax Auxil  ::= Action
+    syntax Action ::= "(" "invoke"         String        ")"
+                    | "(" "invoke"         String Instrs ")"
+                    | "(" "get"            String        ")"
+                    | "(" "get" Identifier String        ")"
+ // --------------------------------------------------------
+    rule <k> ( invoke ENAME:String IS:Instrs ) => IS ~> ( invoke ENAME ) ... </k>
+    rule <k> ( invoke ENAME:String )           => ( call TFIDX )         ... </k>
          <exports> ... ENAME |-> TFIDX ... </exports>
 ```
 

--- a/test.md
+++ b/test.md
@@ -47,7 +47,12 @@ We allow 2 kinds of actions:
  // --------------------------------------------------------
     rule <k> ( invoke ENAME:String IS:Instrs ) => IS ~> ( invoke ENAME ) ... </k>
     rule <k> ( invoke ENAME:String )           => ( call TFIDX )         ... </k>
-         <exports> ... ENAME |-> TFIDX ... </exports>
+         <curModIdx> CUR </curModIdx>
+         <moduleInst>
+           <modIdx> CUR </modIdx>
+           <exports> ... ENAME |-> TFIDX ... </exports>
+           ...
+         </moduleInst>
 ```
 
 ### Registering Modules

--- a/tests/simple/export.wast
+++ b/tests/simple/export.wast
@@ -13,11 +13,8 @@
 )
 ( export "export-1" (func $1) )
 
-(i64.const 100)
-(i64.const 43)
-(i64.const 22)
-(invoke "export-1")
-#assertTopStack < i64 > 35 "call export function export-1"
+(assert_return (invoke "export-1" (i64.const 100) (i64.const 43) (i64.const 22)) (i64.const 35))
+
 #assertFunction $1 [ i64 i64 i64 ] -> [ i64 ] [ i64 ] "call function 1 exists"
 
 ;; test inline export
@@ -27,23 +24,8 @@
     (return)
 )
 
-(i64.const 7)
-(i64.const 8)
-(i32.const 4)
-(call $2)
-#assertTopStack < i32 > 4 "out of order type declaration - call with identifier"
-
-(i64.const 7)
-(i64.const 8)
-(i32.const 3)
-(invoke "cool-align-1")
-#assertTopStack < i32 > 3 "out of order type declaration - call with name"
-
-(i64.const 7)
-(i64.const 8)
-(i32.const 2)
-(invoke "cool-align-2")
-#assertTopStack < i32 > 2 "out of order type declaration - call with name"
+(assert_return (invoke "cool-align-1" (i64.const 7) (i64.const 8) (i32.const 3)) (i32.const 3))
+(assert_return (invoke "cool-align-2" (i64.const 7) (i64.const 8) (i32.const 2)) (i32.const 2))
 
 #assertFunction $2 [ i32 i64 i64 ] -> [ i32 ] [ i32 ] "out of order type declarations"
 
@@ -52,11 +34,7 @@
     (return)
 )
 
-(i64.const 7)
-(i64.const 8)
-(i32.const 1)
-(invoke "export-without-id")
-#assertTopStack < i32 > 1 "export-without-id"
+(assert_return (invoke "export-without-id" (i64.const 7) (i64.const 8) (i32.const 1)) (i32.const 1))
 
 #assertFunction 2 [ i32 i64 i64 ] -> [ i32 ] [ i32 ] "removing a function by its inner index"
 

--- a/tests/simple/functions_call.wast
+++ b/tests/simple/functions_call.wast
@@ -145,7 +145,7 @@
         (local.get 1)
         (i32.xor)
     )
-) 
+)
 
 (assert_return (invoke "add" (i32.const 3) (i32.const 5)) (i32.const 8))
 (assert_return (invoke "mul" (i32.const 3) (i32.const 5)) (i32.const 15))

--- a/tests/simple/functions_call.wast
+++ b/tests/simple/functions_call.wast
@@ -116,11 +116,13 @@
 ;; Function with just a name
 
 (func $3)
+(export "return-null" (func $3) )
+(assert_return (invoke "return-null"))
 
 #assertFunction $3 [ ] -> [ ] [ ] "no domain/range or locals"
 
 (module
-    (func $add
+    (func $add (export "add")
         (param i32 i32)
         (result i32)
         (local.get 0)
@@ -129,7 +131,7 @@
         (return)
     )
 
-    (func $mul
+    (func $mul (export "mul")
         (param i32 i32)
         (result i32)
         (local.get 0)
@@ -143,22 +145,11 @@
         (local.get 1)
         (i32.xor)
     )
-)
+) 
 
-(i32.const 3)
-(i32.const 5)
-(call $add)
-#assertTopStack < i32 > 8 "add in module correctly"
-
-(i32.const 3)
-(i32.const 5)
-(call $mul)
-#assertTopStack < i32 > 15 "mul in module correctly"
-
-(i32.const 3)
-(i32.const 5)
-(call $xor)
-#assertTopStack < i32 > 6 "xor in module correctly"
+(assert_return (invoke "add" (i32.const 3) (i32.const 5)) (i32.const 8))
+(assert_return (invoke "mul" (i32.const 3) (i32.const 5)) (i32.const 15))
+(assert_return (invoke "xor" (i32.const 3) (i32.const 5)) (i32.const 6))
 
 #assertFunction $add [ i32 i32 ] -> [ i32 ] [ ] "add function typed correctly"
 #assertFunction $mul [ i32 i32 ] -> [ i32 ] [ ] "mul function typed correctly"

--- a/tests/simple/modules.wast
+++ b/tests/simple/modules.wast
@@ -23,4 +23,14 @@
 #assertRegistrationNamed "a module name 2" $myMod2 "registration4"
 #assertRegistrationUnnamed "third module name" "registration5"
 
+(assert_malformed
+  (module quote "(func block end $l)")
+  "mismatching label"
+)
+
+(assert_malformed
+  (module quote "(func block $a end $l)")
+  "mismatching label"
+)
+
 #clearConfig

--- a/tests/simple/trap.wast
+++ b/tests/simple/trap.wast
@@ -1,0 +1,32 @@
+(assert_trap
+  (module (func $main (unreachable)) (start $main))
+  "unreachable"
+)
+
+(module
+    (memory 0)
+
+    (func (export "load_at_zero") (result i32) (i32.load (i32.const 0)))
+    (func (export "store_at_zero") (i32.store (i32.const 0) (i32.const 2)))
+)
+
+(assert_trap (invoke "store_at_zero") "out of bounds memory access")
+(assert_trap (invoke "load_at_zero") "out of bounds memory access")
+
+(module
+  (func (export "no_dce.i32.div_s") (param i32) (param i32)
+    (drop (i32.div_s (local.get 0) (local.get 1))))
+  (func (export "no_dce.i32.div_u") (param i32) (param i32)
+    (drop (i32.div_u (local.get 0) (local.get 1))))
+  (func (export "no_dce.i64.div_s") (param i64) (param i64)
+    (drop (i64.div_s (local.get 0) (local.get 1))))
+  (func (export "no_dce.i64.div_u") (param i64) (param i64)
+    (drop (i64.div_u (local.get 0) (local.get 1))))
+)
+
+(assert_trap (invoke "no_dce.i32.div_s" (i32.const 1) (i32.const 0)) "integer divide by zero")
+(assert_trap (invoke "no_dce.i32.div_u" (i32.const 1) (i32.const 0)) "integer divide by zero")
+(assert_trap (invoke "no_dce.i64.div_s" (i64.const 1) (i64.const 0)) "integer divide by zero")
+(assert_trap (invoke "no_dce.i64.div_u" (i64.const 1) (i64.const 0)) "integer divide by zero")
+
+#clearConfig

--- a/tests/simple/trap.wast
+++ b/tests/simple/trap.wast
@@ -15,13 +15,13 @@
 
 (module
   (func (export "no_dce.i32.div_s") (param i32) (param i32)
-    (drop (i32.div_s (local.get 0) (local.get 1))))
+    (drop (i32.div_s (local.get 1) (local.get 0))))
   (func (export "no_dce.i32.div_u") (param i32) (param i32)
-    (drop (i32.div_u (local.get 0) (local.get 1))))
+    (drop (i32.div_u (local.get 1) (local.get 0))))
   (func (export "no_dce.i64.div_s") (param i64) (param i64)
-    (drop (i64.div_s (local.get 0) (local.get 1))))
+    (drop (i64.div_s (local.get 1) (local.get 0))))
   (func (export "no_dce.i64.div_u") (param i64) (param i64)
-    (drop (i64.div_u (local.get 0) (local.get 1))))
+    (drop (i64.div_u (local.get 1) (local.get 0))))
 )
 
 (assert_trap (invoke "no_dce.i32.div_s" (i32.const 1) (i32.const 0)) "integer divide by zero")

--- a/wasm.md
+++ b/wasm.md
@@ -1392,9 +1392,10 @@ A new module instance gets allocated.
 Then, the surrounding `module` tag is discarded, and the definitions are executed, putting them into the module currently being defined.
 
 ```k
-    syntax Stmt ::= "(" "module" Defns ")"
-                  | "(" "module" Identifier Defns ")"
- // -------------------------------------------------
+    syntax Stmt       ::= ModuleDecl
+    syntax ModuleDecl ::= "(" "module" Defns ")"
+                        | "(" "module" Identifier Defns ")"
+ // -------------------------------------------------------
     rule <k> ( module ID:Identifier DEFNS ) => ( module DEFNS ) ... </k>
          <moduleIds> ... .Map => ID |-> NEXT ... </moduleIds>
          <nextModuleIdx> NEXT </nextModuleIdx>


### PR DESCRIPTION
Implemented assert_trap and assert_return.

Added some pretty nice test cases.

We need to notice that assert_return takes an `Action`, and the parameters must be specified inline rather than using separate const instructions before it. (just as conformance test cases)


