### PR TITLE
Text format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ ocaml-deps:
 # Building Definition
 # -------------------
 
-wasm_files:=test.k wasm.k data.k numeric.k kwasm-lemmas.k
+wasm_files:=test.k wasm-text.k wasm.k data.k numeric.k kwasm-lemmas.k
 
 ocaml_dir:=$(defn_dir)/ocaml
 ocaml_defn:=$(patsubst %, $(ocaml_dir)/%, $(wasm_files))

--- a/data.md
+++ b/data.md
@@ -508,8 +508,7 @@ To avoid dealing with these data strings in K, we use a list of integers as an i
 
 ```k
     syntax WasmString ::= ".WasmString"
-    syntax String     ::= #parseWasmString   ( WasmString ) [function, functional, hook(STRING.token2string)]
-    syntax WasmString ::= #unparseWasmString ( String     ) [function, functional, hook(STRING.string2token)]
+    syntax String     ::= #parseWasmString ( WasmString ) [function, functional, hook(STRING.token2string)]
     syntax DataString ::= List{WasmString, ""}            [klabel(listWasmString)]
  // ------------------------------------------------------------------------------
 ```

--- a/data.md
+++ b/data.md
@@ -98,24 +98,23 @@ This rule handles adding an `OptionalId` as a map key, but only when it is a pro
     rule #saveId (MAP, ID:Identifier, IDX) => MAP [ID <- IDX]
 ```
 
-### Text Format Indices
+### Indices
 
-Indices in the text format could be either an `address` or an `identifier`.
-When we are initializing a table with element segment, we need to define a list of Text Format Indices and calculate the length of it.
+Many constructions in Wasm, such a functions, labels, locals, types, etc., are referred to by their index.
+In the abstract syntax of Wasm, indicies are 32 bit unsigned integers.
+However, we extend the `Index` sort with another subsort, `Identifier`, in the text format.
 
 ```k
     syntax Index ::= Int
  // --------------------
-
 ```
 
-### Text Format Conventions
-
-The text format allows the use of symbolic identifiers in place of indices.
-To store these identifiers into concrete indices, some grammar productions are indexed by an identifier context `I` as a synthesized attribute that records the declared identifiers in each index space.
-To lookup an index from a `Index`, which may be either an identifer or a concrete index, we provide the operation `#ContextLookup`.
-It resolves to a concrete index if the input is a concrete index.
-If the the input is an identifier, the corresponding index is looked up in the supplied Map.
+`Int` is the basic form of index, and indices always need to resolve to integers.
+In the text format, `Index` is extended with the `Identifier` subsort, and there needs to be a way to resolve it to an `Int`.
+In Wasm, the current "context" contains a mapping from identifiers to indices.
+The `#ContextLookup` function provides an extensible way to get an `Int` from an index.
+Any extension of the `Index` type requires that the function `#ContextLookup` is suitably extended.
+For `Int`, however, a the context is irrelevant and the index always just resolves to the integer.
 
 ```k
     syntax Int ::= #ContextLookup ( Map , Index ) [function]

--- a/data.md
+++ b/data.md
@@ -507,8 +507,8 @@ To avoid dealing with these data strings in K, we use a list of integers as an i
 
 ```k
     syntax WasmString ::= ".WasmString"
-    syntax String     ::=   #parseWasmString ( WasmString ) [function, functional, hook(STRING.token2string)]
-    syntax WasmString ::= #unparseWasmString (     String ) [function, functional, hook(STRING.string2token)]
+    syntax String     ::= #parseWasmString   ( WasmString ) [function, functional, hook(STRING.token2string)]
+    syntax WasmString ::= #unparseWasmString ( String     ) [function, functional, hook(STRING.string2token)]
     syntax DataString ::= List{WasmString, ""}            [klabel(listWasmString)]
  // ------------------------------------------------------------------------------
 ```

--- a/data.md
+++ b/data.md
@@ -100,12 +100,12 @@ This rule handles adding an `OptionalId` as a map key, but only when it is a pro
 
 ### Text Format Indices
 
-Indices in the text format could be either an `address` or an `identifier.
+Indices in the text format could be either an `address` or an `identifier`.
 When we are initializing a table with element segment, we need to define a list of Text Format Indices and calculate the length of it.
 
 ```k
-    syntax TextFormatIdx ::= Int | Identifier
- // -----------------------------------------
+    syntax Index ::= Int
+ // --------------------
 
 ```
 
@@ -113,16 +113,14 @@ When we are initializing a table with element segment, we need to define a list 
 
 The text format allows the use of symbolic identifiers in place of indices.
 To store these identifiers into concrete indices, some grammar productions are indexed by an identifier context `I` as a synthesized attribute that records the declared identifiers in each index space.
-To lookup an index from a `TextFormatIdx`, which may be either an identifer or a concrete index, we provide the operation `#ContextLookup`.
+To lookup an index from a `Index`, which may be either an identifer or a concrete index, we provide the operation `#ContextLookup`.
 It resolves to a concrete index if the input is a concrete index.
 If the the input is an identifier, the corresponding index is looked up in the supplied Map.
 
 ```k
-    syntax Int ::= #ContextLookup ( Map , TextFormatIdx ) [function]
- // ----------------------------------------------------------------
+    syntax Int ::= #ContextLookup ( Map , Index ) [function]
+ // --------------------------------------------------------
     rule #ContextLookup(IDS:Map, I:Int) => I
-    rule #ContextLookup(IDS:Map, ID:Identifier) => {IDS [ ID ]}:>Int
-      requires ID in_keys(IDS)
 ```
 
 ### ElemSegment
@@ -131,12 +129,12 @@ Element Segment is a list of indices.
 It is used when initializing a WebAssembly table, or used as the parameter of the `br_table` function.
 
 ```k
-    syntax ElemSegment ::= List{TextFormatIdx, ""} [klabel(listTextFormatIdx)]
- // --------------------------------------------------------------------------
+    syntax ElemSegment ::= List{Index, ""} [klabel(listIndex)]
+ // ----------------------------------------------------------
 
-    syntax Int           ::= #lenElemSegment (ElemSegment)      [function]
-    syntax TextFormatIdx ::= #getElemSegment (ElemSegment, Int) [function]
- // ----------------------------------------------------------------------
+    syntax Int   ::= #lenElemSegment (ElemSegment)      [function]
+    syntax Index ::= #getElemSegment (ElemSegment, Int) [function]
+ // --------------------------------------------------------------
     rule #lenElemSegment(.ElemSegment) => 0
     rule #lenElemSegment(TFIDX     ES) => 1 +Int #lenElemSegment(ES)
 
@@ -595,8 +593,8 @@ It is an `address` denoting either a `function instance`, `table instance`, `mem
 
 ```k
     syntax AllocatedKind ::= "func" | "table" | "memory" | "global"
-    syntax Externval     ::= AllocatedKind TextFormatIdx
- // ----------------------------------------------------
+    syntax Externval     ::= AllocatedKind Index
+ // --------------------------------------------
 ```
 
 ```k

--- a/data.md
+++ b/data.md
@@ -105,21 +105,25 @@ In the abstract syntax of Wasm, indicies are 32 bit unsigned integers.
 However, we extend the `Index` sort with another subsort, `Identifier`, in the text format.
 
 ```k
