### PR TITLE
Text format: get rid of `OptionalId` in the core semantics

### DIFF
--- a/data.md
+++ b/data.md
@@ -91,13 +91,6 @@ And we use `OptionalId` to handle the case where an identifier could be omitted.
 In KWasm we store identifiers in maps from `Identifier` to `Int`, the `Int` being an index.
 This rule handles adding an `OptionalId` as a map key, but only when it is a proper identifier.
 
-```k
-    syntax Map ::= #saveId (Map, OptionalId, Int) [function]
- // -------------------------------------------------------
-    rule #saveId (MAP, ID:OptionalId, _)   => MAP             requires notBool isIdentifier(ID)
-    rule #saveId (MAP, ID:Identifier, IDX) => MAP [ID <- IDX]
-```
-
 ### Indices
 
 Many constructions in Wasm, such a functions, labels, locals, types, etc., are referred to by their index.

--- a/data.md
+++ b/data.md
@@ -28,26 +28,6 @@ Note that you cannot use a normal K `String` in any production definitions, beca
  // -----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 ```
 
-### Identifiers
-
-In WebAssembly, identifiers are defined by the regular expression below.
-
-```k
-    syntax Identifier ::= r"\\$[0-9a-zA-Z!$%&'*+/<>?_`|~=:\\@^.-]+" [token]
- // -----------------------------------------------------------------------
-```
-
-### Integers
-
-In WebAssembly, integers could be represented in either the decimal form or hexadecimal form.
-In both cases, digits can optionally be separated by underscores.
-
-```k
-    syntax WasmInt ::= r"[\\+-]?[0-9]+(_[0-9]+)*"               [token]
-                     | r"[\\+-]?0x[0-9a-fA-F]+(_[0-9a-fA-F]+)*" [token]
- // -------------------------------------------------------------------
-```
-
 ### Layout
 
 WebAssembly allows for block comments using `(;` and `;)`, and line comments using `;;`.
@@ -77,19 +57,6 @@ module WASM-DATA
     imports FLOAT
     imports BYTES
 ```
-
-In `KWASM` rules, we use `#freshId ( Int )` to generate a fresh identifier based on the element index in the current module.
-And we use `OptionalId` to handle the case where an identifier could be omitted.
-
-```k
-    syntax Identifier ::= #freshId ( Int )
-    syntax OptionalId ::= "" [klabel(.Identifier)]
-                        | Identifier
- // --------------------------------
-```
-
-In KWasm we store identifiers in maps from `Identifier` to `Int`, the `Int` being an index.
-This rule handles adding an `OptionalId` as a map key, but only when it is a proper identifier.
 
 ### Indices
 
@@ -149,16 +116,14 @@ WebAssembly Types
 
 WebAssembly has four basic types, for 32 and 64 bit integers and floats.
 Here we define `AValType` which stands for `anonymous valtype`, representing values that doesn't have an identifier associated to it.
-Also we define `NValType` which stands for `named valtype`, representing values that has an identifier associated to it.
-`ValType` is the aggregation of `AValType` and `NValType`.
+`ValType` is the aggregation of all representations of values (the text format extends it with a named value type).
 
 ```k
     syntax IValType ::= "i32" | "i64"
     syntax FValType ::= "f32" | "f64"
     syntax AValType ::= IValType | FValType
-    syntax NValType ::= "{" Identifier AValType "}"
-    syntax ValType  ::= AValType | NValType
- // ---------------------------------------
+    syntax ValType  ::= AValType
+ // ----------------------------
 ```
 
 ### Type Constructors
@@ -189,7 +154,6 @@ We need helper functions to remove all the identifiers from a `ValTypes`.
  // ----------------------------------------------------------
     rule unnameValTypes ( .ValTypes     ) => .ValTypes
     rule unnameValTypes ( V:AValType VS ) => V unnameValTypes ( VS )
-    rule unnameValTypes ( { ID V } VS )   => V unnameValTypes ( VS )
 ```
 
 All told, a `Type` can be a value type, vector of types, or function type.

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -153,6 +153,8 @@ In the text format, it is also allowed to have a conditional without the `else` 
 Memory and Tables
 -----------------
 
+The `MemorySpec` and `TableSpec` productions are used to define all ways that a memory and table can specified.
+
 ```k
     syntax MemorySpec ::= MemType
     syntax MemoryDefn ::= "(" "memory" OptionalId MemorySpec ")"
@@ -162,6 +164,16 @@ Memory and Tables
     rule <k> ( memory OID:OptionalId MIN:Int MAX:Int ):MemoryDefn => memory { MIN MAX  } ~> #saveIdentifier memory OID ... </k>
       requires MIN <=Int #maxMemorySize()
        andBool MAX <=Int #maxMemorySize()
+
+    syntax TableSpec ::= TableType
+    syntax TableDefn ::= "(" "table" OptionalId TableSpec ")"
+ // ---------------------------------------------------------
+    rule <k> ( table OID:OptionalId MIN:Int         funcref ):TableDefn => table { MIN .Int } ~> #saveIdentifier table OID ... </k>
+      requires MIN <=Int #maxTableSize()
+    rule <k> ( table OID:OptionalId MIN:Int MAX:Int funcref ):TableDefn => table { MIN MAX  } ~> #saveIdentifier table OID... </k>
+      requires MIN <=Int #maxTableSize()
+       andBool MAX <=Int #maxTableSize()
+
 ```
 
 Intitial memory data, and initial table elements can be given inline in the text format.
@@ -183,7 +195,7 @@ Intitial memory data, and initial table elements can be given inline in the text
          <nextFreshId> NEXTID => NEXTID +Int 1 </nextFreshId>
 
     rule <k> ( table ID:Identifier funcref ( elem ES ) )
-          =>  table { ID #lenElemSegment(ES) #lenElemSegment(ES) }
+          => ( table ID #lenElemSegment(ES) #lenElemSegment(ES) funcref ):TableDefn
           ~> ( elem ID (i32.const 0) ES )
           ...
          </k>

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -42,6 +42,10 @@ module WASM-TEXT
 ```
 
 The text format is a concrete syntax for Wasm.
+It introduces several syntactic sugars, such as
+- grouping expressions with parentheses,
+- allowing identifiers for indices,
+- inlining imports and exprts.
 Most instructions, those in the sort `PlainInstr`, have identical keywords in the abstract and concrete syntax, and can be used idrectly.
 
 Values

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -62,8 +62,38 @@ We define `NValType` which stands for `named valtype`, representing values that 
          <localIds> LOCALIDS => LOCALIDS [ ID <- I ] </localIds>
 ```
 
-Folded Instructions
--------------------
+Identifiers
+-----------
+
+In `KWASM` rules, we use `#freshId ( Int )` to generate a fresh identifier based on the element index in the current module.
+And we use `OptionalId` to handle the case where an identifier could be omitted.
+
+```k
+    syntax Identifier ::= #freshId ( Int )
+    syntax OptionalId ::= "" [klabel(.Identifier)]
+                        | Identifier
+ // --------------------------------
+```
+
+In the abstract Wasm syntax, indices are always integers.
+In the text format, we extend indices to incorporate identifiers.
+
+```k
+    syntax Index ::= Identifier
+ // ---------------------------
+```
+
+We enable context lookups with identifiers.
+
+```k
+    rule #ContextLookup(IDS:Map, ID:Identifier) => {IDS [ ID ]}:>Int
+      requires ID in_keys(IDS)
+```
+
+Instructions
+------------
+
+### Folded Instructions
 
 Folded instructions are a syntactic sugar where expressions can be grouped using parentheses, like S-expressions, for higher readability.
 
