### PR TITLE
Structuring and ordering definitions in modules

### DIFF
--- a/tests/simple/modules.wast
+++ b/tests/simple/modules.wast
@@ -34,3 +34,11 @@
 )
 
 #clearConfig
+
+;; Test ordering of definitions in modules.
+
+(module
+  (elem (i32.const 0) 0)
+  (table 1 funcref)
+  (func)
+)

--- a/tests/simple/modules.wast
+++ b/tests/simple/modules.wast
@@ -40,8 +40,8 @@
 (module
   (start $main) ;; Should initialize memory position 1.
   (elem (i32.const 1) $store)
-  (data (i32.const 100) 5) ;; Should overwrite previous, leaving "5 1" as memory bytes
   (data (i32.const 100) 100 1)
+  (data (i32.const 100) 5) ;; Should overwrite previous, leaving "5 1" as memory bytes
   (func)
   (func $main (call_indirect (i32.const 1))) ;; Should call $store.
   (func $store (i32.store (i32.const 1) (i32.const 42)))

--- a/tests/simple/modules.wast
+++ b/tests/simple/modules.wast
@@ -42,3 +42,5 @@
   (table 1 funcref)
   (func)
 )
+
+#clearConfig

--- a/wasm.md
+++ b/wasm.md
@@ -1476,8 +1476,7 @@ The groups are chosen to represent different stages of allocation and instantiat
 
     // Imports (TODO).
  // rule #structureModule(M, (I:ImportDefn DS:Defns))
- //
-      => #structureModule(M ["imports"   <- (I {M ["imports"  ]}:>Defns)], DS)
+ //   => #structureModule(M ["imports"   <- (I {M ["imports"  ]}:>Defns)], DS)
 
     // Allocations.
     rule #structureModule(M, (A:FuncDefn   DS:Defns))
@@ -1487,7 +1486,7 @@ The groups are chosen to represent different stages of allocation and instantiat
     rule #structureModule(M, (A:MemoryDefn DS:Defns))
       => #structureModule(M ["allocs"    <- (A {M ["allocs"   ]}:>Defns)], DS)
  // rule #structureModule(M, (A:GlobalDefn DS:Defns))
-      => #structureModule(M ["allocs"    <- (A {M ["allocs"   ]}:>Defns)], DS)
+ //   => #structureModule(M ["allocs"    <- (A {M ["allocs"   ]}:>Defns)], DS)
 
     // Exports.
     rule #structureModule(M, (E:ExportDefn DS:Defns))

--- a/wasm.md
+++ b/wasm.md
@@ -1475,6 +1475,7 @@ Then, the surrounding `module` tag is discarded, and the definitions are execute
           ~> MOD["allocs"   ]
           ~> MOD["exports"  ]
           ~> MOD["inits"    ]
+          ~> MOD["start"    ]
          ...
          </k>
          <curModIdx> _ => NEXT </curModIdx>

--- a/wasm.md
+++ b/wasm.md
@@ -1426,7 +1426,7 @@ Start Function
 ```k
     syntax Defn      ::= StartDefn
     syntax StartDefn ::= "(" "start" TextFormatIdx ")"
- // ---------------------------------------------
+ // --------------------------------------------------
     rule <k> ( start TFIDX ) => ( invoke FADDR ) ... </k>
          <curModIdx> CUR </curModIdx>
          <moduleInst>

--- a/wasm.md
+++ b/wasm.md
@@ -637,7 +637,7 @@ When globals are declared, they must also be given a constant initialization val
     syntax GlobalType ::= Mut ValType
     syntax GlobalType ::= asGMut (TextGlobalType) [function]
     syntax TextGlobalType ::= ValType | "(" "mut" ValType ")"
-    syntax Defn  ::= GlobalDefn
+    syntax Defn       ::= GlobalDefn
     syntax GlobalDefn ::= "(" "global"               TextGlobalType Instr ")"
                         | "(" "global" TextFormatIdx TextGlobalType Instr ")"
                         |     "global" GlobalType
@@ -723,13 +723,13 @@ Types
 This defines helper functions that gathers function together.
 
 ```k
-    syntax TypeKeyWord  ::= "param" | "result"
- // ------------------------------------------
+    syntax TypeKeyWord ::= "param" | "result"
+ // -----------------------------------------
 
-    syntax TypeDecl      ::= "(" TypeDecl ")"     [bracket]
-                           | TypeKeyWord ValTypes
-    syntax TypeDecls     ::= List{TypeDecl , ""} [klabel(listTypeDecl)]
- // -------------------------------------------------------------------
+    syntax TypeDecl  ::= "(" TypeDecl ")"     [bracket]
+                       | TypeKeyWord ValTypes
+    syntax TypeDecls ::= List{TypeDecl , ""} [klabel(listTypeDecl)]
+ // ---------------------------------------------------------------
 
     syntax VecType ::=  gatherTypes ( TypeKeyWord , TypeDecls )            [function]
                      | #gatherTypes ( TypeKeyWord , TypeDecls , ValTypes ) [function]