-    syntax Index ::= Int
- // --------------------
+    syntax Index ::= Int | Identifier
+ // ---------------------------------
+
 ```
 
-`Int` is the basic form of index, and indices always need to resolve to integers.
-In the text format, `Index` is extended with the `Identifier` subsort, and there needs to be a way to resolve it to an `Int`.
-In Wasm, the current "context" contains a mapping from identifiers to indices.
-The `#ContextLookup` function provides an extensible way to get an `Int` from an index.
-Any extension of the `Index` type requires that the function `#ContextLookup` is suitably extended.
-For `Int`, however, a the context is irrelevant and the index always just resolves to the integer.
+### Text Format Conventions
+
+The text format allows the use of symbolic identifiers in place of indices.
+To store these identifiers into concrete indices, some grammar productions are indexed by an identifier context `I` as a synthesized attribute that records the declared identifiers in each index space.
+To lookup an index from an `Index`, which may be either an identifer or a concrete index, we provide the operation `#ContextLookup`.
+It resolves to a concrete index if the input is a concrete index.
+If the the input is an identifier, the corresponding index is looked up in the supplied Map.
 
 ```k
     syntax Int ::= #ContextLookup ( Map , Index ) [function]
  // --------------------------------------------------------
     rule #ContextLookup(IDS:Map, I:Int) => I
+    rule #ContextLookup(IDS:Map, ID:Identifier) => {IDS [ ID ]}:>Int
+      requires ID in_keys(IDS)
 ```
 
 ### ElemSegment

--- a/data.md
+++ b/data.md
@@ -507,7 +507,8 @@ To avoid dealing with these data strings in K, we use a list of integers as an i
 
 ```k
     syntax WasmString ::= ".WasmString"
-    syntax String     ::= #parseWasmString ( WasmString ) [function, functional, hook(STRING.token2string)]
+    syntax String     ::=   #parseWasmString ( WasmString ) [function, functional, hook(STRING.token2string)]
+    syntax WasmString ::= #unparseWasmString (     String ) [function, functional, hook(STRING.string2token)]
     syntax DataString ::= List{WasmString, ""}            [klabel(listWasmString)]
  // ------------------------------------------------------------------------------
 ```

--- a/kwasm-lemmas.md
+++ b/kwasm-lemmas.md
@@ -6,7 +6,7 @@ They are part of the *trusted* base, and so should be scrutinized carefully.
 
 ```k
 module KWASM-LEMMAS
-    imports WASM
+    imports WASM-TEXT
 ```
 
 When reasoning about `#chop`, it's often the case that the precondition to the proof contains the information needed to indicate no overflow.

--- a/test.md
+++ b/test.md
@@ -4,8 +4,7 @@ KWasm Testing
 For testing, we augment the semantics with some helpers.
 
 ```k
-require "wasm.k"
-require "data.k"
+require "wasm-text.k"
 ```
 
 Module `WASM-TEST-SYNTAX` is just used for program parsing and `WASM-TEST` consists of the definitions both for parsing and execution.
@@ -13,11 +12,11 @@ Module `WASM-TEST-SYNTAX` is just used for program parsing and `WASM-TEST` consi
 ```k
 module WASM-TEST-SYNTAX
     imports WASM-TEST
-    imports WASM-SYNTAX
+    imports WASM-TEXT-SYNTAX
 endmodule
 
 module WASM-TEST
-    imports WASM
+    imports WASM-TEXT
 ```
 
 Auxiliary

--- a/test.md
+++ b/test.md
@@ -106,9 +106,9 @@ We will reference modules by name in imports.
 `register` is the instruction that allows us to associate a name with a module.
 
 ```k
-    syntax Auxil ::= "(" "register" WasmString               ")"
-                   | "(" "register" WasmString TextFormatIdx ")"
- // ------------------------------------------------------------
+    syntax Auxil ::= "(" "register" WasmString       ")"
+                   | "(" "register" WasmString Index ")"
+ // ----------------------------------------------------
     rule <k> ( register S ) => ( register S (NEXT -Int 1) )... </k> // Register last instantiated module.
          <nextModuleIdx> NEXT </nextModuleIdx>
       requires NEXT >Int 0
@@ -240,9 +240,9 @@ These functions make assertions about the state of the `<valstack>` cell.
 The operator `#assertLocal`/`#assertGlobal` operators perform a check for a local/global variable's value.
 
 ```k
-    syntax Assertion ::= "#assertLocal"  Int           Val WasmString
-                       | "#assertGlobal" TextFormatIdx Val WasmString
- // -----------------------------------------------------------------
+    syntax Assertion ::= "#assertLocal"  Int   Val WasmString
+                       | "#assertGlobal" Index Val WasmString
+ // ---------------------------------------------------------
     rule <k> #assertLocal INDEX VALUE _ => . ... </k>
          <locals> ... INDEX |-> VALUE ... </locals>
 
@@ -270,7 +270,7 @@ The operator `#assertLocal`/`#assertGlobal` operators perform a check for a loca
 `#assertNextTypeIdx` checks whether the number of types are allocated correctly.
 
 ```k
-    syntax Assertion ::= "#assertType" TextFormatIdx FuncType
+    syntax Assertion ::= "#assertType" Index FuncType
                        | "#assertNextTypeIdx" Int
  // ---------------------------------------------
     rule <k> #assertType TFIDX FTYPE => . ... </k>
@@ -296,8 +296,8 @@ The operator `#assertLocal`/`#assertGlobal` operators perform a check for a loca
 This simply checks that the given function exists in the `<funcs>` cell and has the given signature and local types.
 
 ```k
-    syntax Assertion ::= "#assertFunction" TextFormatIdx FuncType VecType WasmString
- // --------------------------------------------------------------------------------
+    syntax Assertion ::= "#assertFunction" Index FuncType VecType WasmString
+ // ------------------------------------------------------------------------
     rule <k> #assertFunction TFIDX FTYPE LTYPE _ => . ... </k>
          <curModIdx> CUR </curModIdx>
          <moduleInst>
@@ -323,8 +323,8 @@ This simply checks that the given function exists in the `<funcs>` cell and has 
 This asserts related operation about tables.
 
 ```k
-    syntax Assertion ::= "#assertTable" TextFormatIdx Int OptionalInt WasmString
- // ----------------------------------------------------------------------------
+    syntax Assertion ::= "#assertTable" Index Int OptionalInt WasmString
+ // --------------------------------------------------------------------
     rule <k> #assertTable TFIDX SIZE MAX MSG => . ... </k>
          <curModIdx> CUR </curModIdx>
          <moduleInst>
