### PR TITLE
Instruction refactoring

### DIFF
--- a/data.md
+++ b/data.md
@@ -51,6 +51,14 @@ When we are initializing a table with element segment, we need to define a list 
     rule #lengthElemSegment(TFIDX     ES) => 1 +Int #lengthElemSegment(ES)
 ```
 
+Memories/tables can optionally have a max size which the memory may not grow beyond.
+The sort `MaxBound` provides a potentially "infinite" `Int`.
+
+```k
+    syntax MaxBound ::= Int | ".MaxBound"
+ // -------------------------------------
+```
+
 WebAssembly Types
 -----------------
 

--- a/tests/proofs/simple-arithmetic-spec.k
+++ b/tests/proofs/simple-arithmetic-spec.k
@@ -4,20 +4,20 @@ module SIMPLE-ARITHMETIC-SPEC
     imports WASM
     imports KWASM-LEMMAS
 
-    rule <k> ( ITYPE:IValType . const X:Int ) => . ... </k>
+    rule <k> ITYPE:IValType . const X:Int => . ... </k>
          <valstack> S:ValStack => < ITYPE > X : S </valstack>
       requires #inUnsignedRange(ITYPE, X)
 
-    rule <k> ( ITYPE:IValType . const X:Int ) => . ... </k>
+    rule <k> ITYPE:IValType . const X:Int => . ... </k>
          <valstack> S:ValStack => < ITYPE > (X +Int #pow(ITYPE)) : S </valstack>
       requires (#minSigned(ITYPE) <=Int X) andBool (X <Int 0)
 
-    rule <k> ( ITYPE:IValType . const X:Int ) ( ITYPE . const Y:Int ) => . ... </k>
+    rule <k> ITYPE:IValType . const X:Int ITYPE . const Y:Int => . ... </k>
          <valstack> S:ValStack => < ITYPE > Y : < ITYPE > X : S </valstack>
       requires #inUnsignedRange(ITYPE, X)
        andBool #inUnsignedRange(ITYPE, Y)
 
-    rule <k> ( ITYPE:IValType . const X:Int ) ( ITYPE . const Y:Int ) ( ITYPE . add ) => . ... </k>
+    rule <k> ITYPE:IValType . const X:Int ITYPE . const Y:Int ITYPE . add => . ... </k>
          <valstack> S:ValStack => < ITYPE > (X +Int Y) : S </valstack>
       requires 0 <=Int X andBool 0 <=Int Y
        andBool (X +Int Y) <Int #pow(ITYPE)

--- a/tests/proofs/simple-arithmetic-spec.k
+++ b/tests/proofs/simple-arithmetic-spec.k
@@ -4,37 +4,37 @@ module SIMPLE-ARITHMETIC-SPEC
     imports WASM
     imports KWASM-LEMMAS
 
-    rule <k> ITYPE:IValType . const X:Int => . ... </k>
+    rule <k> (ITYPE:IValType . const X:Int) => . ... </k>
          <valstack> S:ValStack => < ITYPE > X : S </valstack>
       requires #inUnsignedRange(ITYPE, X)
 
-    rule <k> ITYPE:IValType . const X:Int => . ... </k>
+    rule <k> (ITYPE:IValType . const X:Int) => . ... </k>
          <valstack> S:ValStack => < ITYPE > (X +Int #pow(ITYPE)) : S </valstack>
       requires (#minSigned(ITYPE) <=Int X) andBool (X <Int 0)
 
-    rule <k> ITYPE:IValType . const X:Int ITYPE . const Y:Int => . ... </k>
+    rule <k> (ITYPE:IValType . const X:Int) (ITYPE . const Y:Int) => . ... </k>
          <valstack> S:ValStack => < ITYPE > Y : < ITYPE > X : S </valstack>
       requires #inUnsignedRange(ITYPE, X)
        andBool #inUnsignedRange(ITYPE, Y)
 
-    rule <k> ITYPE:IValType . const X:Int ITYPE . const Y:Int ITYPE . add => . ... </k>
+    rule <k> (ITYPE:IValType . const X:Int) (ITYPE . const Y:Int) (ITYPE . add) => . ... </k>
          <valstack> S:ValStack => < ITYPE > (X +Int Y) : S </valstack>
       requires 0 <=Int X andBool 0 <=Int Y
        andBool (X +Int Y) <Int #pow(ITYPE)
 
     rule <k> block [ .ValTypes ]
                  ( loop [ .ValTypes ]
-                     ( local.get 0 )
-                     ( local.get 1 )
-                     ( i32.add )
-                     ( local.set 1 )
-                     ( local.get 0 )
-                     ( i32.const 1 )
-                     ( i32.sub )
-                     ( local.tee 0 )
-                     ( i32.eqz )
-                     ( br_if 1 )
-                     ( br 0 )
+                     (local.get 0)
+                     (local.get 1)
+                     (i32.add)
+                     (local.set 1)
+                     (local.get 0)
+                     (i32.const 1)
+                     (i32.sub)
+                     (local.tee 0)
+                     (i32.eqz)
+                     (br_if 1)
+                     (br 0)
                  )
              end
           => .

--- a/tests/proofs/simple-arithmetic-spec.k
+++ b/tests/proofs/simple-arithmetic-spec.k
@@ -24,17 +24,17 @@ module SIMPLE-ARITHMETIC-SPEC
 
     rule <k> block [ .ValTypes ]
                  ( loop [ .ValTypes ]
-                     local.get 0
-                     local.get 1
-                     i32.add
-                     local.set 1
-                     local.get 0
-                     i32.const 1
-                     i32.sub
-                     local.tee 0
-                     i32.eqz
-                     br_if 1
-                     br 0
+                     ( local.get 0 )
+                     ( local.get 1 )
+                     ( i32.add )
+                     ( local.set 1 )
+                     ( local.get 0 )
+                     ( i32.const 1 )
+                     ( i32.sub )
+                     ( local.tee 0 )
+                     ( i32.eqz )
+                     ( br_if 1 )
+                     ( br 0 )
                  )
              end
           => .

--- a/tests/proofs/simple-arithmetic-spec.k
+++ b/tests/proofs/simple-arithmetic-spec.k
@@ -24,17 +24,17 @@ module SIMPLE-ARITHMETIC-SPEC
 
     rule <k> block [ .ValTypes ]
                  ( loop [ .ValTypes ]
-                     (local.get 0)
-                     (local.get 1)
-                     (i32.add)
-                     (local.set 1)
-                     (local.get 0)
-                     (i32.const 1)
-                     (i32.sub)
-                     (local.tee 0)
-                     (i32.eqz)
-                     (br_if 1)
-                     (br 0)
+                     local.get 0
+                     local.get 1
+                     i32.add
+                     local.set 1
+                     local.get 0
+                     i32.const 1
+                     i32.sub
+                     local.tee 0
+                     i32.eqz
+                     br_if 1
+                     br 0
                  )
              end
           => .

--- a/tests/simple/control-flow.wast
+++ b/tests/simple/control-flow.wast
@@ -128,11 +128,11 @@ end
 ;; Conditional
 
 (i32.const 1)
-(if [ i32 ] (i32.const 1) else (i32.const -1) end)
+if [ i32 ] i32.const 1 else i32.const -1 end
 #assertTopStack < i32 > 1 "if true"
 
 (i32.const 0)
-(if [ i32 ] (i32.const 1) else (i32.const -1) end)
+if [ i32 ] i32.const 1 else i32.const -1 end
 #assertTopStack < i32 > -1 "if false"
 
 (i32.const -1)

--- a/wasm.md
+++ b/wasm.md
@@ -224,6 +224,10 @@ A `UnOp` operator always produces a result of the same type as its operand.
     syntax PlainInstr ::= IValType "." IUnOp
  //                     | FValType "." FUnOp
  // ----------------------------------------
+
+    syntax Instr ::= IValType "." IUnOp Int
+ //                | FValType "." FUnOp Float
+ // -----------------------------------------
     rule <k> ITYPE . UOP:IUnOp => ITYPE . UOP C1 ... </k>
          <valstack> < ITYPE > C1 : VALSTACK => VALSTACK </valstack>
 ```