@@ -1349,12 +1349,12 @@ The initialization of a table needs an offset and a list of function indices.
 A table index is optional and will be default to zero.
 
 ```k
-    syntax Defn        ::= ElemDefn
-    syntax ElemDefn    ::= "(" "elem"     TextFormatIdx Offset ElemSegment ")"
-                         | "(" "elem"                   Offset ElemSegment ")"
-                         |     "elem" "{" TextFormatIdx        ElemSegment "}"
-    syntax Stmt        ::= #initElements ( Int, Int, ElemSegment )
- // --------------------------------------------------------------
+    syntax Defn     ::= ElemDefn
+    syntax ElemDefn ::= "(" "elem"     TextFormatIdx Offset ElemSegment ")"
+                      | "(" "elem"                   Offset ElemSegment ")"
+                      |     "elem" "{" TextFormatIdx        ElemSegment "}"
+    syntax Stmt     ::= #initElements ( Int, Int, ElemSegment )
+ // -----------------------------------------------------------
     // Default to table with index 0.
     rule <k> ( elem        OFFSET      ELEMSEGMENT ) =>     ( elem 0 OFFSET ELEMSEGMENT ) ... </k>
     rule <k> ( elem TABIDX IS:Instr    ELEMSEGMENT ) => IS ~> elem { TABIDX ELEMSEGMENT } ... </k>
@@ -1384,7 +1384,7 @@ Memories can be initialized with data, specified as a list of bytes together wit
 The `data` initializer simply puts these bytes into the specified memory, starting at the offset.
 
 ```k
-    syntax Defn  ::= DataDefn
+    syntax Defn     ::= DataDefn
     syntax DataDefn ::= "(" "data"     TextFormatIdx Offset DataStrings ")"
                       | "(" "data"                   Offset DataStrings ")"
                       |     "data" "{" TextFormatIdx        DataStrings "}"

--- a/wasm.md
+++ b/wasm.md
@@ -1399,7 +1399,8 @@ Inlined imports and exports are safe to extract as they appear.
 Imports must appear first in a module due to validation.
 Exports only depend on what they are exporting having been allocated, so can appear right after allocation.
 
-The following functions filters out different definitions so that they can be properly ordered.
+`structureModule` takes a list of definitions and returns a map with different groups of definitions.
+The groups are chosen to represent different stages of allocation and instantiation.
 
 ```k
     syntax Map ::=  structureModule (     Defns) [function]
@@ -1416,30 +1417,41 @@ The following functions filters out different definitions so that they can be pr
 
     rule structureModule(DS) => #structureModule(#initialMap (), DS)
 
-    rule #structureModule(M, .Defns              ) => M
+    rule #structureModule(M, .Defns              )
+      => M
 
     // Type declarations.
-    rule #structureModule(M, (T:TypeDefn   DS:Defns)) => #structureModule(M ["typeDecls" <- (T {M ["typeDecls"]}:>Defns)], DS)
+    rule #structureModule(M, (T:TypeDefn   DS:Defns))
+      => #structureModule(M ["typeDecls" <- (T {M ["typeDecls"]}:>Defns)], DS)
 
     // Imports (TODO).
  // rule #structureModule(M, (I:ImportDefn DS:Defns))
- //   => #structureModule(M ["imports"   <- (I {M ["imports"  ]}:>Defns)], DS)
+ //
+      => #structureModule(M ["imports"   <- (I {M ["imports"  ]}:>Defns)], DS)
 
     // Allocations.
-    rule #structureModule(M, (A:FuncDefn   DS:Defns)) => #structureModule(M ["allocs"    <- (A {M ["allocs"   ]}:>Defns)], DS)
-    rule #structureModule(M, (A:TableDefn  DS:Defns)) => #structureModule(M ["allocs"    <- (A {M ["allocs"   ]}:>Defns)], DS)
-    rule #structureModule(M, (A:MemoryDefn DS:Defns)) => #structureModule(M ["allocs"    <- (A {M ["allocs"   ]}:>Defns)], DS)
- // rule #structureModule(M, (A:GlobalDefn DS:Defns)) => #structureModule(M ["allocs"    <- (A {M ["allocs"   ]}:>Defns)], DS)
+    rule #structureModule(M, (A:FuncDefn   DS:Defns))
+      => #structureModule(M ["allocs"    <- (A {M ["allocs"   ]}:>Defns)], DS)
+    rule #structureModule(M, (A:TableDefn  DS:Defns))
+      => #structureModule(M ["allocs"    <- (A {M ["allocs"   ]}:>Defns)], DS)
+    rule #structureModule(M, (A:MemoryDefn DS:Defns))
+      => #structureModule(M ["allocs"    <- (A {M ["allocs"   ]}:>Defns)], DS)
+ // rule #structureModule(M, (A:GlobalDefn DS:Defns))
+      => #structureModule(M ["allocs"    <- (A {M ["allocs"   ]}:>Defns)], DS)
 
     // Exports.
-    rule #structureModule(M, (E:ExportDefn DS:Defns)) => #structureModule(M ["exports"   <- (E {M ["exports"  ]}:>Defns)], DS)
+    rule #structureModule(M, (E:ExportDefn DS:Defns))
+      => #structureModule(M ["exports"   <- (E {M ["exports"  ]}:>Defns)], DS)
 
     // Initializations.
-    rule #structureModule(M, (I:DataDefn   DS:Defns)) => #structureModule(M ["inits"     <- (I {M ["inits"    ]}:>Defns)], DS)
-    rule #structureModule(M, (I:ElemDefn   DS:Defns)) => #structureModule(M ["inits"     <- (I {M ["inits"    ]}:>Defns)], DS)
+    rule #structureModule(M, (I:DataDefn   DS:Defns))
+      => #structureModule(M ["inits"     <- (I {M ["inits"    ]}:>Defns)], DS)
+    rule #structureModule(M, (I:ElemDefn   DS:Defns))
+      => #structureModule(M ["inits"     <- (I {M ["inits"    ]}:>Defns)], DS)
 
     // Start function.
-    rule #structureModule(M, (S:StartDefn  DS:Defns)) => #structureModule(M ["start"     <- (S .Defns)], DS) // There can only be one start function.
+    rule #structureModule(M, (S:StartDefn  DS:Defns))
+      => #structureModule(M ["start"     <- (S .Defns)], DS) // There can only be one start function.
 ```
 
 A new module instance gets allocated.

