### PR TITLE
(Re)implement proper inline modules, and implement global declarations

### DIFF
--- a/test.md
+++ b/test.md
@@ -21,6 +21,8 @@ This subsort contains Auxiliary functions that only used in our KWASM semantics 
  // ---------------------
 ```
 
+We want to be able to write auxilliary commands outside of module definitions.
+In those cases, the command refers to the last defined module.
 We also add `token` as a value in order to implement some test assertions.
 
 ```k
@@ -107,6 +109,7 @@ We'll make `Assertion` a subsort of `Auxil`, since it is a form of top-level emb
     syntax Auxil ::= Assertion
  // --------------------------
 ```
+
 ### Conformance Assertions
 
 Here we inplement the conformance assertions specified in [spec interpreter] including:
@@ -225,8 +228,8 @@ The operator `#assertLocal`/`#assertGlobal` operators perform a check for a loca
 `init_global` is a helper function that helps us to declare a new global variable.
 
 ```k
-    syntax Auxil ::= "init_global" Int Int
- // --------------------------------------
+    syntax Defn ::= "init_global" Int Int
+ // -------------------------------------
     rule <k> init_global INDEX GADDR => . ... </k>
          <curModIdx> CUR </curModIdx>
          <moduleInst>
@@ -410,7 +413,7 @@ The modules are cleaned all together after the test file is executed.
     syntax Auxil ::= "#clearConfig"
  // -------------------------------
     rule <k>    #clearConfig => . ...     </k>
-         <curModIdx>       _ => 0         </curModIdx>
+         <curModIdx>       _ => .K        </curModIdx>
          <valstack>        _ => .ValStack </valstack>
          <locals>          _ => .Map      </locals>
          <nextFreshId>     _ => 0         </nextFreshId>
@@ -427,6 +430,7 @@ The modules are cleaned all together after the test file is executed.
            <mems>          _ => .Bag      </mems>
            <globals>       _ => .Bag      </globals>
          </mainStore>
+         <lastModIdx>      _ => .K        </lastModIdx>
 ```
 
 Registry Assertations

--- a/test.md
+++ b/test.md
@@ -406,7 +406,6 @@ The modules are cleaned all together after the test file is executed.
            <nextGlobAddr>  _ => 0         </nextGlobAddr>
            <globals>       _ => .Bag      </globals>
          </mainStore>
-         <lastModIdx>      _ => .K        </lastModIdx>
 ```
 
 Registry Assertations

--- a/test.md
+++ b/test.md
@@ -225,29 +225,6 @@ The operator `#assertLocal`/`#assertGlobal` operators perform a check for a loca
          </globals>
 ```
 
-`init_global` is a helper function that helps us to declare a new global variable.
-
-```k
-    syntax Defn ::= "init_global" Int Int
- // -------------------------------------
-    rule <k> init_global INDEX GADDR => . ... </k>
-         <curModIdx> CUR </curModIdx>
-         <moduleInst>
-           <modIdx> CUR </modIdx>
-           <globalIndices> GADDRS => GADDRS [ INDEX <- GADDR ] </globalIndices>
-           ...
-         </moduleInst>
-         <globals>
-           ( .Bag
-          => <globalInst>
-               <gAddr> GADDR </gAddr>
-               ...
-             </globalInst>
-           )
-           ...
-         </globals>
-```
-
 ### Type Assertions
 
 `#assertType` checks whether a type is allocated to the correct index.

--- a/test.md
+++ b/test.md
@@ -21,8 +21,6 @@ This subsort contains Auxiliary functions that only used in our KWASM semantics 
  // ---------------------
 ```
 
-We want to be able to write auxilliary commands outside of module definitions.
-In those cases, the command refers to the last defined module.
 We also add `token` as a value in order to implement some test assertions.
 
 ```k

--- a/test.md
+++ b/test.md
@@ -428,6 +428,7 @@ The modules are cleaned all together after the test file is executed.
            <tabs>          _ => .Bag      </tabs>
            <nextMemAddr>   _ => 0         </nextMemAddr>
            <mems>          _ => .Bag      </mems>
+           <nextGlobAddr>  _ => 0         </nextGlobAddr>
            <globals>       _ => .Bag      </globals>
          </mainStore>
          <lastModIdx>      _ => .K        </lastModIdx>