@@ -241,6 +245,10 @@ A `BinOp` operator always produces a result of the same type as its operands.
     syntax PlainInstr ::= IValType "." IBinOp
  //                     | FValType "." FBinOp
  // -----------------------------------------
+
+    syntax Instr ::= IValType "." IBinOp Int Int
+ //                | FValType "." FBinOp Float Float
+ // ------------------------------------------------
     rule <k> ITYPE . BOP:IBinOp => ITYPE . BOP C1 C2 ... </k>
          <valstack> < ITYPE > C2 : < ITYPE > C1 : VALSTACK => VALSTACK </valstack>
 ```
@@ -252,7 +260,12 @@ Test operations consume one operand and produce a bool, which is an `i32` value.
 
 ```k
     syntax PlainInstr ::= IValType "." ITestOp
+ //                     | FValType "." FTestOp
  // ------------------------------------------
+
+    syntax Instr ::= IValType "." ITestOp Int
+ //                | FValType "." FTestOp Float
+ // -------------------------------------------
     rule <k> ITYPE . TOP:ITestOp => ITYPE . TOP C1 ... </k>
          <valstack> < ITYPE > C1 : VALSTACK => VALSTACK </valstack>
 ```
@@ -270,6 +283,10 @@ Comparisons consume two operands and produce a bool, which is an `i32` value.
     syntax PlainInstr ::= IValType "." IRelOp
  //                     | FValType "." FRelOp
  // -----------------------------------------
+
+    syntax Instr ::= IValType "." IRelOp Int Int
+ //                | FValType "." FRelOp Float Float
+ // ------------------------------------------------
     rule <k> ITYPE . ROP:IRelOp => ITYPE . ROP C1 C2 ... </k>
          <valstack> < ITYPE > C2 : < ITYPE > C1 : VALSTACK => VALSTACK  </valstack>
 ```