@@ -101,34 +131,6 @@ Another type of folded instruction is control flow blocks wrapped in parentheses
  // -----------------------------------------------------------------
     rule <k> ( loop               TDECLS:TypeDecls IS ) => loop    TDECLS IS end ... </k>
     rule <k> ( loop ID:Identifier TDECLS:TypeDecls IS ) => loop ID TDECLS IS end ... </k>
-```
-
-Identifiers
------------
-
-In `KWASM` rules, we use `#freshId ( Int )` to generate a fresh identifier based on the element index in the current module.
-And we use `OptionalId` to handle the case where an identifier could be omitted.
-
-```k
-    syntax Identifier ::= #freshId ( Int )
-    syntax OptionalId ::= "" [klabel(.Identifier)]
-                        | Identifier
- // --------------------------------
-```
-
-In the abstract Wasm syntax, indices are always integers.
-In the text format, we extend indices to incorporate identifiers.
-
-```k
-    syntax Index ::= Identifier
- // ---------------------------
-```
-
-We enable context lookups with identifiers.
-
-```k
-    rule #ContextLookup(IDS:Map, ID:Identifier) => {IDS [ ID ]}:>Int
-      requires ID in_keys(IDS)
 ```
 
 Block Instructions

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -181,11 +181,39 @@ Intitial memory data, and initial table elements can be given inline in the text
 Definitions
 -----------
 
+TODO: It's pretty ugly to access `NEXTIDX` the way we are doing here, ideally it should be more functional.
+
 ```k
     syntax DefinitionType ::= "type" | "func" | "table" | "memory" | "global"
     syntax Instr ::= "#saveIdentifier" DefinitionType OptionalId
  // ------------------------------------------------------------
     rule <k> #saveIdentifier _:DefinitionType => . ... </k>
+
+    rule <k> #saveIdentifier func ID:Identifier => . ... </k>
+         <curModIdx> CUR </curModIdx>
+         <moduleInst>
+           <modIdx> CUR </modIdx>
+           <funcIds> IDS => IDS [ID <- NEXTIDX -Int 1] </funcIds>
+           <nextFuncIdx> NEXTIDX </nextFuncIdx>
+           ...
+         </moduleInst>
+
+    rule <k> #saveIdentifier table ID:Identifier => . ... </k>
+         <curModIdx> CUR </curModIdx>
+         <moduleInst>
+           <modIdx> CUR </modIdx>
+           <tabIds> IDS => IDS [ ID <- 0] </tabIds>
+           ...
+         </moduleInst>
+
+    rule <k> #saveIdentifier memory ID:Identifier => . ... </k>
+         <curModIdx> CUR </curModIdx>
+         <moduleInst>
+           <modIdx> CUR </modIdx>
+           <memIds> IDS => IDS [ ID <- 0] </memIds>
+           ...
+         </moduleInst>
+
     rule <k> #saveIdentifier global ID:Identifier => . ... </k>
          <curModIdx> CUR </curModIdx>
          <moduleInst>
@@ -293,9 +321,16 @@ Imports
 Imports can optionally have identifiers.
 
 ```k
-    syntax ImportDesc ::= "(" "global" OptionalId TextFormatGlobalType ")" [klabel(globTextFormatImportDesc)]
- // ---------------------------------------------------------------------------------------------------------
-    rule <k> ( import MOD NAME (global OID:OptionalId TYP:TextFormatGlobalType) ) => ( import MOD NAME (global asGMut(TYP))) ~> #saveIdentifier global OID ... </k>
+    syntax ImportDefn ::= "(" "import" WasmString WasmString ImportDesc ")"
+    syntax ImportDesc ::= "(" "func"   OptionalId TypeUse              ")" [klabel(funcImportDesc)]
+                        | "(" "table"  OptionalId TableType            ")" [klabel( tabImportDesc)]
+                        | "(" "memory" OptionalId MemType              ")" [klabel( memImportDesc)]
+                        | "(" "global" OptionalId TextFormatGlobalType ")" [klabel(globImportDesc)]
+ // -----------------------------------------------------------------------------------------------
+    rule <k> ( import MOD NAME (func   OID:OptionalId TUSE) ) => import { MOD NAME func   TUSE         } ~> #saveIdentifier func   OID ... </k>
+    rule <k> ( import MOD NAME (table  OID:OptionalId TTYP) ) => import { MOD NAME table  TTYP         } ~> #saveIdentifier table  OID ... </k>
+    rule <k> ( import MOD NAME (memory OID:OptionalId MTYP) ) => import { MOD NAME memory MTYP         } ~> #saveIdentifier memory OID ... </k>
+    rule <k> ( import MOD NAME (global OID:OptionalId GTYP) ) => import { MOD NAME global asGMut(GTYP) } ~> #saveIdentifier global OID ... </k>
 ```
 
 Imports can be declared like regular functions, memories, etc., by giving an inline import declaration.

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -392,33 +392,30 @@ The groups are chosen to represent different stages of allocation and instantiat
                  | #initialMap ()                [function]
  // -------------------------------------------------------
     rule #initialMap ()
-      => "typeDecls" |-> .Defns
+      => "types"     |-> .Defns
          "imports"   |-> .Defns
-         "func/glob" |-> .Defns
-         "allocs"    |-> .Defns
+         "functions" |-> .Defns
+         "tables"    |-> .Defns
+         "memories"  |-> .Defns
+         "globals"   |-> .Defns
          "exports"   |-> .Defns
-         "inits"     |-> .Defns
          "start"     |-> .Defns
+         "elem"      |-> .Defns
+         "data"      |-> .Defns
 
     rule structureModule(DS) => #structureModule(#initialMap (), #reverse(DS, .Defns))
 
     rule #structureModule(M,                  .Defns) => M
-    rule #structureModule(M, (T:TypeDefn   DS:Defns)) => #structureModule(M ["typeDecls" <- (T {M ["typeDecls"]}:>Defns)], DS)
-
-    rule #structureModule(M, (I:ImportDefn DS:Defns)) => #structureModule(M ["imports"   <- (I {M ["imports"  ]}:>Defns)], DS)
-
-    rule #structureModule(M, (X:FuncDefn   DS:Defns)) => #structureModule(M ["func/glob" <- (X {M ["func/glob"]}:>Defns)], DS)
-    rule #structureModule(M, (X:GlobalDefn DS:Defns)) => #structureModule(M ["func/glob" <- (X {M ["func/glob"]}:>Defns)], DS)
-
-    rule #structureModule(M, (A:TableDefn  DS:Defns)) => #structureModule(M ["allocs"    <- (A {M ["allocs"   ]}:>Defns)], DS)
-    rule #structureModule(M, (A:MemoryDefn DS:Defns)) => #structureModule(M ["allocs"    <- (A {M ["allocs"   ]}:>Defns)], DS)
-
-    rule #structureModule(M, (E:ExportDefn DS:Defns)) => #structureModule(M ["exports"   <- (E {M ["exports"  ]}:>Defns)], DS)
-
-    rule #structureModule(M, (I:DataDefn   DS:Defns)) => #structureModule(M ["inits"     <- (I {M ["inits"    ]}:>Defns)], DS)
-    rule #structureModule(M, (I:ElemDefn   DS:Defns)) => #structureModule(M ["inits"     <- (I {M ["inits"    ]}:>Defns)], DS)
-
-    rule #structureModule(M, (S:StartDefn  DS:Defns)) => #structureModule(M ["start"     <- (S .Defns)],                   DS)
+    rule #structureModule(M, (T:TypeDefn    DS:Defns)) => #structureModule(M ["types"     <- (T  {M ["types"    ]}:>Defns)], DS)
+    rule #structureModule(M, (I:ImportDefn  DS:Defns)) => #structureModule(M ["imports"   <- (I  {M ["imports"  ]}:>Defns)], DS)
+    rule #structureModule(M, (F:FuncDefn    DS:Defns)) => #structureModule(M ["functions" <- (F  {M ["functions"]}:>Defns)], DS)
+    rule #structureModule(M, (T:TableDefn   DS:Defns)) => #structureModule(M ["tables"    <- (T  {M ["tables"   ]}:>Defns)], DS)
+    rule #structureModule(M, (MM:MemoryDefn DS:Defns)) => #structureModule(M ["memories"  <- (MM {M ["memories" ]}:>Defns)], DS)
+    rule #structureModule(M, (G:GlobalDefn  DS:Defns)) => #structureModule(M ["globals"   <- (G  {M ["globals"  ]}:>Defns)], DS)
+    rule #structureModule(M, (E:ExportDefn  DS:Defns)) => #structureModule(M ["exports"   <- (E  {M ["exports"  ]}:>Defns)], DS)
+    rule #structureModule(M, (S:StartDefn   DS:Defns)) => #structureModule(M ["start"     <- (S  .Defns                  )], DS)
+    rule #structureModule(M, (E:ElemDefn    DS:Defns)) => #structureModule(M ["elem"      <- (E  {M ["elem"     ]}:>Defns)], DS)
+    rule #structureModule(M, (D:DataDefn    DS:Defns)) => #structureModule(M ["data"      <- (D  {M ["data"     ]}:>Defns)], DS)
 
     syntax Defns ::= #reverse(Defns, Defns) [function]
  // --------------------------------------------------
@@ -433,6 +430,17 @@ It is permissible to define modules without the `module` keyword, by simply stat
          <curModIdx> .Int </curModIdx>
 ```
 
