### PR TITLE
Shorter klab prove target, CI will finish quicker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,12 +159,14 @@ parse-conformance: $(conformance_tests:=.parse)
 ### Proof Tests
 
 proof_tests:=$(wildcard tests/proofs/*-spec.k)
+slow_proof_tests:=tests/proofs/loops-spec.k
+quick_proof_tests:=$(filter-out $(slow_proof_tests), $(proof_tests))
 
 test-prove: $(proof_tests:=.prove)
 
 ### KLab interactive
 
-test-klab-prove: $(proof_tests:=.klab-prove)
+test-klab-prove: $(quick_proof_tests:=.klab-prove)
 
 # Presentation
 # ------------

--- a/tests/proofs/loops-spec.k
+++ b/tests/proofs/loops-spec.k
@@ -1,0 +1,29 @@
+requires "kwasm-lemmas.k"
+
+module LOOPS-SPEC
+    imports WASM
+    imports KWASM-LEMMAS
+
+    rule <k> block .TypeDecls
+                 ( loop .TypeDecls
+                     (local.get 0)
+                     (local.get 1)
+                     (i32.add)
+                     (local.set 1)
+                     (local.get 0)
+                     (i32.const 1)
+                     (i32.sub)
+                     (local.tee 0)
+                     (i32.eqz)
+                     (br_if 1)
+                     (br 0)
+                 )
+             end
+          => .
+          ...
+         </k>
+         <locals>
+           0 |-> < i32 > (10 => 0)
+           1 |-> < i32 > (0 => 55)
+         </locals>
+endmodule

--- a/tests/proofs/simple-arithmetic-spec.k
+++ b/tests/proofs/simple-arithmetic-spec.k
@@ -21,27 +21,4 @@ module SIMPLE-ARITHMETIC-SPEC
          <valstack> S:ValStack => < ITYPE > (X +Int Y) : S </valstack>
       requires 0 <=Int X andBool 0 <=Int Y
        andBool (X +Int Y) <Int #pow(ITYPE)
-
-    rule <k> block .TypeDecls
-                 ( loop .TypeDecls
-                     (local.get 0)
-                     (local.get 1)
-                     (i32.add)
-                     (local.set 1)
-                     (local.get 0)
-                     (i32.const 1)
-                     (i32.sub)
-                     (local.tee 0)
-                     (i32.eqz)
-                     (br_if 1)
-                     (br 0)
-                 )
-             end
-          => .
-          ...
-         </k>
-         <locals>
-           0 |-> < i32 > (10 => 0)
-           1 |-> < i32 > (0 => 55)
-         </locals>
 endmodule


### PR DESCRIPTION
We only need to test that `klab-prove` works at all, not to run it on all the proofs.