@@ -284,32 +301,18 @@ The target type is before the `.`, and the source type is after the `_`.
 
 ```k
     syntax PlainInstr ::= IValType "." ConvOp
+ //                     | FValType "." ConvOp
  // -----------------------------------------
+
+    syntax Instr ::= IValType "." ConvOp Int
+ //                | FValType "." ConvOp Float
+ // ------------------------------------------
     rule <k> ITYPE . CONVOP:ConvOp => ITYPE . CONVOP C1  ... </k>
          <valstack> < SRCTYPE > C1 : VALSTACK => VALSTACK </valstack>
       requires #convSourceType(CONVOP) ==K SRCTYPE
 
     syntax IValType ::= #convSourceType ( ConvOp ) [function]
  // ---------------------------------------------------------
-```
-
-Numeric Operators
------------------
-
-These instructions are reduced to from the plain instructions defined above.
-They take operands as parameters rather than from the `<valstack>` and is used to define the numeric computation rules.
-
-```k
-    syntax Instr  ::= IValType "." IUnOp   Int
-                    | IValType "." IBinOp  Int   Int
-                    | IValType "." ITestOp Int
-                    | IValType "." IRelOp  Int   Int
-                    | IValType "." ConvOp  Int
- //                 | FValType "." FUnOp   Float
- //                 | FValType "." FBinOp  Float Float
- //                 | FValType "." FTestOp Float
- //                 | FValType "." FRelOp  Float Float
- //                 | FValType "." ConvOp  Float
 ```
 
 ### Integer Arithmetic