@@ -367,8 +367,8 @@ This asserts related operation about tables.
 This checks that the last allocated memory has the given size and max value.
 
 ```k
-    syntax Assertion ::= "#assertMemory" TextFormatIdx Int OptionalInt WasmString
- // -----------------------------------------------------------------------------
+    syntax Assertion ::= "#assertMemory" Index Int OptionalInt WasmString
+ // ---------------------------------------------------------------------
     rule <k> #assertMemory TFIDX SIZE MAX MSG => . ... </k>
          <curModIdx> CUR </curModIdx>
          <moduleInst>

--- a/tests/proofs/loops-spec.k
+++ b/tests/proofs/loops-spec.k
@@ -1,7 +1,7 @@
 requires "kwasm-lemmas.k"
 
 module LOOPS-SPEC
-    imports WASM
+    imports WASM-TEXT
     imports KWASM-LEMMAS
 
     rule <k> block .TypeDecls

--- a/tests/proofs/simple-arithmetic-spec.k
+++ b/tests/proofs/simple-arithmetic-spec.k
@@ -1,7 +1,7 @@
 requires "kwasm-lemmas.k"
 
 module SIMPLE-ARITHMETIC-SPEC
-    imports WASM
+    imports WASM-TEXT
     imports KWASM-LEMMAS
 
     rule <k> (ITYPE:IValType . const X:Int) => . ... </k>

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -17,7 +17,7 @@ module WASM-TEXT
 Folded Instructions
 -------------------
 
-Folded Instructions (`FoldedInstr`): Folded Instructions describes the rules of desugaring plain instructions and block instructions.
+Folded Instructions describes the rules of desugaring plain instructions and block instructions.
 
 ```k
     syntax Instr ::= FoldedInstr

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -59,50 +59,10 @@ Another type of folded instruction is control flow blocks wrapped in parentheses
     rule <k> ( loop ID:Identifier TDECLS:TypeDecls IS ) => loop ID TDECLS IS end ... </k>
 ```
 
-Looking up Indices
-------------------
-
-In the abstract Wasm syntax, indices are always integers.
-In the text format, we extend indices to incorporate identifiers.
-
-```k
-    syntax Index ::= Identifier
- // ---------------------------
-```
-
-We enable context lookups with identifiers.
-
-```k
-    rule #ContextLookup(IDS:Map, ID:Identifier) => {IDS [ ID ]}:>Int
-      requires ID in_keys(IDS)
-```
-
 Block Instructions
 ------------------
 
-In the text format, block instructions can have identifiers attached to them, and branch instructions can refer to these identifiers.
-First, we allow identifiers on labels.
-
-```k
-    syntax Label ::= "label" Identifier VecType "{" Instrs "}" ValStack
- // --------------------------------------------------------------------
-    rule <k> label _:Identifier [ TYPES ] { _ } VALSTACK' => . ... </k>
-         <valstack> VALSTACK => #take(TYPES, VALSTACK) ++ VALSTACK' </valstack>
-```
-
-Then, we define how to branch to identifiers, and how the branches using integers still match on named labels.
-
-```k
-    rule <k> br 0     ~> ( label _:Identifier [ TYPES ] { IS } VALSTACK' => label [ TYPES ] { IS } VALSTACK' ) ... </k>
-
-    rule <k> br ID:Identifier ~> label ID  [ TYPES ] { IS } VALSTACK' => IS ... </k>
-         <valstack> VALSTACK => #take(TYPES, VALSTACK) ++ VALSTACK' </valstack>
-    rule <k> br ID:Identifier ~> label [ TYPES ] { IS } VALSTACK' => br ID ... </k>
-    rule <k> br ID:Identifier ~> label ID' [ TYPES ] { IS } VALSTACK' => br ID ... </k>
-      requires ID =/=K ID'
-```
-
-Finally, we introduce the text format block instructions, which may have identifiers after each keyword.
+Block instructions may have identifiers after each keyword.
 If more than one identifier is present, they all have to agree (they are just there to make clear what if-block they belong to).
 If identifiers are used, one must occur after the initial keyword (`block`, `if` or `loop`).
 

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -72,7 +72,9 @@ Intitial memory data, and initial table elements can be given inline in the text
 
     rule <k> ( memory ID:Identifier ( data DS ) )
           =>  memory { ID #lengthDataPages(DS) #lengthDataPages(DS) }
-          ~> ( data ID (i32.const 0) DS ) ... </k>
+          ~> ( data ID (i32.const 0) DS )
+          ...
+         </k>
       requires #lengthDataPages(DS) <=Int #maxMemorySize()
 
     syntax TableSpec ::= TableElemType "(" "elem" ElemSegment ")"

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -14,6 +14,33 @@ module WASM-TEXT
     imports WASM
 ```
 
+Folded Instructions
+-------------------
+
+Folded Instructions (`FoldedInstr`): Folded Instructions describes the rules of desugaring plain instructions and block instructions.
+
+```k
+    syntax Instr ::= FoldedInstr
+    syntax FoldedInstr ::= "(" PlainInstr Instrs ")"
+                         | "(" PlainInstr        ")" [prefer]
+ // ---------------------------------------------------------
+    rule <k> ( PI:PlainInstr IS:Instrs ):FoldedInstr => IS ~> PI ... </k>
+    rule <k> ( PI:PlainInstr           ):FoldedInstr =>       PI ... </k>
+
+    syntax FoldedInstr ::= "(" "block" OptionalId TypeDecls Instrs ")"
+ // ------------------------------------------------------------------
+    rule <k> ( block OID:OptionalId TDECLS:TypeDecls INSTRS:Instrs ) => block OID TDECLS INSTRS end ... </k>
+
+    syntax FoldedInstr ::= "(" "if" OptionalId TypeDecls Instrs "(" "then" Instrs ")" ")"
+                         | "(" "if" OptionalId TypeDecls Instrs "(" "then" Instrs ")" "(" "else" Instrs ")" ")"
+ // -----------------------------------------------------------------------------------------------------------
+    rule <k> ( if OID:OptionalId TDECLS:TypeDecls C:Instrs ( then IS ) )              => C ~> if OID TDECLS IS else .Instrs end ... </k>
+    rule <k> ( if OID:OptionalId TDECLS:TypeDecls C:Instrs ( then IS ) ( else IS' ) ) => C ~> if OID TDECLS IS else IS'     end ... </k>
+
+    syntax FoldedInstr ::= "(" "loop" OptionalId TypeDecls Instrs ")"
+ // -----------------------------------------------------------------
+    rule <k> ( loop OID:OptionalId TDECLS:TypeDecls IS ) => loop OID TDECLS IS end ... </k>
+```
 
 ```k
 endmodule

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -42,32 +42,8 @@ Folded Instructions describes the rules of desugaring plain instructions and blo
     rule <k> ( loop OID:OptionalId TDECLS:TypeDecls IS ) => loop OID TDECLS IS end ... </k>
 ```
 
-Block Instructions and Control
+Block Instructions
 ------------------
-
-In the abstract Wasm syntax, indices are always integers.
-In the text format, we extend indices to incorporate identifiers.
-
-```k
-    syntax Index ::= Identifier
- // ---------------------------
-```
-
-First, we enable context lookups with identifiers.
-
-```k
-    rule #ContextLookup(IDS:Map, ID:Identifier) => {IDS [ ID ]}:>Int
-      requires ID in_keys(IDS)
-```
-
-Then, we define how to branch to identifiers.
-
-```k
-    rule <k> br ID:Identifier ~> label ID  [ TYPES ] { IS } VALSTACK' => IS ... </k>
-         <valstack> VALSTACK => #take(TYPES, VALSTACK) ++ VALSTACK' </valstack>
-    rule <k> br ID:Identifier ~> label ID' [ TYPES ] { IS } VALSTACK' => br ID ... </k>
-      requires ID =/=K ID'
-```
 
 Structured control instructions are used to control the program flow.
 