--- a/tests/simple/data.wast
+++ b/tests/simple/data.wast
@@ -1,5 +1,3 @@
-(module)
-
 ;; Instantiating with data
 
 (memory (data 87 65 83 77 50 46 48))
@@ -15,7 +13,6 @@
 #assertMemory 1 1 "memorys string length"
 
 #clearConfig
-(module)
 
 (memory 1 1)
 (data (offset (i32.const 100)) 87 65 83 77)
@@ -26,7 +23,6 @@
 #assertMemory 1 1 "memorys string length"
 
 #clearConfig
-(module)
 
 (memory 0 1)
 (data (i32.const 100) 87 65 83 77)
@@ -37,13 +33,11 @@
 #assertMemory 0 1 "memory data separate inst"
 
 #clearConfig
-(module)
 
 (memory (data))
 #assertMemory 0 0 "memorys string length"
 
 #clearConfig
-(module)
 
 (memory (data 87))
 #assertMemoryData (0, 87) "text to ascii W"

--- a/tests/simple/export.wast
+++ b/tests/simple/export.wast
@@ -1,4 +1,3 @@
-(module)
 ;; test function export
 
 (func $1 param i64 i64 i64 result i64 local i64

--- a/tests/simple/functions_call.wast
+++ b/tests/simple/functions_call.wast
@@ -1,5 +1,3 @@
-(module)
-
 ;; Simple add function
 
 (type $a-cool-type (func (param i32 i32 ) ( result i32 )))

--- a/tests/simple/identifiers.wast
+++ b/tests/simple/identifiers.wast
@@ -1,4 +1,3 @@
-(module)
 ;; tests of function identifier names
 
 (func $oeauth

--- a/tests/simple/memory.wast
+++ b/tests/simple/memory.wast
@@ -1,22 +1,17 @@
-(module)
-
 ( memory )
 #assertMemory 0 .MaxBound "memory initial 1"
 
 #clearConfig
-(module)
 
 ( memory 34)
 #assertMemory 34 .MaxBound "memory initial 2"
 
 #clearConfig
-(module)
 
 ( memory 4 10 )
 #assertMemory 4 10 "memory initial 3"
 
 #clearConfig
-(module)
 
 ( memory 0 10 )
 (memory.size)
@@ -24,7 +19,6 @@
 #assertMemory 0 10 "memory ungrown"
 
 #clearConfig
-(module)
 
 ( memory 0 10 )
 (memory.grow (i32.const 10))
@@ -35,7 +29,6 @@
 #assertMemory 10 10 "memory grown"
 
 #clearConfig
-(module)
 
 ( memory #maxMemorySize())
 (memory.grow (i32.const 1))
@@ -43,7 +36,6 @@
 #assertMemory #maxMemorySize() .MaxBound "memory grow max too large"
 
 #clearConfig
-(module)
 
 ( memory )
 (memory.grow (i32.const #maxMemorySize()))
@@ -57,7 +49,6 @@
 ;; Store and load
 
 #clearConfig
-(module)
 
 (memory 1)
 (i32.const 1)
@@ -79,7 +70,6 @@
 #assertMemory 1 .MaxBound ""
 
 #clearConfig
-(module)
 
 (memory 0)
 (i32.const 0)
@@ -89,7 +79,6 @@
 #assertMemory 0 .MaxBound ""
 
 #clearConfig
-(module)
 
 (memory 1)
 (i32.const 65535)
@@ -103,7 +92,6 @@
 #assertMemory 1 .MaxBound ""
 
 #clearConfig
-(module)
 
 (memory 1)
 (i64.store (i32.const 15) (i64.const #pow(i32) -Int 1))
@@ -133,7 +121,6 @@
 ;; Updating
 
 #clearConfig
-(module)
 
 (memory 1)
 (i64.store (i32.const 1) (i64.const #pow(i64) -Int 1))
@@ -144,7 +131,6 @@
 #assertMemory 1 .MaxBound "Zero updates erases memory"
 
 #clearConfig
-(module)
 
 (memory 1)
 (i64.store (i32.const 1) (i64.const #pow(i64) -Int 1))

--- a/tests/simple/start.wast
+++ b/tests/simple/start.wast
@@ -1,5 +1,3 @@
-(module)
-
 (memory 1)
 (func $inc
   (i32.store8
@@ -22,7 +20,6 @@
 #assertMemory 1 .MaxBound ""
 
 #clearConfig
-(module)
 
 (func $foo (unreachable))
 (start $foo)

--- a/tests/simple/variables.wast
+++ b/tests/simple/variables.wast
@@ -19,8 +19,8 @@ init_locals < i32 > 0 : < i32 > 0 : < i32 > 0 : .ValStack
 
 ;; Test globals
 
-init_global 0 0
-init_global 1 1
+(global (mut i32) (i32.const 0))
+(global (mut i32) (i32.const 0))
 
 (i32.const 43)
 (global.set 0)
@@ -36,9 +36,9 @@ init_global 1 1
 
 #clearConfig
 
-init_global 0 0
+(global (mut i32) (i32.const 0))
 (global.set 0 (i32.const 77))
-init_global 1 1
+(global (mut i32) (i32.const 0))
 (global.set 1 (i32.const 99))
 
 #assertGlobal 1 < i32 > 99 "set_global folded"

--- a/tests/simple/variables.wast
+++ b/tests/simple/variables.wast
@@ -1,4 +1,3 @@
-(module)
 ;; Test locals
 
 init_locals < i32 > 0 : < i32 > 0 : < i32 > 0 : .ValStack
@@ -36,7 +35,6 @@ init_global 1 1
 ;; Test global folded forms
 
 #clearConfig
-(module)
 
 init_global 0 0
 (global.set 0 (i32.const 77))

--- a/tests/success-haskell.out
+++ b/tests/success-haskell.out
@@ -12,45 +12,25 @@
     <locals>
       .Map
     </locals>
+    <curModIdx>
+      .Map
+    </curModIdx>
   </curFrame>
   <nextFreshId>
     0
   </nextFreshId>
-  <moduleInst>
-    <typeIds>
-      .Map
-    </typeIds>
-    <funcIds>
-      .Map
-    </funcIds>
-    <nextTypeIdx>
-      0
-    </nextTypeIdx>
-    <nextFuncIdx>
-      0
-    </nextFuncIdx>
-    <nextGlobalIdx>
-      0
-    </nextGlobalIdx>
-    <types>
-      .Map
-    </types>
-    <funcIndices>
-      .Map
-    </funcIndices>
-    <tabIndices>
-      .Map
-    </tabIndices>
-    <memIndices>
-      .Map
-    </memIndices>
-    <globalIndices>
-      .Map
-    </globalIndices>
-    <exports>
-      .Map
-    </exports>
-  </moduleInst>
+  <moduleIds>
+    .Map
+  </moduleIds>
+  <nextModuleIdx>
+    0
+  </nextModuleIdx>
+  <moduleInstances>
+    .Map
+  </moduleInstances>
+  <moduleRegistry>
+    .Map
+  </moduleRegistry>
   <mainStore>
     <nextFuncAddr>
       0
@@ -70,20 +50,11 @@
     <mems>
       .MemInstCellMap
     </mems>
+    <nextGlobAddr>
+      0
+    </nextGlobAddr>
     <globals>
       .GlobalInstCellMap
     </globals>
   </mainStore>
-  <moduleIds>
-    .Map
-  </moduleIds>
-  <nextModuleIdx>
-    0
-  </nextModuleIdx>
-  <moduleInstances>
-    .Map
-  </moduleInstances>
-  <moduleRegistry>
-    .Map
-  </moduleRegistry>
 </generatedTop>

--- a/tests/success-java.out
+++ b/tests/success-java.out
@@ -57,7 +57,4 @@
       .Map
     </globals>
   </mainStore>
-  <lastModIdx>
-    .
-  </lastModIdx>
 </generatedTop>

--- a/tests/success-java.out
+++ b/tests/success-java.out
@@ -50,6 +50,9 @@
     <mems>
       .Map
     </mems>
+    <nextGlobAddr>
+      0
+    </nextGlobAddr>
     <globals>
       .Map
     </globals>

--- a/tests/success-java.out
+++ b/tests/success-java.out
@@ -13,7 +13,7 @@
       .Map
     </locals>
     <curModIdx>
-      0
+      .
     </curModIdx>
   </curFrame>
   <nextFreshId>
@@ -54,4 +54,7 @@
       .Map
     </globals>
   </mainStore>
+  <lastModIdx>
+    .
+  </lastModIdx>
 </generatedTop>

--- a/tests/success-ocaml.out
+++ b/tests/success-ocaml.out
@@ -57,7 +57,4 @@
       .GlobalInstCellMap
     </globals>
   </mainStore>
-  <lastModIdx>
-    .
-  </lastModIdx>
 </generatedTop>

--- a/tests/success-ocaml.out
+++ b/tests/success-ocaml.out
@@ -13,7 +13,7 @@
       .Map
     </locals>
     <curModIdx>
-      0
+      .
     </curModIdx>
   </curFrame>
   <nextFreshId>
@@ -54,4 +54,7 @@
       .GlobalInstCellMap
     </globals>
   </mainStore>
+  <lastModIdx>
+    .
+  </lastModIdx>
 </generatedTop>

--- a/tests/success-ocaml.out
+++ b/tests/success-ocaml.out
@@ -50,6 +50,9 @@
     <mems>
       .MemInstCellMap
     </mems>
+    <nextGlobAddr>
+      0
+    </nextGlobAddr>
     <globals>
       .GlobalInstCellMap
     </globals>

--- a/wasm.md
+++ b/wasm.md
@@ -79,7 +79,6 @@ Configuration
           </globalInst>
         </globals>
       </mainStore>
-      <lastModIdx> .K </lastModIdx>
 ```
 
 ### Assumptions and invariants
@@ -1463,9 +1462,6 @@ Then, the surrounding `module` tag is discarded, and the definitions are execute
            )
            ...
          </moduleInstances>
-         <lastModIdx> _ => CUR  </lastModIdx>
-
-
 ```
 
 It is permissible to define modules without the `module` keyword, by simply stating the definitions at the top level in the file.

--- a/wasm.md
+++ b/wasm.md
@@ -18,7 +18,7 @@ Configuration
       <valstack> .ValStack </valstack>
       <curFrame>
         <locals> .Map </locals>
-        <curModIdx> 0 </curModIdx>
+        <curModIdx> .K </curModIdx>
       </curFrame>
       <nextFreshId> 0 </nextFreshId>
       <moduleInstances>
@@ -77,6 +77,7 @@ Configuration
           </globalInst>
         </globals>
       </mainStore>
+      <lastModIdx> .K </lastModIdx>
 ```
 
 ### Assumptions and invariants
@@ -246,7 +247,6 @@ Test operations consume one operand and produce a bool, which is an `i32` value.
 
 When a comparison operator is the next instruction, the two arguments are loaded from the `<valstack>` automatically.
 Comparisons consume two operands and produce a bool, which is an `i32` value.
-
 
 ```k
     syntax RelOp ::= IRelOp
@@ -1401,7 +1401,7 @@ Then, the surrounding `module` tag is discarded, and the definitions are execute
          <nextModuleIdx> NEXT </nextModuleIdx>
 
     rule <k> ( module DEFNS ) => DEFNS ... </k>
-         <curModIdx> _ => NEXT </curModIdx>
+         <curModIdx> CUR => NEXT </curModIdx>
          <nextModuleIdx> NEXT => NEXT +Int 1 </nextModuleIdx>
          <moduleInstances>
            ( .Bag
@@ -1412,6 +1412,16 @@ Then, the surrounding `module` tag is discarded, and the definitions are execute
            )
            ...
          </moduleInstances>
+         <lastModIdx> _ => CUR  </lastModIdx>
+
+
+```
+
+It is permissible to define modules without the `module` keyword, by simply stating the definitions at the top level in the file.
+
+```k
+    rule <k> D:Defn => ( module .Defns ) ~> D ... </k>
+         <curModIdx> .K </curModIdx>
 ```
 
 After a module is instantiated, it should be saved somewhere.


### PR DESCRIPTION
The spec explicitly allows inline modules, like we had earlier, where definitions could be placed at the top level, i.e., no need to explicitly use `module` keyword. See the official test `inline_module.wast` for an example.

The rule that allows this is the very last one in `wasm.md`, which kicks in only when a `Defn` is encountered and there is no current module. In that case, a module is instantiated.

I'm not a huge fan of the fact that we can (and do) use a simple `(module)` statement to create a module and then have it hanging around as the current module. I'd prefer if we actually were a bit stricter so that the `curModIdx` cell is cleared after a module declaration is done. This messes a lot with our assertions, though, and I haven't really got that working yet.

The new rule relies on grouping `Defns`, so I had some issues with `init_globals` being an `Auxil`. I figured it would be straightforward to just replace it with actual `global` definitions.