@@ -699,7 +702,7 @@ The `get` and `set` instructions read and write globals.
 ```k
     syntax PlainInstr ::= "global.get" Int
                         | "global.set" Int
- // --------------------------------------------
+ // --------------------------------------
     rule <k> global.get INDEX => . ... </k>
          <valstack> VALSTACK => VALUE : VALSTACK </valstack>
          <curModIdx> CUR </curModIdx>

--- a/wasm.md
+++ b/wasm.md
@@ -211,12 +211,10 @@ A `UnOp` operator always produces a result of the same type as its operand.
  //               | FUnOp
  // ---------------------
 
-    syntax Instr ::= "(" IValType "." IUnOp ")" | "(" IValType "." IUnOp Instr ")" | IValType "." IUnOp Int
- //                | "(" FValType "." FUnOp ")" | "(" FValType "." FUnOp Instr ")" | FValType "." FUnOp Float
- // ---------------------------------------------------------------------------------------------------------
-    rule <k> ( ITYPE . UOP:IUnOp I:Instr ) => I ~> ( ITYPE . UOP ) ... </k>
-
-    rule <k> ( ITYPE . UOP:IUnOp ) => ITYPE . UOP C1 ... </k>
+    syntax PlainInstr ::= IValType "." IUnOp
+ //                     | FValType "." FUnOp
+ // ----------------------------------------
+    rule <k> ITYPE . UOP:IUnOp => ITYPE . UOP C1 ... </k>
          <valstack> < ITYPE > C1 : VALSTACK => VALSTACK </valstack>
 ```
 
@@ -230,12 +228,10 @@ A `BinOp` operator always produces a result of the same type as its operands.
  //                | FBinOp
  // -----------------------
 