+### Binary Modules
+
+**TODO**: Implement modules represented in binary format.
+
+```k
+    syntax ModuleDecl ::= "(" "module" OptionalId "binary" DataString ")"
+                        | "module" "binary" Int
+ // -------------------------------------------
+    rule <k> ( module OID binary DS ) => module binary Bytes2Int(#DS2Bytes(DS), LE, Unsigned) ... </k>
+    rule <k> module binary I => . ... </k>
+```
 
 ```k
 endmodule

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -200,57 +200,6 @@ In the text format, it is also allowed to have a conditional without the `else` 
        andBool ( ID ==K OID'' orBool notBool isIdentifier(OID'') )
 ```
 
-Memory and Tables
------------------
-
-The `MemorySpec` and `TableSpec` productions are used to define all ways that a memory and table can specified.
-
-```k
-    syntax MemorySpec ::= MemType
-    syntax MemoryDefn ::= "(" "memory" OptionalId MemorySpec ")"
- // ------------------------------------------------------------
-    rule <k> ( memory OID:OptionalId MIN:Int         ):MemoryDefn => memory { MIN .Int } ~> #saveIdentifier memory OID ... </k>
-      requires MIN <=Int #maxMemorySize()
-    rule <k> ( memory OID:OptionalId MIN:Int MAX:Int ):MemoryDefn => memory { MIN MAX  } ~> #saveIdentifier memory OID ... </k>
-      requires MIN <=Int #maxMemorySize()
-       andBool MAX <=Int #maxMemorySize()
-
-    syntax TableSpec ::= TableType
-    syntax TableDefn ::= "(" "table" OptionalId TableSpec ")"
- // ---------------------------------------------------------
-    rule <k> ( table OID:OptionalId MIN:Int         funcref ):TableDefn => table { MIN .Int } ~> #saveIdentifier table OID ... </k>
-      requires MIN <=Int #maxTableSize()
-    rule <k> ( table OID:OptionalId MIN:Int MAX:Int funcref ):TableDefn => table { MIN MAX  } ~> #saveIdentifier table OID... </k>
-      requires MIN <=Int #maxTableSize()
-       andBool MAX <=Int #maxTableSize()
-
-```
-
-Intitial memory data, and initial table elements can be given inline in the text format.
-
-```k
-    syntax MemorySpec ::= "(" "data" DataString ")"
- // -----------------------------------------------
-    rule <k> ( memory ( data DS ) ) => ( memory #freshId(NEXTID) (data DS) ) ... </k>
-         <nextFreshId> NEXTID => NEXTID +Int 1 </nextFreshId>
-
-    rule <k> ( memory ID:Identifier ( data DS ) )
-          => ( memory ID #lengthDataPages(DS) #lengthDataPages(DS) ):MemoryDefn
-          ~> ( data ID (i32.const 0) DS ) ... </k>
-      requires #lengthDataPages(DS) <=Int #maxMemorySize()
-
-    syntax TableSpec ::= TableElemType "(" "elem" ElemSegment ")"
- // -------------------------------------------------------------
-    rule <k> ( table funcref ( elem ES ) ) => ( table #freshId(NEXTID) funcref (elem ES) ) ... </k>
-         <nextFreshId> NEXTID => NEXTID +Int 1 </nextFreshId>
-
-    rule <k> ( table ID:Identifier funcref ( elem ES ) )
-          => ( table ID #lenElemSegment(ES) #lenElemSegment(ES) funcref ):TableDefn
-          ~> ( elem ID (i32.const 0) ES )
-          ...
-         </k>
-```
-
 Definitions
 -----------
 
@@ -362,6 +311,56 @@ In the abstract syntax, types are tagged with `var` or `const`, whereas in the t
     rule <k> ( global OID:OptionalId TYP:TextFormatGlobalType IS:Instr )
           => global { asGMut(TYP) IS }
           ~> #saveIdentifier global OID
