### PR TITLE
"Correct" filename for kompiling to Haskell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ java_kompiled:=$(java_dir)/test-kompiled/compiled.txt
 
 haskell_dir:=$(defn_dir)/haskell
 haskell_defn:=$(patsubst %, $(haskell_dir)/%, $(wasm_files))
-haskell_kompiled:=$(haskell_dir)/test-kompiled/compiled.txt
+haskell_kompiled:=$(haskell_dir)/test-kompiled/definition.kore
 
 # Tangle definition from *.md files
 

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ java_kompiled:=$(java_dir)/test-kompiled/compiled.txt
 
 haskell_dir:=$(defn_dir)/haskell
 haskell_defn:=$(patsubst %, $(haskell_dir)/%, $(wasm_files))
-haskell_kompiled:=$(haskell_dir)/test-kompiled/kore.txt
+haskell_kompiled:=$(haskell_dir)/test-kompiled/compiled.txt
 
 # Tangle definition from *.md files
 


### PR DESCRIPTION
Kompiling to haskell no longer produces a `kore.txt` file, but rather a `compiled.txt` file. Due to the nature of Makefiles, this issue meant that make constantly found the `kore.txt` file lacking, and thus always rebuilt the haskell backend regardless of if it's necessary or not. That's a lot of wasted time every time `make build` is called.