--- a/wasm.md
+++ b/wasm.md
@@ -1373,7 +1373,8 @@ Start Function
 --------------
 
 ```k
-    syntax Defn ::= "(" "start" TextFormatIdx ")"
+    syntax Defn      ::= StartDefn
+    syntax StartDefn ::= "(" "start" TextFormatIdx ")"
  // ---------------------------------------------
     rule <k> ( start TFIDX ) => ( invoke FADDR ) ... </k>
          <curModIdx> CUR </curModIdx>
@@ -1390,6 +1391,12 @@ Module Instantiation
 
 A new module instance gets allocated.
 Then, the surrounding `module` tag is discarded, and the definitions are executed, putting them into the module currently being defined.
+
+```k
+    syntax Defns ::= gatherAllocs(Defns)
+ // ------------------------------------
+    rule <k> D:Func
+```
 
 ```k
     syntax Stmt       ::= ModuleDecl

--- a/wasm.md
+++ b/wasm.md
@@ -637,10 +637,11 @@ When globals are declared, they must also be given a constant initialization val
     syntax GlobalType ::= Mut ValType
     syntax GlobalType ::= asGMut (TextGlobalType) [function]
     syntax TextGlobalType ::= ValType | "(" "mut" ValType ")"
-    syntax Defn ::= "(" "global"               TextGlobalType Instr ")"
-                  | "(" "global" TextFormatIdx TextGlobalType Instr ")"
-                  |     "global" GlobalType
- // ---------------------------------------
+    syntax Defn  ::= GlobalDefn
+    syntax GlobalDefn ::= "(" "global"               TextGlobalType Instr ")"
+                        | "(" "global" TextFormatIdx TextGlobalType Instr ")"
+                        |     "global" GlobalType
+ // ---------------------------------------------
     rule asGMut ( (mut T:ValType ) ) => var   T
     rule asGMut (      T:ValType   ) => const T
     rule <k> ( global ID:TextFormatIdx TYP:TextGlobalType IS:Instr ) => ( global TYP IS ) ... </k>
@@ -1485,8 +1486,8 @@ The groups are chosen to represent different stages of allocation and instantiat
       => #structureModule(M ["allocs"    <- (A {M ["allocs"   ]}:>Defns)], DS)
     rule #structureModule(M, (A:MemoryDefn DS:Defns))
       => #structureModule(M ["allocs"    <- (A {M ["allocs"   ]}:>Defns)], DS)
- // rule #structureModule(M, (A:GlobalDefn DS:Defns))
- //   => #structureModule(M ["allocs"    <- (A {M ["allocs"   ]}:>Defns)], DS)
+    rule #structureModule(M, (A:GlobalDefn DS:Defns))
+      => #structureModule(M ["allocs"    <- (A {M ["allocs"   ]}:>Defns)], DS)
 
     // Exports.
     rule #structureModule(M, (E:ExportDefn DS:Defns))


### PR DESCRIPTION
This traverses the definitions in a module and orders them appropriately for allocation and instantiation. Imports are yet to be implemented, but I added them to the ordering for completeness.