### PR TITLE
assert_return should assert the exact return value

### DIFF
--- a/test.md
+++ b/test.md
@@ -184,7 +184,7 @@ And we implement some helper assertions to help testing.
     syntax Assertion ::= "#assertAndRemoveEqual"
                        | "#assertAndRemoveToken"
  // --------------------------------------------
-    rule <k> #assertAndRemoveEqual   => #assertTopStack V "" ~> ( drop ) ... </k>
+    rule <k> #assertAndRemoveEqual   => #assertTopStackExactly V "" ~> ( drop ) ... </k>
          <valstack> V : VALSTACK     => VALSTACK </valstack>
     rule <k> #assertAndRemoveToken   => . ... </k>
          <valstack> token : VALSTACK => VALSTACK </valstack>


### PR DESCRIPTION
This is a very small PR.

assert_return now asserts both the correct type and the correct value.

For example, if the return type of a function is `<i32>`, assert_return must give an `<i32>` return value rather than any of `<i32>` and `<i64>`.

This fix will benefit the type conversion tests.