-    syntax Instr ::= "(" IValType "." IBinOp ")" | "(" IValType "." IBinOp Instr Instr ")" | IValType "." IBinOp Int   Int
- //                | "(" FValType "." FBinOp ")" | "(" FValType "." FBinOp Instr Instr ")" | FValType "." FBinOp Float Float
- // ------------------------------------------------------------------------------------------------------------------------
-    rule <k> ( ITYPE . BOP:IBinOp I:Instr I':Instr ) => I ~> I' ~> ( ITYPE . BOP ) ... </k>
-
-    rule <k> ( ITYPE . BOP:IBinOp ) => ITYPE . BOP C1 C2 ... </k>
+    syntax PlainInstr ::= IValType "." IBinOp
+ //                     | FValType "." FBinOp
+ // -----------------------------------------
+    rule <k> ITYPE . BOP:IBinOp => ITYPE . BOP C1 C2 ... </k>
          <valstack> < ITYPE > C2 : < ITYPE > C1 : VALSTACK => VALSTACK </valstack>
 ```
 
@@ -245,11 +241,9 @@ When a test operator is the next instruction, the single argument is loaded from
 Test operations consume one operand and produce a bool, which is an `i32` value.
 
 ```k
-    syntax Instr ::= "(" IValType "." ITestOp ")" | "(" IValType "." ITestOp Instr ")" | IValType "." ITestOp Int
- // -------------------------------------------------------------------------------------------------------------
-    rule <k> ( ITYPE . TOP:ITestOp I:Instr ) => I ~> ( ITYPE . TOP ) ... </k>
-
-    rule <k> ( ITYPE . TOP:ITestOp ) => ITYPE . TOP C1 ... </k>
+    syntax PlainInstr ::= IValType "." ITestOp
+ // ------------------------------------------
+    rule <k> ITYPE . TOP:ITestOp => ITYPE . TOP C1 ... </k>
          <valstack> < ITYPE > C1 : VALSTACK => VALSTACK </valstack>
 ```
 
@@ -264,12 +258,10 @@ Comparisons consume two operands and produce a bool, which is an `i32` value.
  //                | FRelOp
  // -----------------------
 
-    syntax Instr ::= "(" IValType "." IRelOp ")" | "(" IValType "." IRelOp Instr Instr ")" | IValType "." IRelOp Int   Int
- //                  "(" FValType "." FRelOp ")" | "(" IValType "." FRelOp Instr Instr ")" | IValType "." FRelOp Float Float
- // ------------------------------------------------------------------------------------------------------------------------
-    rule <k> ( ITYPE . ROP:IRelOp I:Instr I':Instr ) => I ~> I' ~> ( ITYPE . ROP ) ... </k>
-
-    rule <k> ( ITYPE . ROP:IRelOp ) => ITYPE . ROP C1 C2 ... </k>
+    syntax PlainInstr ::= IValType "." IRelOp
+ //                     | FValType "." FRelOp
+ // -----------------------------------------
+    rule <k> ITYPE . ROP:IRelOp => ITYPE . ROP C1 C2 ... </k>
          <valstack> < ITYPE > C2 : < ITYPE > C1 : VALSTACK => VALSTACK  </valstack>
 ```
 
@@ -282,11 +274,9 @@ These operators convert constant elements at the top of the stack to another typ
 The target type is before the `.`, and the source type is after the `_`.
 
 ```k
-    syntax Instr ::= "(" IValType "." ConvOp ")" | "(" IValType "." ConvOp Instr ")" | IValType "." ConvOp Int
- // ----------------------------------------------------------------------------------------------------------
-    rule <k> ( ITYPE . CONVOP:ConvOp I:Instr ) => I ~> ( ITYPE . CONVOP ) ... </k>
-
-    rule <k> ( ITYPE . CONVOP:ConvOp ) => ITYPE . CONVOP C1  ... </k>
+    syntax PlainInstr ::= IValType "." ConvOp
+ // -----------------------------------------
+    rule <k> ITYPE . CONVOP:ConvOp => ITYPE . CONVOP C1  ... </k>
          <valstack> < SRCTYPE > C1 : VALSTACK => VALSTACK </valstack>
       requires #convSourceType(CONVOP) ==K SRCTYPE
 
@@ -296,6 +286,19 @@ The target type is before the `.`, and the source type is after the `_`.
 
 Numeric Operators
 -----------------
+
+```k
+    syntax Instr  ::= IValType "." IUnOp   Int
+                    | IValType "." IBinOp  Int   Int
+                    | IValType "." ITestOp Int
+                    | IValType "." IRelOp  Int   Int
+                    | IValType "." ConvOp  Int
+ //                 | FValType "." FUnOp   Float
+ //                 | FValType "." FBinOp  Float Float
+ //                 | FValType "." FTestOp Float
+ //                 | FValType "." FRelOp  Float Float
+ //                 | FValType "." ConvOp  Float
+```
 
 ### Integer Arithmetic
 

--- a/wasm.md
+++ b/wasm.md
@@ -134,11 +134,11 @@ The sorts `EmptyStmt` and `EmptyStmts` are administrative so that the empty list
     syntax Stmt  ::= Instr | Defn
  // -----------------------------
 
-    syntax EmptyStmts ::= List{EmptyStmt, ""} [klabel(listStmt)]
-    syntax Instrs     ::= List{Instr, ""}     [klabel(listStmt)]
-    syntax Defns      ::= List{Defn , ""}     [klabel(listStmt)]
-    syntax Stmts      ::= List{Stmt , ""}     [klabel(listStmt)]
- // ------------------------------------------------------------
+    syntax EmptyStmts ::= List{EmptyStmt , ""} [klabel(listStmt)]
+    syntax Instrs     ::= List{Instr     , ""} [klabel(listStmt)]
+    syntax Defns      ::= List{Defn      , ""} [klabel(listStmt)]
+    syntax Stmts      ::= List{Stmt      , ""} [klabel(listStmt)]
+ // -------------------------------------------------------------
 
     syntax Instrs ::= EmptyStmts
     syntax Defns  ::= EmptyStmts

--- a/wasm.md
+++ b/wasm.md
@@ -214,13 +214,9 @@ To resolve these `identifiers` into concrete `indices`, some grammar production 
 ### Unary Operators
 
 When a unary operator is the next instruction, the single argument is loaded from the `<valstack>` automatically.
-A `UnOp` operator always produces a result of the same type as its operand.
+An `*UnOp` operator always produces a result of the same type as its operand.
 
 ```k
-    syntax UnOp ::= IUnOp
- //               | FUnOp
- // ---------------------
-
     syntax PlainInstr ::= IValType "." IUnOp
  //                     | FValType "." FUnOp
  // ----------------------------------------
@@ -235,13 +231,9 @@ A `UnOp` operator always produces a result of the same type as its operand.
 ### Binary Operators
 
 When a binary operator is the next instruction, the two arguments are loaded from the `<valstack>` automatically.
-A `BinOp` operator always produces a result of the same type as its operands.
+A `*BinOp` operator always produces a result of the same type as its operands.
 
 ```k
-    syntax BinOp ::= IBinOp
- //                | FBinOp
- // -----------------------
-
     syntax PlainInstr ::= IValType "." IBinOp
  //                     | FValType "." FBinOp
  // -----------------------------------------
@@ -276,10 +268,6 @@ When a comparison operator is the next instruction, the two arguments are loaded
 Comparisons consume two operands and produce a bool, which is an `i32` value.
 
 ```k
-    syntax RelOp ::= IRelOp
- //                | FRelOp
- // -----------------------
-
     syntax PlainInstr ::= IValType "." IRelOp
  //                     | FValType "." FRelOp
  // -----------------------------------------

--- a/wasm.md
+++ b/wasm.md
@@ -99,9 +99,10 @@ Plain Instructions could be written in the folded form.
 ```k
     syntax Instr ::= PlainInstr
                    | BlockInstr
-                   | "(" PlainInstr Instrs ")"
- // ------------------------------------------
-    rule <k> ( PI:PlainInstr IS:Instrs ):Instr => IS ~> PI ... </k>
+                   | FoldedInstr
+    syntax FoldedInstr ::= "(" PlainInstr Instrs ")"
+ // ------------------------------------------------
+    rule <k> ( PI:PlainInstr IS:Instrs ):FoldedInstr => IS ~> PI ... </k>
 ```
 
 ### Sequencing
@@ -520,9 +521,9 @@ It simply executes the block then records a label with an empty continuation.
     rule <k> label [ TYPES ] { _ } VALSTACK' => . ... </k>
          <valstack> VALSTACK => #take(TYPES, VALSTACK) ++ VALSTACK' </valstack>
 
-    syntax Instr      ::= "(" "block" TypeDecls Instrs ")"
-    syntax BlockInstr ::= "block" VecType Instrs "end"
- // --------------------------------------------------
+    syntax FoldedInstr ::= "(" "block" TypeDecls Instrs ")"
+    syntax BlockInstr  ::= "block" VecType Instrs "end"
+ // ---------------------------------------------------
     rule <k> ( block FDECLS:TypeDecls INSTRS:Instrs )
           => block gatherTypes(result, FDECLS) INSTRS end
          ...
@@ -576,9 +577,9 @@ Finally, we have the conditional and loop instructions.
          <valstack> < i32 > VAL : VALSTACK => VALSTACK </valstack>
        requires VAL  ==Int 0
 
-    syntax BlockInstr ::= "loop" VecType Instrs "end"
-    syntax Instr      ::=  "(" "loop" VecType Instrs ")"
- // ----------------------------------------------------
+    syntax BlockInstr  ::= "loop" VecType Instrs "end"
+    syntax FoldedInstr ::=  "(" "loop" VecType Instrs ")"
+ // -----------------------------------------------------
     rule <k> ( loop FDECLS IS ) => loop FDECLS IS end ... </k>
 
     rule <k> loop VTYPE IS end => IS ~> label [ .ValTypes ] { loop VTYPE IS end } VALSTACK ... </k>

--- a/wasm.md
+++ b/wasm.md
@@ -93,12 +93,19 @@ All places in the data with no entry are considered zero bytes.
 Instructions
 ------------
 
-Instructions are syntactically distinguished into plain and structured instructions.
-Plain Instructions could be written in the folded form.
+According to the WebAssembly semantics there are 4 categories of instructions.
+
+-  Plain Instructions (`PlainInstr`): Most instructions are plain instructions. They could be wrapped in parentheses and optionally includes nested folded instructions to indicate its operands.
+-  Structured control instructions (`BlockInstr`): Structured control instructions are used to control the program flow. They can be annotated with a symbolic label identifier. 
+-  Administrative Instructions (`AdminInstr`): Administrative instructions are used to experess the reduction of `traps`, `calls`, and `control instructions`.
+-  Folded Instructions (`FoldedInstr`): Folded Instructions describes the rules of desugaring plain instructions and block instructions.
+
+Also in our definition, there are some helper instructions not directly used in programs but will help us define the rules, they are directly subsorted into `Instr`.
 
 ```k
     syntax Instr ::= PlainInstr
                    | BlockInstr
+                   | AdminInstr
                    | FoldedInstr
     syntax FoldedInstr ::= "(" PlainInstr Instrs ")"
  // ------------------------------------------------
@@ -149,8 +156,8 @@ Statements are not part of Wasm semantics, but rather of the embedder, and is wh
 Thus, a `trap` "bubbles up" (more correctly, to "consumes the continuation") until it reaches a statement which is not an `Instr` or `Def`.
 
 ```k
-    syntax Instr ::= "trap"
- // -----------------------
+    syntax AdminInstr ::= "trap"
+ // ----------------------------
     rule <k> trap ~> (L:Label   => .) ... </k>
     rule <k> trap ~> (F:Frame   => .) ... </k>
     rule <k> trap ~> (I:Instr   => .) ... </k>
@@ -516,8 +523,9 @@ A block is the simplest way to create targets for break instructions (ie. jump d
 It simply executes the block then records a label with an empty continuation.
 
 ```k
-    syntax Label ::= "label" VecType "{" Instrs "}" ValStack
- // --------------------------------------------------------
+    syntax AdminInstr ::= Label
+    syntax Label      ::= "label" VecType "{" Instrs "}" ValStack
+ // -------------------------------------------------------------
     rule <k> label [ TYPES ] { _ } VALSTACK' => . ... </k>
          <valstack> VALSTACK => #take(TYPES, VALSTACK) ++ VALSTACK' </valstack>
 
@@ -854,15 +862,16 @@ Similar to labels, they sit on the instruction stack (the `<k>` cell), and `retu
 Unlike labels, only one frame can be "broken" through at a time.
 
 ```k
-    syntax Frame ::= "frame" Int ValTypes ValStack Map
- // --------------------------------------------------
+    syntax AdminInstr ::= Frame
+    syntax Frame      ::= "frame" Int ValTypes ValStack Map
+ // -------------------------------------------------------
     rule <k> frame MODIDX' TRANGE VALSTACK' LOCAL' => . ... </k>
          <valstack> VALSTACK => #take(TRANGE, VALSTACK) ++ VALSTACK' </valstack>
          <locals> _ => LOCAL' </locals>
          <curModIdx> _ => MODIDX' </curModIdx>
 
-    syntax Instr ::= "(" "invoke" Int ")"
- // -------------------------------------
+    syntax AdminInstr ::= "(" "invoke" Int ")"
+ // ------------------------------------------
     rule <k> ( invoke FADDR )
           => init_locals #take(TDOMAIN, VALSTACK) ++ #zero(TLOCALS)
           ~> INSTRS

--- a/wasm.md
+++ b/wasm.md
@@ -534,8 +534,6 @@ Upon reaching it, the label itself is executed.
 
 Note that, unlike in the WebAssembly specification document, we do not need the special "context" operator here because the value and instruction stacks are separate.
 
-** TODO **: implement "br_table"
-
 ```k
     syntax PlainInstr ::= "br" Int
  // ------------------------------
@@ -554,9 +552,6 @@ Note that, unlike in the WebAssembly specification document, we do not need the 
     rule <k> br_if N => .    ... </k>
          <valstack> < TYPE > VAL : VALSTACK => VALSTACK </valstack>
       requires VAL  ==Int 0
-
-    syntax PlainInstr ::= "br_table" ElemSegment
- // --------------------------------------------
 ```
 
 Finally, we have the conditional and loop instructions.

--- a/wasm.md
+++ b/wasm.md
@@ -295,6 +295,9 @@ The target type is before the `.`, and the source type is after the `_`.
 Numeric Operators
 -----------------
 
+These instructions are reduced to from the plain instructions defined above.
+They take operands as parameters rather than from the `<valstack>` and is used to define the numeric computation rules.
+
 ```k
     syntax Instr  ::= IValType "." IUnOp   Int
                     | IValType "." IBinOp  Int   Int

--- a/wasm.md
+++ b/wasm.md
@@ -561,25 +561,27 @@ Note that, unlike in the WebAssembly specification document, we do not need the 
 Finally, we have the conditional and loop instructions.
 
 ```k
-    syntax Instr ::= "(" "if" VecType Instrs "else" Instrs "end" ")"
-                   | "(" "if" VecType Instrs "(" "then" Instrs ")" ")"
-                   | "(" "if" VecType Instrs "(" "then" Instrs ")" "(" "else" Instrs ")" ")"
-                   | "(" "if"         Instrs "(" "then" Instrs ")" "(" "else" Instrs ")" ")"
- // ----------------------------------------------------------------------------------------
+    syntax FoldedInstr ::= "(" "if" VecType Instrs "(" "then" Instrs ")" ")"
+                         | "(" "if" VecType Instrs "(" "then" Instrs ")" "(" "else" Instrs ")" ")"
+                         | "(" "if"         Instrs "(" "then" Instrs ")" "(" "else" Instrs ")" ")"
+    syntax BlockInstr  ::= "if" VecType Instrs "else" Instrs "end"
+                         | "if" VecType Instrs               "end"
+ // --------------------------------------------------------------
     rule <k> ( if VTYPE C:Instrs ( then IS ) )              => C ~> ( if VTYPE IS else .Instrs end ) ... </k>
     rule <k> ( if VTYPE C:Instrs ( then IS ) ( else IS' ) ) => C ~> ( if VTYPE IS else IS'     end ) ... </k>
     rule <k> ( if       C:Instrs ( then IS ) ( else IS' ) ) => C ~> ( if [ .ValTypes ] IS else IS' end ) ... </k>
 
-    rule <k> ( if VTYPE IS else IS' end ) => IS  ~> label VTYPE { .Instrs } VALSTACK ... </k>
+    rule <k> if VTYPE IS          end => if VTYPE IS else .Instrs end ... </k>
+    rule <k> if VTYPE IS else IS' end => IS  ~> label VTYPE { .Instrs } VALSTACK ... </k>
          <valstack> < i32 > VAL : VALSTACK => VALSTACK </valstack>
        requires VAL =/=Int 0
-    rule <k> ( if VTYPE IS else IS' end ) => IS' ~> label VTYPE { .Instrs } VALSTACK ... </k>
+    rule <k> if VTYPE IS else IS' end => IS' ~> label VTYPE { .Instrs } VALSTACK ... </k>
          <valstack> < i32 > VAL : VALSTACK => VALSTACK </valstack>
        requires VAL  ==Int 0
 
-    syntax BlockInstr  ::= "loop" VecType Instrs "end"
     syntax FoldedInstr ::=  "(" "loop" VecType Instrs ")"
- // -----------------------------------------------------
+    syntax BlockInstr  ::= "loop" VecType Instrs "end"
+ // --------------------------------------------------
     rule <k> ( loop FDECLS IS ) => loop FDECLS IS end ... </k>
 
     rule <k> loop VTYPE IS end => IS ~> label [ .ValTypes ] { loop VTYPE IS end } VALSTACK ... </k>

--- a/wasm.md
+++ b/wasm.md
@@ -110,8 +110,10 @@ Also in our definition, there are some helper instructions not directly used in 
                    | AdminInstr
                    | FoldedInstr
     syntax FoldedInstr ::= "(" PlainInstr Instrs ")"
- // ------------------------------------------------
+                         | "(" PlainInstr        ")" [prefer]
+ // ---------------------------------------------------------
     rule <k> ( PI:PlainInstr IS:Instrs ):FoldedInstr => IS ~> PI ... </k>
+    rule <k> ( PI:PlainInstr           ):FoldedInstr =>       PI ... </k>
 ```
 
 ### Sequencing


### PR DESCRIPTION
This solves most of the problems in issue https://github.com/kframework/wasm-semantics/issues/77.

Now instruction are categorized into `plaininstr`, `blockinstr`, and some still named as `instr`, according to the specs.

`plaininstr` could be written in folded form, so we can use one rule to represent all folded forms rather than needing rules for each of them. Also, we do not have to wrap instructions in parenthesis.

These instructions are still named as `instr`:
   - administrative instructions, including `invoke idx`, `trap`, `label`, `init_xxx`.
   - `blockinstr` when in the format of being wrapped in parenthesis.
   - helper instructions we defined to help computation.