@@ -111,6 +87,33 @@ Finally, we have the conditional and loop instructions.
          <valstack> VALSTACK => .ValStack </valstack>
       requires OID ==K OID'
         orBool notBool isIdentifier(OID')
+```
+
+Looking up Indices
+------------------
+
+In the abstract Wasm syntax, indices are always integers.
+In the text format, we extend indices to incorporate identifiers.
+
+```k
+    syntax Index ::= Identifier
+ // ---------------------------
+```
+
+First, we enable context lookups with identifiers.
+
+```k
+    rule #ContextLookup(IDS:Map, ID:Identifier) => {IDS [ ID ]}:>Int
+      requires ID in_keys(IDS)
+```
+
+Then, we define how to branch to identifiers.
+
+```k
+    rule <k> br ID:Identifier ~> label ID  [ TYPES ] { IS } VALSTACK' => IS ... </k>
+         <valstack> VALSTACK => #take(TYPES, VALSTACK) ++ VALSTACK' </valstack>
+    rule <k> br ID:Identifier ~> label ID' [ TYPES ] { IS } VALSTACK' => br ID ... </k>
+      requires ID =/=K ID'
 ```
 
 Memory and Tables

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -1,0 +1,20 @@
+WebAssembly Text Format
+=======================
+
+```k
+require "wasm.k"
+require "data.k"
+
+module WASM-TEXT-SYNTAX
+    imports WASM-TEXT
+    imports WASM-SYNTAX
+endmodule
+
+module WASM-TEXT
+    imports WASM
+```
+
+
+```k
+endmodule
+```

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -42,6 +42,128 @@ Folded Instructions describes the rules of desugaring plain instructions and blo
     rule <k> ( loop OID:OptionalId TDECLS:TypeDecls IS ) => loop OID TDECLS IS end ... </k>
 ```
 
+Memory and Tables
+-----------------
+
+Intitial memory data, and initial table elements can be given inline in the text format.
+
+```k
+    syntax MemorySpec ::= "(" "data" DataString ")"
+ // -----------------------------------------------
+    rule <k> ( memory ( data DS ) ) => ( memory #freshId(NEXTID) (data DS) ) ... </k>
+         <nextFreshId> NEXTID => NEXTID +Int 1 </nextFreshId>
+
+    rule <k> ( memory ID:Identifier ( data DS ) )
+          =>  memory { ID #lengthDataPages(DS) #lengthDataPages(DS) }
+          ~> ( data ID (i32.const 0) DS ) ... </k>
+      requires #lengthDataPages(DS) <=Int #maxMemorySize()
+
+    syntax TableSpec ::= TableElemType "(" "elem" ElemSegment ")"
+ // -------------------------------------------------------------
+    rule <k> ( table funcref ( elem ES ) ) => ( table #freshId(NEXTID) funcref (elem ES) ) ... </k>
+         <nextFreshId> NEXTID => NEXTID +Int 1 </nextFreshId>
+
+    rule <k> ( table ID:Identifier funcref ( elem ES ) )
+          =>  table { ID #lenElemSegment(ES) #lenElemSegment(ES) }
+          ~> ( elem ID (i32.const 0) ES )
+          ...
+         </k>
+```
+
+Exports
+-------
+
+Exports can also be declared like regular functions, memories, etc., by giving an inline export declaration.
+In that case, it simply desugars to an export followed by the definition, after introducing a fresh identifier if no identifier is present.
+Note that it is possible to define multiple exports inline, i.e., export a single entity under many names.
+
+```k
+    syntax InlineExport  ::= "(" "export" WasmString ")"
+ // ----------------------------------------------------
+
+    syntax GlobalSpec ::= InlineExport GlobalSpec
+ // ---------------------------------------------
+    rule <k> ( global                  EXPO:InlineExport SPEC:GlobalSpec )
+          => ( global #freshId(NEXTID) EXPO              SPEC            )
+          ...
+         </k>
+         <nextFreshId> NEXTID => NEXTID +Int 1 </nextFreshId>
+
+    rule <k> ( global ID:Identifier ( export ENAME ) SPEC:GlobalSpec )
+          => ( export ENAME ( global ID ) )
+          ~> ( global ID SPEC )
+          ...
+         </k>
+
+    syntax FuncSpec   ::= InlineExport FuncSpec
+ // -------------------------------------------
+    rule <k> ( func                  EXPO:InlineExport SPEC:FuncSpec )
+          => ( func #freshId(NEXTID) EXPO              SPEC          )
+          ...
+         </k>
+         <nextFreshId> NEXTID => NEXTID +Int 1 </nextFreshId>
+
+    rule <k> ( func ID:Identifier ( export ENAME ) SPEC:FuncSpec )
+          => ( export ENAME ( func ID ) )
+          ~> ( func ID SPEC )
+          ...
+         </k>
+
+    syntax TableSpec  ::= InlineExport TableSpec
+ // --------------------------------------------
+    rule <k> ( table                  EXPO:InlineExport SPEC:TableSpec )
+          => ( table #freshId(NEXTID) EXPO              SPEC           )
+          ...
+         </k>
+         <nextFreshId> NEXTID => NEXTID +Int 1 </nextFreshId>
+
+    rule <k> ( table ID:Identifier ( export ENAME ) SPEC:TableSpec )
+          => ( export ENAME ( table ID ) )
+          ~> ( table ID SPEC )
+          ...
+         </k>
+
+    syntax MemorySpec ::= InlineExport MemorySpec
+ // ---------------------------------------------
+    rule <k> ( memory                  EXPO:InlineExport SPEC:MemorySpec )
+          => ( memory #freshId(NEXTID) EXPO              SPEC            )
+          ...
+         </k>
+         <nextFreshId> NEXTID => NEXTID +Int 1 </nextFreshId>
+
+    rule <k> ( memory ID:Identifier ( export ENAME ) SPEC:MemorySpec )
+          => ( export ENAME ( memory ID ) )
+          ~> ( memory ID SPEC )
+          ...
+         </k>
+```
+
+Imports
+-------
+
+Imports can also be declared like regular functions, memories, etc., by giving an inline import declaration.
+
+```k
+    syntax InlineImport ::= "(" "import" WasmString WasmString ")"
+ // --------------------------------------------------------------
+
+    syntax GlobalSpec ::= InlineImport TextFormatGlobalType
+ // -------------------------------------------------------
+    rule <k> ( global OID:OptionalId (import MOD NAME) TYP ) => ( import MOD NAME (global OID TYP) ) ... </k>
+
+    syntax FuncSpec ::= InlineImport TypeUse
+ // ----------------------------------------
+    rule <k> ( func OID:OptionalId (import MOD NAME) TUSE ) => ( import MOD NAME (func OID TUSE) ) ... </k>
+
+    syntax TableSpec ::= InlineImport TableType
+ // -------------------------------------------
+    rule <k> ( table OID:OptionalId (import MOD NAME) TT:TableType ) => ( import MOD NAME (table OID TT) ) ... </k>
+
+    syntax MemorySpec ::= InlineImport MemType
+ // ------------------------------------------
+    rule <k> ( memory OID:OptionalId (import MOD NAME) MT:MemType ) => ( import MOD NAME (memory OID MT) ) ... </k>
+```
+
 ```k
 endmodule
 ```

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -59,57 +59,6 @@ Another type of folded instruction is control flow blocks wrapped in parentheses
     rule <k> ( loop ID:Identifier TDECLS:TypeDecls IS ) => loop ID TDECLS IS end ... </k>
 ```
 
-Block Instructions
-------------------
-
-Block instructions may have identifiers after each keyword.
-If more than one identifier is present, they all have to agree (they are just there to make clear what if-block they belong to).
-If identifiers are used, one must occur after the initial keyword (`block`, `if` or `loop`).
-
-```k
-    syntax Instr ::= BlockInstr
- // ---------------------------
-
-    syntax BlockInstr ::= "block" Identifier TypeDecls Instrs "end" OptionalId
- // --------------------------------------------------------------------------
-    rule <k> block ID:Identifier TDECLS IS end OID':OptionalId => IS ~> label ID gatherTypes(result, TDECLS) { .Instrs } VALSTACK ... </k>
-         <valstack> VALSTACK => .ValStack </valstack>
-      requires ID ==K OID'
-        orBool notBool isIdentifier(OID')
-
-    syntax BlockInstr ::= "loop" Identifier TypeDecls Instrs "end" OptionalId
- // -------------------------------------------------------------------------
-    rule <k> loop ID:Identifier TDECLS:TypeDecls IS end OID':OptionalId => IS ~> label ID gatherTypes(result, TDECLS) { loop ID TDECLS IS end } VALSTACK ... </k>
-         <valstack> VALSTACK => .ValStack </valstack>
-      requires ID ==K OID'
-        orBool notBool isIdentifier(OID')
-```
-
-In the text format, it is also allowed to have a conditional without the `else` branch.
-
-```k
-    syntax BlockInstr ::= "if" Identifier TypeDecls Instrs "else" OptionalId Instrs "end" OptionalId
-                        | "if" OptionalId TypeDecls Instrs                          "end" OptionalId
- // ------------------------------------------------------------------------------------------------
-    rule <k> if TDECLS:TypeDecls IS end => if TDECLS IS else .Instrs end ... </k>
-
-    rule <k> if ID:Identifier TDECLS:TypeDecls IS                         end OID'':OptionalId => if ID TDECLS IS else ID .Instrs end ID ... </k>
-      requires ID ==K OID''
-        orBool notBool isIdentifier(OID'')
-
-    rule <k> if ID:Identifier TDECLS:TypeDecls IS else OID':OptionalId IS' end OID'':OptionalId => IS  ~> label ID gatherTypes(result, TDECLS) { .Instrs } VALSTACK ... </k>
-         <valstack> < i32 > VAL : VALSTACK => VALSTACK </valstack>
-      requires VAL =/=Int 0
-       andBool ( ID ==K OID'  orBool notBool isIdentifier(OID')  )
-       andBool ( ID ==K OID'' orBool notBool isIdentifier(OID'') )
-
-    rule <k> if ID:Identifier TDECLS:TypeDecls IS else OID':OptionalId IS' end OID'':OptionalId => IS' ~> label ID gatherTypes(result, TDECLS) { .Instrs } VALSTACK ... </k>
-         <valstack> < i32 > VAL : VALSTACK => VALSTACK </valstack>
-      requires VAL ==Int 0
-       andBool ( ID ==K OID'  orBool notBool isIdentifier(OID')  )
-       andBool ( ID ==K OID'' orBool notBool isIdentifier(OID'') )
-```
-
 Memory and Tables
 -----------------
 

--- a/wasm.md
+++ b/wasm.md
@@ -315,9 +315,9 @@ A block is the simplest way to create targets for break instructions (ie. jump d
 It simply executes the block then records a label with an empty continuation.
 
 ```k
-    syntax Label ::= "label" VecType "{" Instrs "}" ValStack
- // --------------------------------------------------------
-    rule <k> label [ TYPES ] { _ } VALSTACK' => . ... </k>
+    syntax Label ::= "label" OptionalId VecType "{" Instrs "}" ValStack
+ // -------------------------------------------------------------------
+    rule <k> label ID [ TYPES ] { _ } VALSTACK' => . ... </k>
          <valstack> VALSTACK => #take(TYPES, VALSTACK) ++ VALSTACK' </valstack>
 
     syntax Instr ::= "block" TypeDecls Instrs "end"
@@ -336,10 +336,14 @@ Note that, unlike in the WebAssembly specification document, we do not need the 
  // --------------------------------
     rule <k> br TFIDX ~> (SS:Stmts => .) ... </k>
     rule <k> br TFIDX ~> (PI:PlainInstr => .) ... </k>
-    rule <k> br 0     ~> label [ TYPES ] { IS } VALSTACK' => IS ... </k>
+    rule <k> br 0     ~> label ID [ TYPES ] { IS } VALSTACK' => IS ... </k>
          <valstack> VALSTACK => #take(TYPES, VALSTACK) ++ VALSTACK' </valstack>
     rule <k> br N:Int ~> L:Label => br N -Int 1 ... </k>
       requires N >Int 0
+    rule <k> br ID:Identifier ~> label ID  [ TYPES ] { IS } VALSTACK' => IS ... </k>
+         <valstack> VALSTACK => #take(TYPES, VALSTACK) ++ VALSTACK' </valstack>
+    rule <k> br ID:Identifier ~> label ID' [ TYPES ] { IS } VALSTACK' => br ID ... </k>
+      requires ID =/=K ID'
 
     syntax PlainInstr ::= "br_if" Index
  // -----------------------------------

--- a/wasm.md
+++ b/wasm.md
@@ -102,13 +102,16 @@ All places in the data with no entry are considered zero bytes.
 Instructions
 ------------
 
-### Text Format
+According to the WebAssembly semantics there are 3 categories of instructions.
 
-WebAssmebly code consists of instruction sequences.
-The basic abstract syntax contains only the `instr` syntax production.
-The text format also specifies the `plaininstr`, which corresponds almost exactly to the the `instr` production.
+-  Plain Instructions (`PlainInstr`): Most instructions are plain instructions. They could be wrapped in parentheses and optionally includes nested folded instructions to indicate its operands.
+-  Structured control instructions (`BlockInstr`): Structured control instructions are used to control the program flow. They can be annotated with a symbolic label identifier.
+-  Folded Instructions (`FoldedInstr`): Folded Instructions describes the rules of desugaring plain instructions and block instructions.
 
-Most instructions are plain instructions.
+The core semantics deals with plain instructions and block instructions.
+Folded instructions are part of the text format only.
+
+Also in our definition, there are some helper instructions not directly used in programs but will help us define the rules, they are directly subsorted into `Instr`.
 
 ```k
     syntax Instr ::= PlainInstr | BlockInstr

--- a/wasm.md
+++ b/wasm.md
@@ -108,11 +108,10 @@ According to the WebAssembly semantics there are 3 categories of instructions.
 -  Structured control instructions (`BlockInstr`): Structured control instructions are used to control the program flow. They can be annotated with a symbolic label identifier.
 -  Folded Instructions (`FoldedInstr`): Folded Instructions describes the rules of desugaring plain instructions and block instructions.
 
-Also in our definition, there are some helper instructions not directly used in programs but will help us define the rules, they are directly subsorted into `Instr`.
-
 ```k
     syntax Instr ::= PlainInstr | BlockInstr | FoldedInstr
  // ------------------------------------------------------
+    rule P:PlainInstr => 
 
     syntax FoldedInstr ::= "(" PlainInstr Instrs ")"
                          | "(" PlainInstr        ")" [prefer]

--- a/wasm.md
+++ b/wasm.md
@@ -335,8 +335,8 @@ Upon reaching it, the label itself is executed.
 Note that, unlike in the WebAssembly specification document, we do not need the special "context" operator here because the value and instruction stacks are separate.
 
 ```k
-    syntax PlainInstr ::= "br" TextFormatIdx
- // ----------------------------------------
+    syntax PlainInstr ::= "br" Index
+ // --------------------------------
     rule <k> br TFIDX ~> (SS:Stmts => .) ... </k>
     rule <k> br TFIDX ~> (PI:PlainInstr => .) ... </k>
     rule <k> br 0     ~> label ID [ TYPES ] { IS } VALSTACK' => IS ... </k>
@@ -348,8 +348,8 @@ Note that, unlike in the WebAssembly specification document, we do not need the 
     rule <k> br ID:Identifier ~> label ID' [ TYPES ] { IS } VALSTACK' => br ID ... </k>
       requires ID =/=K ID'
 
-    syntax PlainInstr ::= "br_if" TextFormatIdx
- // -------------------------------------------
+    syntax PlainInstr ::= "br_if" Index
+ // -----------------------------------
     rule <k> br_if TFIDX => br TFIDX ... </k>
          <valstack> < TYPE > VAL : VALSTACK => VALSTACK </valstack>
       requires VAL =/=Int 0
@@ -434,10 +434,10 @@ The various `init_local` variants assist in setting up the `locals` cell.
 The `*_local` instructions are defined here.
 
 ```k
-    syntax PlainInstr ::= "local.get" TextFormatIdx
-                        | "local.set" TextFormatIdx
-                        | "local.tee" TextFormatIdx
- //------------------------------------------------
+    syntax PlainInstr ::= "local.get" Index
+                        | "local.set" Index
+                        | "local.tee" Index
+ //----------------------------------------
     rule <k> local.get TFIDX => . ... </k>
          <valstack> VALSTACK => VALUE : VALSTACK </valstack>
          <locals> ... #ContextLookup(IDS , TFIDX) |-> VALUE ... </locals>
@@ -505,9 +505,9 @@ The importing and exporting parts of specifications are dealt with in the respec
 The `get` and `set` instructions read and write globals.
 
 ```k
-    syntax PlainInstr ::= "global.get" TextFormatIdx
-                        | "global.set" TextFormatIdx
- // ------------------------------------------------
+    syntax PlainInstr ::= "global.get" Index
+                        | "global.set" Index
+ // ----------------------------------------
     rule <k> global.get TFIDX => . ... </k>
          <valstack> VALSTACK => VALUE : VALSTACK </valstack>
          <curModIdx> CUR </curModIdx>
@@ -578,9 +578,9 @@ A type use should start with `'(' 'type' x:typeidx ')'` followed by a group of i
 
 ```k
     syntax TypeUse ::= TypeDecls
-                     | "(type" TextFormatIdx ")"           [prefer]
-                     | "(type" TextFormatIdx ")" TypeDecls
- // ------------------------------------------------------
+                     | "(type" Index ")"           [prefer]
+                     | "(type" Index ")" TypeDecls
+ // ----------------------------------------------
 
     syntax FuncType ::= asFuncType ( TypeDecls )         [function, klabel(TypeDeclsAsFuncType)]
                       | asFuncType ( Map, Map, TypeUse ) [function, klabel(TypeUseAsFuncType)  ]
@@ -752,8 +752,8 @@ The `#take` function will return the parameter stack in the reversed order, then
 `call funcidx` and `call_indirect typeidx` are 2 control instructions that invokes a function in the current frame.
 
 ```k
-    syntax PlainInstr ::= "call" TextFormatIdx
- // ------------------------------------------
+    syntax PlainInstr ::= "call" Index
+ // ----------------------------------
     rule <k> call TFIDX => ( invoke FADDR:Int ) ... </k>
          <curModIdx> CUR </curModIdx>
          <moduleInst>
@@ -1200,14 +1200,14 @@ The offset can either be specified explicitly with the `offset` key word, or be 
 ### Table initialization
 
 Tables can be initialized with element and the element type is always `funcref".
-The initialization of a table needs an offset and a list of functions, given as `TextFormatIdx`s.
+The initialization of a table needs an offset and a list of functions, given as `Index`s.
 A table index is optional and will be default to zero.
 
 ```k
     syntax Defn     ::= ElemDefn
-    syntax ElemDefn ::= "(" "elem"     TextFormatIdx Offset ElemSegment ")"
+    syntax ElemDefn ::= "(" "elem"     Index Offset ElemSegment ")"
                       | "(" "elem"                   Offset ElemSegment ")"
-                      |     "elem" "{" TextFormatIdx        ElemSegment "}"
+                      |     "elem" "{" Index        ElemSegment "}"
     syntax Stmt     ::= #initElements ( Int, Int, Map, Map, ElemSegment )
  // ---------------------------------------------------------------------
     // Default to table with index 0.
@@ -1243,10 +1243,10 @@ The `data` initializer simply puts these bytes into the specified memory, starti
 
 ```k
     syntax Defn     ::= DataDefn
-    syntax DataDefn ::= "(" "data"     TextFormatIdx Offset DataString ")"
+    syntax DataDefn ::= "(" "data"     Index Offset DataString ")"
                       | "(" "data"                   Offset DataString ")"
-                      |     "data" "{" TextFormatIdx        Bytes      "}"
- // ----------------------------------------------------------------------
+                      |     "data" "{" Index        Bytes      "}"
+ // --------------------------------------------------------------
     // Default to memory 0.
     rule <k> ( data       OFFSET:Offset STRINGS ) =>     ( data   0     OFFSET    STRINGS  ) ... </k>
     rule <k> ( data MEMID IS:Instr      STRINGS ) => IS ~> data { MEMID #DS2Bytes(STRINGS) } ... </k>
@@ -1286,8 +1286,8 @@ The `start` component of a module declares the function index of a `start functi
 
 ```k
     syntax Defn      ::= StartDefn
-    syntax StartDefn ::= "(" "start" TextFormatIdx ")"
- // --------------------------------------------------
+    syntax StartDefn ::= "(" "start" Index ")"
+ // ------------------------------------------
     rule <k> ( start TFIDX ) => ( invoke FADDR ) ... </k>
          <curModIdx> CUR </curModIdx>
          <moduleInst>
@@ -1307,7 +1307,7 @@ Exports make functions, tables, memories and globals available for importing int
     syntax Defn       ::= ExportDefn
     syntax ExportDefn ::= "(" "export" WasmString "(" Externval ")" ")"
  // -------------------------------------------------------------------
-    rule <k> ( export ENAME ( _:AllocatedKind TFIDX:TextFormatIdx ) ) => . ... </k>
+    rule <k> ( export ENAME ( _:AllocatedKind TFIDX:Index ) ) => . ... </k>
          <curModIdx> CUR </curModIdx>
          <moduleInst>
            <modIdx> CUR </modIdx>

--- a/wasm.md
+++ b/wasm.md
@@ -1169,7 +1169,7 @@ A table index is optional and will be default to zero.
 ```k
     syntax Defn     ::= ElemDefn
     syntax ElemDefn ::= "(" "elem"     Index Offset ElemSegment ")"
-                      | "(" "elem"                   Offset ElemSegment ")"
+                      | "(" "elem"           Offset ElemSegment ")"
                       |     "elem" "{" Index        ElemSegment "}"
     syntax Stmt     ::= #initElements ( Int, Int, Map, Map, ElemSegment )
  // ---------------------------------------------------------------------
@@ -1207,7 +1207,7 @@ The `data` initializer simply puts these bytes into the specified memory, starti
 ```k
     syntax Defn     ::= DataDefn
     syntax DataDefn ::= "(" "data"     Index Offset DataString ")"
-                      | "(" "data"                   Offset DataString ")"
+                      | "(" "data"           Offset DataString ")"
                       |     "data" "{" Index        Bytes      "}"
  // --------------------------------------------------------------
     // Default to memory 0.

--- a/wasm.md
+++ b/wasm.md
@@ -851,7 +851,6 @@ The importing and exporting parts of specifications are dealt with in the respec
     syntax Defn      ::= TableDefn
     syntax TableType ::= Limits TableElemType
     syntax TableSpec ::= TableType
-                       | TableElemType "(" "elem" ElemSegment ")"
     syntax TableDefn ::= "(" "table"     OptionalId TableSpec ")"
                        |     "table" "{" OptionalId Int OptionalInt "}"
  // -------------------------------------------------------------------
@@ -860,15 +859,6 @@ The importing and exporting parts of specifications are dealt with in the respec
     rule <k> ( table OID:OptionalId MIN:Int MAX:Int funcref ):TableDefn => table { OID MIN MAX  } ... </k>
       requires MIN <=Int #maxTableSize()
        andBool MAX <=Int #maxTableSize()
-
-    rule <k> ( table funcref ( elem ES ) ) => ( table #freshId(NEXTID) funcref (elem ES) ) ... </k>
-         <nextFreshId> NEXTID => NEXTID +Int 1 </nextFreshId>
-
-    rule <k> ( table ID:Identifier funcref ( elem ES ) )
-          =>  table { ID #lenElemSegment(ES) #lenElemSegment(ES) }
-          ~> ( elem ID (i32.const 0) ES )
-          ...
-         </k>
 
     rule <k> table { _ _ _ } => trap ... </k>
          <curModIdx> CUR </curModIdx>
@@ -916,7 +906,6 @@ The importing and exporting parts of specifications are dealt with in the respec
     syntax Defn       ::= MemoryDefn
     syntax MemType    ::= Limits
     syntax MemorySpec ::= MemType
-                        | "(" "data" DataString ")"
     syntax MemoryDefn ::= "(" "memory" OptionalId MemorySpec ")"
                         |     "memory" "{" OptionalId Int OptionalInt "}"
  // ---------------------------------------------------------------------
@@ -925,14 +914,6 @@ The importing and exporting parts of specifications are dealt with in the respec
     rule <k> ( memory OID:OptionalId MIN:Int MAX:Int ):MemoryDefn => memory { OID MIN MAX  } ... </k>
       requires MIN <=Int #maxMemorySize()
        andBool MAX <=Int #maxMemorySize()
-
-    rule <k> ( memory ( data DS ) ) => ( memory #freshId(NEXTID) (data DS) ) ... </k>
-         <nextFreshId> NEXTID => NEXTID +Int 1 </nextFreshId>
-
-    rule <k> ( memory ID:Identifier ( data DS ) )
-          =>  memory { ID #lengthDataPages(DS) #lengthDataPages(DS) }
-          ~> ( data ID (i32.const 0) DS ) ... </k>
-      requires #lengthDataPages(DS) <=Int #maxMemorySize()
 
     rule <k> memory { _ _ _ } => trap ... </k>
          <curModIdx> CUR </curModIdx>
@@ -1316,71 +1297,6 @@ Exports make functions, tables, memories and globals available for importing int
          </moduleInst>
 ```
 
-Exports can also be declared like regular functions, memories, etc., by giving an inline export declaration.
-In that case, it simply desugars to an export followed by the definition, after introducing a fresh identifier if no identifier is present.
-Note that it is possible to define multiple exports inline, i.e., export a single entity under many names.
-
-```k
-    syntax InlineExport  ::= "(" "export" WasmString ")"
- // ----------------------------------------------------
-
-    syntax GlobalSpec ::= InlineExport GlobalSpec
- // ---------------------------------------------
-    rule <k> ( global                  EXPO:InlineExport SPEC:GlobalSpec )
-          => ( global #freshId(NEXTID) EXPO              SPEC            )
-          ...
-         </k>
-         <nextFreshId> NEXTID => NEXTID +Int 1 </nextFreshId>
-
-    rule <k> ( global ID:Identifier ( export ENAME ) SPEC:GlobalSpec )
-          => ( export ENAME ( global ID ) )
-          ~> ( global ID SPEC )
-          ...
-         </k>
-
-    syntax FuncSpec   ::= InlineExport FuncSpec
- // -------------------------------------------
-    rule <k> ( func                  EXPO:InlineExport SPEC:FuncSpec )
-          => ( func #freshId(NEXTID) EXPO              SPEC          )
-          ...
-         </k>
-         <nextFreshId> NEXTID => NEXTID +Int 1 </nextFreshId>
-
-    rule <k> ( func ID:Identifier ( export ENAME ) SPEC:FuncSpec )
-          => ( export ENAME ( func ID ) )
-          ~> ( func ID SPEC )
-          ...
-         </k>
-
-    syntax TableSpec  ::= InlineExport TableSpec
- // --------------------------------------------
-    rule <k> ( table                  EXPO:InlineExport SPEC:TableSpec )
-          => ( table #freshId(NEXTID) EXPO              SPEC           )
-          ...
-         </k>
-         <nextFreshId> NEXTID => NEXTID +Int 1 </nextFreshId>
-
-    rule <k> ( table ID:Identifier ( export ENAME ) SPEC:TableSpec )
-          => ( export ENAME ( table ID ) )
-          ~> ( table ID SPEC )
-          ...
-         </k>
-
-    syntax MemorySpec ::= InlineExport MemorySpec
- // ---------------------------------------------
-    rule <k> ( memory                  EXPO:InlineExport SPEC:MemorySpec )
-          => ( memory #freshId(NEXTID) EXPO              SPEC            )
-          ...
-         </k>
-         <nextFreshId> NEXTID => NEXTID +Int 1 </nextFreshId>
-
-    rule <k> ( memory ID:Identifier ( export ENAME ) SPEC:MemorySpec )
-          => ( export ENAME ( memory ID ) )
-          ~> ( memory ID SPEC )
-          ...
-         </k>
-```
-
 Imports
 -------
 
@@ -1505,29 +1421,6 @@ The following function checks if the limits in the first parameter *match*, i.e.
     rule #limitsMatchImport(L1,      _, L2:Int   ) => L1 >=Int L2
     rule #limitsMatchImport( _,   .Int,  _:Int  _) => false
     rule #limitsMatchImport(L1, U1:Int, L2:Int U2) => L1 >=Int L2 andBool U1 <=Int U2
-```
-
-Imports can also be declared like regular functions, memories, etc., by giving an inline import declaration.
-
-```k
-    syntax InlineImport ::= "(" "import" WasmString WasmString ")"
- // --------------------------------------------------------------
-
-    syntax GlobalSpec ::= InlineImport TextFormatGlobalType
- // -------------------------------------------------------
-    rule <k> ( global OID:OptionalId (import MOD NAME) TYP ) => ( import MOD NAME (global OID TYP) ) ... </k>
-
-    syntax FuncSpec ::= InlineImport TypeUse
- // ----------------------------------------
-    rule <k> ( func OID:OptionalId (import MOD NAME) TUSE ) => ( import MOD NAME (func OID TUSE) ) ... </k>
-
-    syntax TableSpec ::= InlineImport TableType
- // -------------------------------------------
-    rule <k> ( table OID:OptionalId (import MOD NAME) TT:TableType ) => ( import MOD NAME (table OID TT) ) ... </k>
-
-    syntax MemorySpec ::= InlineImport MemType
- // ------------------------------------------
-    rule <k> ( memory OID:OptionalId (import MOD NAME) MT:MemType ) => ( import MOD NAME (memory OID MT) ) ... </k>
 ```
 
 Module Instantiation

--- a/wasm.md
+++ b/wasm.md
@@ -102,22 +102,18 @@ All places in the data with no entry are considered zero bytes.
 Instructions
 ------------
 
+### Text Format
+
+TODO: Break out into its own module.
+
 According to the WebAssembly semantics there are 3 categories of instructions.
 
 -  Plain Instructions (`PlainInstr`): Most instructions are plain instructions. They could be wrapped in parentheses and optionally includes nested folded instructions to indicate its operands.
 -  Structured control instructions (`BlockInstr`): Structured control instructions are used to control the program flow. They can be annotated with a symbolic label identifier.
--  Folded Instructions (`FoldedInstr`): Folded Instructions describes the rules of desugaring plain instructions and block instructions.
 
 ```k
-    syntax Instr ::= PlainInstr | BlockInstr | FoldedInstr
- // ------------------------------------------------------
-    rule P:PlainInstr => 
-
-    syntax FoldedInstr ::= "(" PlainInstr Instrs ")"
-                         | "(" PlainInstr        ")" [prefer]
- // ---------------------------------------------------------
-    rule <k> ( PI:PlainInstr IS:Instrs ):FoldedInstr => IS ~> PI ... </k>
-    rule <k> ( PI:PlainInstr           ):FoldedInstr =>       PI ... </k>
+    syntax Instr ::= PlainInstr | BlockInstr
+ // ----------------------------------------
 ```
 
 ### Sequencing
@@ -325,10 +321,6 @@ It simply executes the block then records a label with an empty continuation.
     rule <k> label ID [ TYPES ] { _ } VALSTACK' => . ... </k>
          <valstack> VALSTACK => #take(TYPES, VALSTACK) ++ VALSTACK' </valstack>
 
-    syntax FoldedInstr ::= "(" "block" OptionalId TypeDecls Instrs ")"
- // ------------------------------------------------------------------
-    rule <k> ( block OID:OptionalId TDECLS:TypeDecls INSTRS:Instrs ) => block OID TDECLS INSTRS end ... </k>
-
     syntax BlockInstr ::= "block" OptionalId TypeDecls Instrs "end" OptionalId
  // --------------------------------------------------------------------------
     rule <k> block OID:OptionalId TDECLS IS end OID':OptionalId => IS ~> label OID gatherTypes(result, TDECLS) { .Instrs } VALSTACK ... </k>
@@ -374,12 +366,6 @@ Note that, unlike in the WebAssembly specification document, we do not need the 
 Finally, we have the conditional and loop instructions.
 
 ```k
-    syntax FoldedInstr ::= "(" "if" OptionalId TypeDecls Instrs "(" "then" Instrs ")" ")"
-                         | "(" "if" OptionalId TypeDecls Instrs "(" "then" Instrs ")" "(" "else" Instrs ")" ")"
- // -----------------------------------------------------------------------------------------------------------
-    rule <k> ( if OID:OptionalId TDECLS:TypeDecls C:Instrs ( then IS ) )              => C ~> if OID TDECLS IS else .Instrs end ... </k>
-    rule <k> ( if OID:OptionalId TDECLS:TypeDecls C:Instrs ( then IS ) ( else IS' ) ) => C ~> if OID TDECLS IS else IS'     end ... </k>
-
     syntax BlockInstr ::= "if" OptionalId TypeDecls Instrs "else" OptionalId Instrs "end" OptionalId
                         | "if" OptionalId TypeDecls Instrs                          "end" OptionalId
  // ------------------------------------------------------------------------------------------------
@@ -398,10 +384,6 @@ Finally, we have the conditional and loop instructions.
       requires VAL ==Int 0
        andBool ( OID ==K OID'  orBool notBool isIdentifier(OID')  )
        andBool ( OID ==K OID'' orBool notBool isIdentifier(OID'') )
-
-    syntax FoldedInstr ::= "(" "loop" OptionalId TypeDecls Instrs ")"
- // -----------------------------------------------------------------
-    rule <k> ( loop OID:OptionalId TDECLS:TypeDecls IS ) => loop OID TDECLS IS end ... </k>
 
     syntax BlockInstr ::= "loop" OptionalId TypeDecls Instrs "end" OptionalId
  // -------------------------------------------------------------------------

--- a/wasm.md
+++ b/wasm.md
@@ -359,8 +359,8 @@ Note that, unlike in the WebAssembly specification document, we do not need the 
 Finally, we have the conditional and loop instructions.
 
 ```k
-    syntax Instr ::= "if" TypeDecls Instrs "else" OptionalId Instrs "end"
- // ---------------------------------------------------------------------
+    syntax Instr ::= "if" TypeDecls Instrs "else" Instrs "end"
+ // ----------------------------------------------------------
     rule <k> if TDECLS:TypeDecls IS else IS' end => IS  ~> label gatherTypes(result, TDECLS) { .Instrs } VALSTACK ... </k>
          <valstack> < i32 > VAL : VALSTACK => VALSTACK </valstack>
       requires VAL =/=Int 0

--- a/wasm.md
+++ b/wasm.md
@@ -104,11 +104,11 @@ Instructions
 
 ### Text Format
 
-TODO: Break out into its own module.
+WebAssmebly code consists of instruction sequences.
+The basic abstract syntax contains only the `instr` syntax production.
+The text format also specifies the `plaininstr`, which corresponds almost exactly to the the `instr` production.
 
-According to the WebAssembly semantics there are 3 categories of instructions.
-
--  Plain Instructions (`PlainInstr`): Most instructions are plain instructions. They could be wrapped in parentheses and optionally includes nested folded instructions to indicate its operands.
+Most instructions are plain instructions.
 
 ```k
     syntax Instr ::= PlainInstr


### PR DESCRIPTION
Introduce a separate module for the text format.

Instead of having all these rules in the core syntax, we can keep them in a separate module. This both makes the core semantics smaller, more like the official spec, and a smaller compile target for the binary format.

This is not a full separation of text format and core semantics. The following remains:
1a. Getting rid of any mentions identifiers in the definitions in the core semantics, ideally by making all the definitions more abstract in the core semantics, and only giving their text format, with identifiers and all, in the text semantics. This can be achieved since this PR splits the definitions of `Index`, and all lookups pass through the `#ContextLookup` function.
1b. Getting rid of identifiers on branches and labels in the core semantics (requires some way to look up the correct branching index).
2. Only using integers in the core semantics and getting rid of the `#ContextLookup`. 
  2a. Move all definitions (functions, memories, etc.) with identifiers to the text format.
  2b. Get rid of `#ContextLookup` altogether: remove it from types lookups, etc.
3. Getting rid of all the `<*Ids>` cells in the core configuration and use configuration composition to add identifiers.

I'd say 1a. is really nice, and I have actually implemented it, and have an upcoming PR for it. 1b could be achieved by looking through the `<k>` cell, counting labels until you get to the label you are looking for. Not super elegant, but gets the job done. 2. is also a nice improvement, and because `#ContextLookup` is an inelegant dependency on the text format in the core semantics. 3. is perhaps a bit overkill.