### PR TITLE
Unparse WasmString

### DIFF
--- a/data.md
+++ b/data.md
@@ -507,8 +507,8 @@ To avoid dealing with these data strings in K, we use a list of integers as an i
 
 ```k
     syntax WasmString ::= ".WasmString"
-    syntax String     ::=   #parseWasmString ( WasmString ) [function, functional, hook(STRING.token2string)]
-    syntax WasmString ::= #unparseWasmString (     String ) [function, functional, hook(STRING.string2token)]
+    syntax String     ::= #parseWasmString   ( WasmString ) [function, functional, hook(STRING.token2string)]
+    syntax WasmString ::= #unparseWasmString ( String     ) [function, functional, hook(STRING.string2token)]
     syntax DataString ::= List{WasmString, ""}            [klabel(listWasmString)]
  // ------------------------------------------------------------------------------
 ```

--- a/data.md
+++ b/data.md
@@ -507,7 +507,8 @@ To avoid dealing with these data strings in K, we use a list of integers as an i
 
 ```k
     syntax WasmString ::= ".WasmString"
-    syntax String     ::= #parseWasmString ( WasmString ) [function, functional, hook(STRING.token2string)]
+    syntax String     ::=   #parseWasmString ( WasmString ) [function, functional, hook(STRING.token2string)]
+    syntax WasmString ::= #unparseWasmString (     String ) [function, functional, hook(STRING.string2token)]
     syntax DataString ::= List{WasmString, ""}            [klabel(listWasmString)]
  // ------------------------------------------------------------------------------
 ```

--- a/data.md
+++ b/data.md
@@ -509,8 +509,8 @@ To avoid dealing with these data strings in K, we use a list of integers as an i
     syntax WasmString ::= ".WasmString"
     syntax String     ::= #parseWasmString   ( WasmString ) [function, functional, hook(STRING.token2string)]
     syntax WasmString ::= #unparseWasmString ( String     ) [function, functional, hook(STRING.string2token)]
-    syntax DataString ::= List{WasmString, ""}            [klabel(listWasmString)]
- // ------------------------------------------------------------------------------
+    syntax DataString ::= List{WasmString, ""}              [klabel(listWasmString)]
+ // --------------------------------------------------------------------------------
 ```
 
 `DataString`, as is defined in the wasm semantics, is a list of `WasmString`s.


### PR DESCRIPTION
Add a conversion from String to WasmString, useful for making concrete WasmStrings inside a semantics. I use this in Ewasm, which has a few special strings, such as `"ethereum"` and `"main"`.