+          ...
+         </k>
+```
+
+### Memories and Tables
+
+The `MemorySpec` and `TableSpec` productions are used to define all ways that a memory and table can specified.
+
+```k
+    syntax MemorySpec ::= MemType
+    syntax MemoryDefn ::= "(" "memory" OptionalId MemorySpec ")"
+ // ------------------------------------------------------------
+    rule <k> ( memory OID:OptionalId MIN:Int         ):MemoryDefn => memory { MIN .Int } ~> #saveIdentifier memory OID ... </k>
+      requires MIN <=Int #maxMemorySize()
+    rule <k> ( memory OID:OptionalId MIN:Int MAX:Int ):MemoryDefn => memory { MIN MAX  } ~> #saveIdentifier memory OID ... </k>
+      requires MIN <=Int #maxMemorySize()
+       andBool MAX <=Int #maxMemorySize()
+
+    syntax TableSpec ::= TableType
+    syntax TableDefn ::= "(" "table" OptionalId TableSpec ")"
+ // ---------------------------------------------------------
+    rule <k> ( table OID:OptionalId MIN:Int         funcref ):TableDefn => table { MIN .Int } ~> #saveIdentifier table OID ... </k>
+      requires MIN <=Int #maxTableSize()
+    rule <k> ( table OID:OptionalId MIN:Int MAX:Int funcref ):TableDefn => table { MIN MAX  } ~> #saveIdentifier table OID... </k>
+      requires MIN <=Int #maxTableSize()
+       andBool MAX <=Int #maxTableSize()
+
+```
+
+Intitial memory data, and initial table elements can be given inline in the text format.
+
+```k
+    syntax MemorySpec ::= "(" "data" DataString ")"
+ // -----------------------------------------------
+    rule <k> ( memory ( data DS ) ) => ( memory #freshId(NEXTID) (data DS) ) ... </k>
+         <nextFreshId> NEXTID => NEXTID +Int 1 </nextFreshId>
+
+    rule <k> ( memory ID:Identifier ( data DS ) )
+          => ( memory ID #lengthDataPages(DS) #lengthDataPages(DS) ):MemoryDefn
+          ~> ( data ID (i32.const 0) DS ) ... </k>
+      requires #lengthDataPages(DS) <=Int #maxMemorySize()
+
+    syntax TableSpec ::= TableElemType "(" "elem" ElemSegment ")"
+ // -------------------------------------------------------------
+    rule <k> ( table funcref ( elem ES ) ) => ( table #freshId(NEXTID) funcref (elem ES) ) ... </k>
+         <nextFreshId> NEXTID => NEXTID +Int 1 </nextFreshId>
+
+    rule <k> ( table ID:Identifier funcref ( elem ES ) )
+          => ( table ID #lenElemSegment(ES) #lenElemSegment(ES) funcref ):TableDefn
+          ~> ( elem ID (i32.const 0) ES )
           ...
          </k>
 ```

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -184,7 +184,7 @@ Definitions
 TODO: It's pretty ugly to access `NEXTIDX` the way we are doing here, ideally it should be more functional.
 
 ```k
-    syntax DefinitionType ::= "type" | "func" | "table" | "memory" | "global"
+    syntax DefinitionType ::= "type" | "func" | "table" | "memory" | "global" | "module"
     syntax Instr ::= "#saveIdentifier" DefinitionType OptionalId
  // ------------------------------------------------------------
     rule <k> #saveIdentifier _:DefinitionType => . ... </k>
@@ -222,6 +222,10 @@ TODO: It's pretty ugly to access `NEXTIDX` the way we are doing here, ideally it
            <nextGlobIdx> NEXTIDX </nextGlobIdx>
            ...
          </moduleInst>
+
+    rule <k> #saveIdentifier module ID:Identifier => . ... </k>
+         <moduleIds> IDS => IDS [ID <- NEXTIDX -Int 1 ] </moduleIds>
+         <nextModuleIdx> NEXTIDX </nextModuleIdx>
 ```
 
 ### Globals
@@ -355,6 +359,80 @@ Imports can be declared like regular functions, memories, etc., by giving an inl
  // ------------------------------------------
     rule <k> ( memory OID:OptionalId (import MOD NAME) MT:MemType ) => ( import MOD NAME (memory OID MT) ) ... </k>
 ```
+
+Modules
+-------
+
+In the text format, a module may have an identifier.
+The definitions may appear in any order, so before starting module instantiation, the defintions must be structured.
+
+```k
+    syntax ModuleDecl ::= "(" "module" OptionalId Defns ")"
+ // -------------------------------------------------------
+    rule <k> ( module OID:OptionalId DEFNS ) => module structureModule(DEFNS) ~> #saveIdentifier module OID ... </k>
+```
+
+However, there are some dependencies among definitions that require that we do them in a certain order, even though they may appear in many valid orders.
+First, functions, tables, memories and globals get *allocated*.
+Then, tables, memories and globals get *instantiated* with elements, data and initialization vectors.
+However, since (currently) globals can only make use of imported globals to be instantiated, we can initialize at allocation time.
+Finally, the start function is invoked.
+Exports may appear anywhere in a module, but can only be performed after what they refer to has been allocated.
+Exports that are inlined in a definition, e.g., `func (export "foo") ...`, are safe to extract as they appear.
+Imports must appear before any allocations in a module, due to validation.
+
+A subtle point is related to tables with inline `elem` definitions: since these may refer to functions by identifier, we need to make sure that tables definitions come after function definitions.
+
+`structureModule` takes a list of definitions and returns a map with different groups of definitions, preserving the order within each group.
+The groups are chosen to represent different stages of allocation and instantiation.
+
+```k
+    syntax Map ::=  structureModule (     Defns) [function]
+                 | #structureModule (Map, Defns) [function]
+                 | #initialMap ()                [function]
+ // -------------------------------------------------------
+    rule #initialMap ()
+      => "typeDecls" |-> .Defns
+         "imports"   |-> .Defns
+         "func/glob" |-> .Defns
+         "allocs"    |-> .Defns
+         "exports"   |-> .Defns
+         "inits"     |-> .Defns
+         "start"     |-> .Defns
+
+    rule structureModule(DS) => #structureModule(#initialMap (), #reverse(DS, .Defns))
+
+    rule #structureModule(M,                  .Defns) => M
+    rule #structureModule(M, (T:TypeDefn   DS:Defns)) => #structureModule(M ["typeDecls" <- (T {M ["typeDecls"]}:>Defns)], DS)
+
+    rule #structureModule(M, (I:ImportDefn DS:Defns)) => #structureModule(M ["imports"   <- (I {M ["imports"  ]}:>Defns)], DS)
+
+    rule #structureModule(M, (X:FuncDefn   DS:Defns)) => #structureModule(M ["func/glob" <- (X {M ["func/glob"]}:>Defns)], DS)
+    rule #structureModule(M, (X:GlobalDefn DS:Defns)) => #structureModule(M ["func/glob" <- (X {M ["func/glob"]}:>Defns)], DS)
+
+    rule #structureModule(M, (A:TableDefn  DS:Defns)) => #structureModule(M ["allocs"    <- (A {M ["allocs"   ]}:>Defns)], DS)
+    rule #structureModule(M, (A:MemoryDefn DS:Defns)) => #structureModule(M ["allocs"    <- (A {M ["allocs"   ]}:>Defns)], DS)
+
+    rule #structureModule(M, (E:ExportDefn DS:Defns)) => #structureModule(M ["exports"   <- (E {M ["exports"  ]}:>Defns)], DS)
+
+    rule #structureModule(M, (I:DataDefn   DS:Defns)) => #structureModule(M ["inits"     <- (I {M ["inits"    ]}:>Defns)], DS)
+    rule #structureModule(M, (I:ElemDefn   DS:Defns)) => #structureModule(M ["inits"     <- (I {M ["inits"    ]}:>Defns)], DS)
+
+    rule #structureModule(M, (S:StartDefn  DS:Defns)) => #structureModule(M ["start"     <- (S .Defns)],                   DS)
+
+    syntax Defns ::= #reverse(Defns, Defns) [function]
+ // --------------------------------------------------
+    rule #reverse(       .Defns  , ACC) => ACC
+    rule #reverse(D:Defn DS:Defns, ACC) => #reverse(DS, D ACC)
+```
+
+It is permissible to define modules without the `module` keyword, by simply stating the definitions at the top level in the file.
+
+```k
+    rule <k> D:Defn => ( module .Defns ) ~> D ... </k>
+         <curModIdx> .Int </curModIdx>
+```
+
 
 ```k
 endmodule

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -178,6 +178,46 @@ Intitial memory data, and initial table elements can be given inline in the text
          </k>
 ```
 
+Definitions
+-----------
+
+```k
+    syntax DefinitionType ::= "type" | "func" | "table" | "memory" | "global"
+    syntax Instr ::= "#saveIdentifier" DefinitionType OptionalId
+ // ------------------------------------------------------------
+    rule <k> #saveIdentifier _:DefinitionType => . ... </k>
+    rule <k> #saveIdentifier global ID:Identifier => . ... </k>
+         <curModIdx> CUR </curModIdx>
+         <moduleInst>
+           <modIdx> CUR </modIdx>
+           <globIds> IDS => IDS [ID <- NEXTIDX -Int 1] </globIds>
+           <nextGlobIdx> NEXTIDX </nextGlobIdx>
+           ...
+         </moduleInst>
+```
+
+### Globals
+
+The declaration of mutable/immutable globals differ between text format and abstract syntax.
+In the abstract syntax, types are tagged with `var` or `const`, whereas in the text format, contants types are untagged and mutable types are tagged with `mut`.
+
+```k
+    syntax TextFormatGlobalType ::= AValType | "(" "mut" AValType ")"
+    syntax GlobalType ::= asGMut (TextFormatGlobalType) [function]
+ // --------------------------------------------------------------
+    rule asGMut ( (mut T:AValType ) ) => var   T
+    rule asGMut (      T:AValType   ) => const T
+
+    syntax GlobalSpec ::= TextFormatGlobalType Instr
+    syntax GlobalDefn ::= "(" "global" OptionalId GlobalSpec ")"
+ // ------------------------------------------------------------
+    rule <k> ( global OID:OptionalId TYP:TextFormatGlobalType IS:Instr )
+          => global asGMut(TYP) IS
+          ~> #saveIdentifier global OID
+          ...
+         </k>
+```
+
 Exports
 -------
 
@@ -249,6 +289,14 @@ Note that it is possible to define multiple exports inline, i.e. export a single
 
 Imports
 -------
+
+Imports can optionally have identifiers.
+
+```k
+    syntax ImportDesc ::= "(" "global" OptionalId TextFormatGlobalType ")" [klabel(globTextFormatImportDesc)]
+ // ---------------------------------------------------------------------------------------------------------
+    rule <k> ( import MOD NAME (global OID:OptionalId TYP:TextFormatGlobalType) ) => ( import MOD NAME (global asGMut(TYP))) ~> #saveIdentifier global OID ... </k>
+```
 
 Imports can be declared like regular functions, memories, etc., by giving an inline import declaration.
 

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -267,7 +267,7 @@ In the abstract syntax, types are tagged with `var` or `const`, whereas in the t
     syntax GlobalDefn ::= "(" "global" OptionalId GlobalSpec ")"
  // ------------------------------------------------------------
     rule <k> ( global OID:OptionalId TYP:TextFormatGlobalType IS:Instr )
-          => global asGMut(TYP) IS
+          => global { asGMut(TYP) IS }
           ~> #saveIdentifier global OID
           ...
          </k>

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -153,6 +153,17 @@ In the text format, it is also allowed to have a conditional without the `else` 
 Memory and Tables
 -----------------
 
+```k
+    syntax MemorySpec ::= MemType
+    syntax MemoryDefn ::= "(" "memory" OptionalId MemorySpec ")"
+ // ------------------------------------------------------------
+    rule <k> ( memory OID:OptionalId MIN:Int         ):MemoryDefn => memory { MIN .Int } ~> #saveIdentifier memory OID ... </k>
+      requires MIN <=Int #maxMemorySize()
+    rule <k> ( memory OID:OptionalId MIN:Int MAX:Int ):MemoryDefn => memory { MIN MAX  } ~> #saveIdentifier memory OID ... </k>
+      requires MIN <=Int #maxMemorySize()
+       andBool MAX <=Int #maxMemorySize()
+```
+
 Intitial memory data, and initial table elements can be given inline in the text format.
 
 ```k
@@ -162,7 +173,7 @@ Intitial memory data, and initial table elements can be given inline in the text
          <nextFreshId> NEXTID => NEXTID +Int 1 </nextFreshId>
 
     rule <k> ( memory ID:Identifier ( data DS ) )
-          =>  memory { ID #lengthDataPages(DS) #lengthDataPages(DS) }
+          => ( memory ID #lengthDataPages(DS) #lengthDataPages(DS) ):MemoryDefn
           ~> ( data ID (i32.const 0) DS ) ... </k>
       requires #lengthDataPages(DS) <=Int #maxMemorySize()
 

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -212,6 +212,15 @@ TODO: It's pretty ugly to access `NEXTIDX` the way we are doing here, ideally it
  // ------------------------------------------------------------
     rule <k> #saveIdentifier _:DefinitionType => . ... </k>
 
+    rule <k> #saveIdentifier type ID:Identifier => . ... </k>
+         <curModIdx> CUR </curModIdx>
+         <moduleInst>
+           <modIdx> CUR </modIdx>
+           <typeIds> IDS => IDS [ID <- NEXTIDX -Int 1] </typeIds>
+           <nextTypeIdx> NEXTIDX </nextTypeIdx>
+           ...
+         </moduleInst>
+
     rule <k> #saveIdentifier func ID:Identifier => . ... </k>
          <curModIdx> CUR </curModIdx>
          <moduleInst>
@@ -249,6 +258,40 @@ TODO: It's pretty ugly to access `NEXTIDX` the way we are doing here, ideally it
     rule <k> #saveIdentifier module ID:Identifier => . ... </k>
          <moduleIds> IDS => IDS [ID <- NEXTIDX -Int 1 ] </moduleIds>
          <nextModuleIdx> NEXTIDX </nextModuleIdx>
+```
+
+### Types
+
+Type could be declared explicitly and could optionally bind with an identifier.
+`identifier` for `param` will be used only when the function type is declared when defining a function.
+When defining `TypeDefn`, the `identifier` for `param` will be ignored and will not be saved into the module instance.
+
+```k
+    syntax TypeDecl  ::= "(" TypeDecl ")"     [bracket]
+                       | "param" Identifier AValType
+ // ------------------------------------------------
+    rule #gatherTypes(result , param ID:Identifier     _:AValType TDECLS:TypeDecls , TYPES) => #gatherTypes(result , TDECLS , TYPES)
+    rule #gatherTypes(param  , param ID:Identifier VTYPE:AValType TDECLS:TypeDecls , TYPES) => #gatherTypes(param  , TDECLS , TYPES + { ID VTYPE } .ValTypes)
+
+    syntax TypeDefn ::= "(type" OptionalId "(" "func" TypeDecls ")" ")"
+ // ----------------------------------------------------------------------
+    rule <k> (type OID:OptionalId ( func TDECLS ) ) => ftype { TDECLS } ~> #saveIdentifier type OID ... </k>
+```
+
+### Functions
+
+```k
+    syntax FuncDefn ::= "(" "func" OptionalId FuncSpec ")"
+ // ------------------------------------------------------
+    rule <k> ( func OID:OptionalId TUSE:TypeUse LDECLS:LocalDecls INSTRS:Instrs ) => func { TUSE LDECLS INSTRS } ~> #saveIdentifier func OID ... </k>
+```
+
+#### Locals
+
+```k
+    syntax LocalDecl ::= "local" Identifier AValType
+ // ------------------------------------------------
+    rule #asLocalType(local ID:Identifier VTYPE:AValType   LDECLS:LocalDecls , VTYPES) => #asLocalType(LDECLS , VTYPES + { ID VTYPE } .ValTypes)
 ```
 
 ### Globals

--- a/wasm.md
+++ b/wasm.md
@@ -411,8 +411,6 @@ The various `init_local` variants assist in setting up the `locals` cell.
     rule <k> init_localids VTYPES => #init_localids 0 VTYPES ... </k>
     rule <k> #init_localids I:Int .ValTypes     => .                          ... </k>
     rule <k> #init_localids I:Int V:AValType VS => #init_localids I +Int 1 VS ... </k>
-    rule <k> #init_localids I:Int { ID V }   VS => #init_localids I +Int 1 VS ... </k>
-         <localIds> LOCALIDS => LOCALIDS [ ID <- I ] </localIds>
 ```
 
 The `*_local` instructions are defined here.

--- a/wasm.md
+++ b/wasm.md
@@ -825,30 +825,12 @@ The importing and exporting parts of specifications are dealt with in the respec
 ```k
     syntax Defn      ::= TableDefn
     syntax TableType ::= Limits TableElemType
-    syntax TableSpec ::= TableType
-    syntax TableDefn ::= "(" "table"     OptionalId TableSpec ")"
-                       |     "table" "{" OptionalId Int OptionalInt "}"
- // -------------------------------------------------------------------
-    rule <k> ( table OID:OptionalId MIN:Int         funcref ):TableDefn => table { OID MIN .Int } ... </k>
-      requires MIN <=Int #maxTableSize()
-    rule <k> ( table OID:OptionalId MIN:Int MAX:Int funcref ):TableDefn => table { OID MIN MAX  } ... </k>
-      requires MIN <=Int #maxTableSize()
-       andBool MAX <=Int #maxTableSize()
-
-    rule <k> table { _ _ _ } => trap ... </k>
+    syntax TableDefn ::= "table" "{" Int OptionalInt "}"
+ // ----------------------------------------------------
+    rule <k> table { MIN MAX } => . ... </k>
          <curModIdx> CUR </curModIdx>
          <moduleInst>
            <modIdx> CUR </modIdx>
-           <tabAddrs> MAP </tabAddrs>
-           ...
-         </moduleInst>
-       requires MAP =/=K .Map
-
-    rule <k> table { ID MIN MAX } => . ... </k>
-         <curModIdx> CUR </curModIdx>
-         <moduleInst>
-           <modIdx> CUR </modIdx>
-           <tabIds> IDS => #saveId(IDS, ID, 0) </tabIds>
            <tabAddrs> .Map => (0 |-> NEXTADDR) </tabAddrs>
            ...
          </moduleInst>

--- a/wasm.md
+++ b/wasm.md
@@ -13,6 +13,8 @@ module WASM
 Configuration
 -------------
 
+TODO: Move Ids out of this configuration completely.
+
 ```k
     configuration
       <wasm>
@@ -1135,7 +1137,7 @@ The offset can either be specified explicitly with the `offset` key word, or be 
 
 ### Table initialization
 
-Tables can be initialized with element and the element type is always `funcref".
+Tables can be initialized with element and the element type is always `funcref`.
 The initialization of a table needs an offset and a list of functions, given as `Index`s.
 A table index is optional and will be default to zero.
 

--- a/wasm.md
+++ b/wasm.md
@@ -448,9 +448,9 @@ The importing and exporting parts of specifications are dealt with in the respec
 ```k
     syntax Defn       ::= GlobalDefn
     syntax GlobalType ::= Mut AValType
-    syntax GlobalDefn ::= "global" GlobalType Instr
- // -----------------------------------------------
-    rule <k> global TYP:GlobalType IS:Instr => IS ~> #storeGlobal TYP ... </k>
+    syntax GlobalDefn ::= "global" "{" GlobalType Instr "}"
+ // -------------------------------------------------------
+    rule <k> global { TYP:GlobalType IS:Instr } => IS ~> #storeGlobal TYP ... </k>
 
     syntax Defn ::= "#storeGlobal" GlobalType
  // -----------------------------------------

--- a/wasm.md
+++ b/wasm.md
@@ -445,28 +445,19 @@ The specification can also include export directives.
 The importing and exporting parts of specifications are dealt with in the respective sections for import and export.
 
 ```k
-    syntax TextFormatGlobalType ::= AValType | "(" "mut" AValType ")"
- // -----------------------------------------------------------------
-
-    syntax GlobalType ::= Mut AValType
-                        | asGMut (TextFormatGlobalType) [function]
- // --------------------------------------------------------------
-    rule asGMut ( (mut T:AValType ) ) => var   T
-    rule asGMut (      T:AValType   ) => const T
-
     syntax Defn       ::= GlobalDefn
-    syntax GlobalSpec ::= TextFormatGlobalType Instr
-    syntax GlobalDefn ::= "(" "global" OptionalId GlobalSpec ")"
-                        |     "global" OptionalId GlobalType
- // --------------------------------------------------------
-    rule <k> ( global OID:OptionalId TYP:TextFormatGlobalType IS:Instr ) => IS ~> global OID asGMut(TYP) ... </k>
+    syntax GlobalType ::= Mut AValType
+    syntax GlobalDefn ::= "global" GlobalType Instr
+ // -----------------------------------------------
+    rule <k> global TYP:GlobalType IS:Instr => IS ~> #storeGlobal TYP ... </k>
 
-    rule <k> global OID:OptionalId MUT:Mut TYP:AValType => . ... </k>
+    syntax Defn ::= "#storeGlobal" GlobalType
+ // -----------------------------------------
+    rule <k> #storeGlobal MUT:Mut TYP:AValType => . ... </k>
          <valstack> < TYP > VAL : STACK => STACK </valstack>
          <curModIdx> CUR </curModIdx>
          <moduleInst>
            <modIdx> CUR </modIdx>
-           <globIds> IDS => #saveId(IDS, OID, NEXTIDX) </globIds>
            <nextGlobIdx> NEXTIDX => NEXTIDX +Int 1                </nextGlobIdx>
            <globalAddrs> GLOBS   => GLOBS [ NEXTIDX <- NEXTADDR ] </globalAddrs>
            ...
@@ -1292,7 +1283,7 @@ The value of a global gets copied when it is imported.
     syntax ImportDesc ::= "(" "func"   OptionalId TypeUse              ")" [klabel(funcImportDesc)]
                         | "(" "table"  OptionalId TableType            ")" [klabel( tabImportDesc)]
                         | "(" "memory" OptionalId MemType              ")" [klabel( memImportDesc)]
-                        | "(" "global" OptionalId TextFormatGlobalType ")" [klabel(globImportDesc)]
+                        | "(" "global" GlobalType ")" [klabel(globImportDesc)]
  // -----------------------------------------------------------------------------------------------
     rule <k> ( import MOD NAME (func OID:OptionalId TUSE:TypeUse) ) => . ... </k>
          <curModIdx> CUR </curModIdx>
@@ -1368,11 +1359,10 @@ The value of a global gets copied when it is imported.
          </memInst>
        requires #limitsMatchImport(SIZE, MAX, LIM)
 
-    rule <k> ( import MOD NAME (global OID:OptionalId TGTYP:TextFormatGlobalType) ) => . ... </k>
+    rule <k> ( import MOD NAME (global MUT:Mut TYP:AValType) ) => . ... </k>
          <curModIdx> CUR </curModIdx>
          <moduleInst>
            <modIdx> CUR </modIdx>
-           <globIds> IDS => #saveId(IDS, OID, NEXT) </globIds>
            <globalAddrs> GS => GS [NEXT <- ADDR] </globalAddrs>
            <nextGlobIdx> NEXT => NEXT +Int 1 </nextGlobIdx>
            ...
@@ -1390,7 +1380,6 @@ The value of a global gets copied when it is imported.
            <gValue> <TYP> _ </gValue>
            <gMut>   MUT     </gMut>
          </globalInst>
-       requires asGMut(TGTYP) ==K MUT TYP
 ```
 
 Tables and memories have proper subtyping, unlike globals and functions where a type is only a subtype of itself.

--- a/wasm.md
+++ b/wasm.md
@@ -877,31 +877,13 @@ The importing and exporting parts of specifications are dealt with in the respec
 
 ```k
     syntax Defn       ::= MemoryDefn
-    syntax MemType    ::= Limits
-    syntax MemorySpec ::= MemType
-    syntax MemoryDefn ::= "(" "memory" OptionalId MemorySpec ")"
-                        |     "memory" "{" OptionalId Int OptionalInt "}"
- // ---------------------------------------------------------------------
-    rule <k> ( memory OID:OptionalId MIN:Int         ):MemoryDefn => memory { OID MIN .Int } ... </k>
-      requires MIN <=Int #maxMemorySize()
-    rule <k> ( memory OID:OptionalId MIN:Int MAX:Int ):MemoryDefn => memory { OID MIN MAX  } ... </k>
-      requires MIN <=Int #maxMemorySize()
-       andBool MAX <=Int #maxMemorySize()
-
-    rule <k> memory { _ _ _ } => trap ... </k>
+    syntax MemType    ::= Limits | ".MemType"
+    syntax MemoryDefn ::= "memory" "{" Int OptionalInt "}"
+ // ---------------------------------------------------
+    rule <k> memory { MIN MAX } => . ... </k>
          <curModIdx> CUR </curModIdx>
          <moduleInst>
            <modIdx> CUR </modIdx>
-           <memAddrs> MAP </memAddrs>
-           ...
-         </moduleInst>
-      requires MAP =/=K .Map
-
-    rule <k> memory { ID MIN MAX } => . ... </k>
-         <curModIdx> CUR </curModIdx>
-         <moduleInst>
-           <modIdx> CUR </modIdx>
-           <memIds> IDS => #saveId(IDS, ID, 0) </memIds>
            <memAddrs> .Map => (0 |-> NEXTADDR) </memAddrs>
            ...
          </moduleInst>

--- a/wasm.md
+++ b/wasm.md
@@ -441,7 +441,6 @@ The `*_local` instructions are defined here.
 ### Globals
 
 When globals are declared, they must also be given a constant initialization value.
-The `GlobalSpec` production is used to define all ways that a global can specified.
 Globals can either be specified by giving a type and an initializer expression; or by an import and it's expected type.
 The specification can also include export directives.
 The importing and exporting parts of specifications are dealt with in the respective sections for import and export.
@@ -817,7 +816,6 @@ The allocation of a new `tableinst`.
 Currently at most one table may be defined or imported in a single module.
 The only allowed `TableElemType` is "funcref", so we ignore this term in the reducted sort.
 The table values are addresses into the store of functions.
-The `TableSpec` production is used to define all ways that a global can specified.
 A table can either be specified by giving its type (limits and `funcref`); by specifying a vector of its initial `elem`ents; or by an import and its expected type.
 The specification can also include export directives.
 The importing and exporting parts of specifications are dealt with in the respective sections for import and export.
@@ -854,7 +852,6 @@ Memory
 When memory is allocated, it is put into the store at the next available index.
 Memory can only grow in size, so the minimum size is the initial value.
 Currently, only one memory may be accessible to a module, and thus the `<mAddr>` cell is an array with at most one value, at index 0.
-The `MemorySpec` production is used to define all ways that a global can specified.
 A memory can either be specified by giving its type (limits); by specifying a vector of its initial `data`; or by an import and its expected type.
 The specification can also include export directives.
 The importing and exporting parts of specifications are dealt with in the respective sections for import and export.

--- a/wasm.md
+++ b/wasm.md
@@ -1394,71 +1394,18 @@ The following function checks if the limits in the first parameter *match*, i.e.
 Module Instantiation
 --------------------
 
-There is some dependencies among definitions that require that we do them in a certain order, even though they may appear in many valid orders.
-First, functions, tables, memories and globals get *allocated*.
-Then, tables, memories and globals get *instantiated* with elements, data and initialization vectors.
-However, since (currently) globals can only make use of imported globals to be instantiated, we can initialize at allocation time.
-Finally, the start function is invoked.
-Exports may appear anywhere in a module, but can only be performed after what they refer to has been allocated.
-Exports that are inlined in a definition, e.g., `func (export "foo") ...`, are safe to extract as they appear.
-Imports must appear before any allocations in a module, due to validation.
-
-A subtle point is related to tables with inline `elem` definitions: since these may refer to functions by identifier, we need to make sure that tables definitions come after function definitions.
-
-`structureModule` takes a list of definitions and returns a map with different groups of definitions, preserving the order within each group.
-The groups are chosen to represent different stages of allocation and instantiation.
-
-```k
-    syntax Map ::=  structureModule (     Defns) [function]
-                 | #structureModule (Map, Defns) [function]
-                 | #initialMap ()                [function]
- // -------------------------------------------------------
-    rule #initialMap ()
-      => "typeDecls" |-> .Defns
-         "imports"   |-> .Defns
-         "func/glob" |-> .Defns
-         "allocs"    |-> .Defns
-         "exports"   |-> .Defns
-         "inits"     |-> .Defns
-         "start"     |-> .Defns
-
-    rule structureModule(DS) => #structureModule(#initialMap (), #reverse(DS, .Defns))
-
-    rule #structureModule(M,                  .Defns) => M
-    rule #structureModule(M, (T:TypeDefn   DS:Defns)) => #structureModule(M ["typeDecls" <- (T {M ["typeDecls"]}:>Defns)], DS)
-
-    rule #structureModule(M, (I:ImportDefn DS:Defns)) => #structureModule(M ["imports"   <- (I {M ["imports"  ]}:>Defns)], DS)
-
-    rule #structureModule(M, (X:FuncDefn   DS:Defns)) => #structureModule(M ["func/glob" <- (X {M ["func/glob"]}:>Defns)], DS)
-    rule #structureModule(M, (X:GlobalDefn DS:Defns)) => #structureModule(M ["func/glob" <- (X {M ["func/glob"]}:>Defns)], DS)
-
-    rule #structureModule(M, (A:TableDefn  DS:Defns)) => #structureModule(M ["allocs"    <- (A {M ["allocs"   ]}:>Defns)], DS)
-    rule #structureModule(M, (A:MemoryDefn DS:Defns)) => #structureModule(M ["allocs"    <- (A {M ["allocs"   ]}:>Defns)], DS)
-
-    rule #structureModule(M, (E:ExportDefn DS:Defns)) => #structureModule(M ["exports"   <- (E {M ["exports"  ]}:>Defns)], DS)
-
-    rule #structureModule(M, (I:DataDefn   DS:Defns)) => #structureModule(M ["inits"     <- (I {M ["inits"    ]}:>Defns)], DS)
-    rule #structureModule(M, (I:ElemDefn   DS:Defns)) => #structureModule(M ["inits"     <- (I {M ["inits"    ]}:>Defns)], DS)
-
-    rule #structureModule(M, (S:StartDefn  DS:Defns)) => #structureModule(M ["start"     <- (S .Defns)],                   DS)
-
-    syntax Defns ::= #reverse(Defns, Defns) [function]
- // --------------------------------------------------
-    rule #reverse(       .Defns  , ACC) => ACC
-    rule #reverse(D:Defn DS:Defns, ACC) => #reverse(DS, D ACC)
-```
-
+Modules are divided into sections that get processed in order.
+The module is instantiated with a map, mapping each section to its definitions.
 A new module instance gets allocated.
 Then, the surrounding `module` tag is discarded, and the definitions are executed, putting them into the module currently being defined.
 
 ```k
     syntax Stmt       ::= ModuleDecl
-    syntax ModuleDecl ::= "(" "module" OptionalId Defns ")"
-                        |     "module" OptionalId Map
- // -------------------------------------------------
-    rule <k> ( module OID:OptionalId DEFNS ) => module OID structureModule(DEFNS) ... </k>
+    syntax ModuleDecl ::= "module" Map
+ // ----------------------------------
 
-    rule <k> module OID:OptionalId MOD
+    rule <k> module MOD
+          => MOD["typeDecls"]
           => MOD["typeDecls"]
           ~> MOD["imports"  ]
           ~> MOD["func/glob"]
@@ -1470,7 +1417,6 @@ Then, the surrounding `module` tag is discarded, and the definitions are execute
          </k>
          <curModIdx> _ => NEXT </curModIdx>
          <nextModuleIdx> NEXT => NEXT +Int 1 </nextModuleIdx>
-         <moduleIds> IDS => #saveId(IDS, OID, NEXT) </moduleIds>
          <moduleInstances>
            ( .Bag
           => <moduleInst>
@@ -1490,13 +1436,6 @@ Then, the surrounding `module` tag is discarded, and the definitions are execute
  // -------------------------------------------
     rule <k> ( module OID binary DS ) => module binary Bytes2Int(#DS2Bytes(DS), LE, Unsigned) ... </k>
     rule <k> module binary I => . ... </k>
-```
-
-It is permissible to define modules without the `module` keyword, by simply stating the definitions at the top level in the file.
-
-```k
-    rule <k> D:Defn => ( module .Defns ) ~> D ... </k>
-         <curModIdx> .Int </curModIdx>
 ```
 
 After a module is instantiated, it should be saved somewhere.

--- a/wasm.md
+++ b/wasm.md
@@ -1405,13 +1405,15 @@ Then, the surrounding `module` tag is discarded, and the definitions are execute
  // ----------------------------------
 
     rule <k> module MOD
-          => MOD["typeDecls"]
-          => MOD["typeDecls"]
+          => MOD["types"    ]
           ~> MOD["imports"  ]
-          ~> MOD["func/glob"]
-          ~> MOD["allocs"   ]
+          ~> MOD["functions"]
+          ~> MOD["tables"   ]
+          ~> MOD["memories" ]
+          ~> MOD["globals"  ]
           ~> MOD["exports"  ]
-          ~> MOD["inits"    ]
+          ~> MOD["elem"     ]
+          ~> MOD["data"     ]
           ~> MOD["start"    ]
          ...
          </k>
@@ -1426,16 +1428,6 @@ Then, the surrounding `module` tag is discarded, and the definitions are execute
            )
            ...
          </moduleInstances>
-```
-
-**TODO**: Implement modules represented in binary format.
-
-```k
-    syntax ModuleDecl ::= "(" "module" OptionalId "binary" DataString ")"
-                        | "module" "binary" Int
- // -------------------------------------------
-    rule <k> ( module OID binary DS ) => module binary Bytes2Int(#DS2Bytes(DS), LE, Unsigned) ... </k>
-    rule <k> module binary I => . ... </k>
 ```
 
 After a module is instantiated, it should be saved somewhere.

--- a/wasm.md
+++ b/wasm.md
@@ -1279,19 +1279,18 @@ The value of a global gets copied when it is imported.
 
 ```k
     syntax Defn       ::= ImportDefn
-    syntax ImportDefn ::= "(" "import" WasmString WasmString ImportDesc ")"
-    syntax ImportDesc ::= "(" "func"   OptionalId TypeUse              ")" [klabel(funcImportDesc)]
-                        | "(" "table"  OptionalId TableType            ")" [klabel( tabImportDesc)]
-                        | "(" "memory" OptionalId MemType              ")" [klabel( memImportDesc)]
-                        | "(" "global" GlobalType ")" [klabel(globImportDesc)]
- // -----------------------------------------------------------------------------------------------
-    rule <k> ( import MOD NAME (func OID:OptionalId TUSE:TypeUse) ) => . ... </k>
+    syntax ImportDefn ::= "import" "{" WasmString WasmString ImportDesc "}"
+    syntax ImportDesc ::= "func"   TypeUse
+                        | "table"  TableType
+                        | "memory" MemType
+                        | "global" GlobalType
+ // -----------------------------------------
+    rule <k> import { MOD NAME func TUSE:TypeUse } => . ... </k>
          <curModIdx> CUR </curModIdx>
          <moduleInst>
            <modIdx> CUR </modIdx>
            <typeIds> TYPEIDS </typeIds>
            <types>   TYPES   </types>
-           <funcIds> IDS => #saveId(IDS, OID, NEXT) </funcIds>
            <funcAddrs> FS => FS [NEXT <- ADDR] </funcAddrs>
            <nextFuncIdx> NEXT => NEXT +Int 1 </nextFuncIdx>
            ...
@@ -1311,11 +1310,10 @@ The value of a global gets copied when it is imported.
          </funcDef>
       requires unnameFuncType(FTYPE) ==K unnameFuncType(asFuncType(TYPEIDS, TYPES, TUSE))
 
-    rule <k> ( import MOD NAME (table OID:OptionalId (LIM _):TableType) ) => . ... </k>
+    rule <k> import { MOD NAME table LIM _:TableElemType } => . ... </k>
          <curModIdx> CUR </curModIdx>
          <moduleInst>
            <modIdx> CUR </modIdx>
-           <tabIds> IDS => #saveId(IDS, OID, 0) </tabIds>
            <tabAddrs> .Map => 0 |-> ADDR </tabAddrs>
            ...
          </moduleInst>
@@ -1335,11 +1333,10 @@ The value of a global gets copied when it is imported.
          </tabInst>
        requires #limitsMatchImport(SIZE, MAX, LIM)
 
-    rule <k> ( import MOD NAME (memory OID:OptionalId LIM:Limits) ) => . ... </k>
+    rule <k> import { MOD NAME memory LIM:Limits } => . ... </k>
          <curModIdx> CUR </curModIdx>
          <moduleInst>
            <modIdx> CUR </modIdx>
-           <memIds> IDS => #saveId(IDS, OID, 0) </memIds>
            <memAddrs> .Map => 0 |-> ADDR </memAddrs>
            ...
          </moduleInst>
@@ -1359,7 +1356,7 @@ The value of a global gets copied when it is imported.
          </memInst>
        requires #limitsMatchImport(SIZE, MAX, LIM)
 
-    rule <k> ( import MOD NAME (global MUT:Mut TYP:AValType) ) => . ... </k>
+    rule <k> import { MOD NAME global MUT:Mut TYP:AValType } => . ... </k>
          <curModIdx> CUR </curModIdx>
          <moduleInst>
            <modIdx> CUR </modIdx>


### PR DESCRIPTION
This would be step 1 in the list in PR #178. The only thing that makes it slightly inelegant is the implementation of `#saveId`. I still think it's a big improvement. And with step 2 in that same list, it could become more elegant, even though it would still look at `<next*Idx>` without updating it.