### PR TITLE
Build updates for quieter more reliable build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 .krun*
 .kompile*
 
-rustc-*-src/
+/rustc-*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,6 +31,7 @@ pipeline {
       }
     }
     stage('Test') {
+      options { timeout(time: 5, unit: 'MINUTES') }
       parallel {
         stage('Exec OCaml') {
           steps {

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,6 @@ build-haskell: $(haskell_kompiled)
 build-llvm: $(llvm_kompiled)
 
 $(ocaml_kompiled): $(ocaml_defn)
-	@echo "== kompile: $@"
 	eval $$(opam config env)                                        \
 	    kompile -O3 --non-strict --backend ocaml                    \
 	    --directory $(ocaml_dir) -I $(ocaml_dir)                    \
@@ -118,21 +117,18 @@ $(ocaml_kompiled): $(ocaml_defn)
 	    $(KOMPILE_OPTIONS)
 
 $(java_kompiled): $(java_defn)
-	@echo "== kompile: $@"
 	kompile --backend java                                          \
 	    --directory $(java_dir) -I $(java_dir)                      \
 	    --main-module WASM-TEST --syntax-module WASM-TEST-SYNTAX $< \
 	    $(KOMPILE_OPTIONS)
 
 $(haskell_kompiled): $(haskell_defn)
-	@echo "== kompile: $@"
 	kompile --backend haskell                                       \
 	    --directory $(haskell_dir) -I $(haskell_dir)                \
 	    --main-module WASM-TEST --syntax-module WASM-TEST-SYNTAX $< \
 	    $(KOMPILE_OPTIONS)
 
 $(llvm_kompiled): $(llvm_defn)
-	@echo "== kompile: $@"
 	kompile --backend llvm                                          \
 	    --directory $(llvm_dir) -I $(llvm_dir)                      \
 	    --main-module WASM-TEST --syntax-module WASM-TEST-SYNTAX $< \
@@ -149,7 +145,6 @@ KPROVE_MODULE:=KWASM-LEMMAS
 CHECK:=git --no-pager diff --no-index --ignore-all-space
 
 tests/%/make.timestamp:
-	@echo "== submodule: $@"
 	git submodule update --init -- tests/$*
 	touch $@
 

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,8 @@ $(llvm_dir)/%.k: %.md $(PANDOC_TANGLE_SUBMODULE)/make.timestamp
 
 # Build definitions
 
+KOMPILE_OPTIONS :=
+
 build: build-ocaml build-java build-haskell build-llvm
 build-ocaml: $(ocaml_kompiled)
 build-java: $(java_kompiled)
@@ -108,25 +110,29 @@ $(ocaml_kompiled): $(ocaml_defn)
 	eval $$(opam config env)                                        \
 	    kompile -O3 --non-strict --backend ocaml                    \
 	    --directory $(ocaml_dir) -I $(ocaml_dir)                    \
-	    --main-module WASM-TEST --syntax-module WASM-TEST-SYNTAX $<
+	    --main-module WASM-TEST --syntax-module WASM-TEST-SYNTAX $< \
+	    $(KOMPILE_OPTIONS)
 
 $(java_kompiled): $(java_defn)
 	@echo "== kompile: $@"
 	kompile --backend java                                          \
 	    --directory $(java_dir) -I $(java_dir)                      \
-	    --main-module WASM-TEST --syntax-module WASM-TEST-SYNTAX $<
+	    --main-module WASM-TEST --syntax-module WASM-TEST-SYNTAX $< \
+	    $(KOMPILE_OPTIONS)
 
 $(haskell_kompiled): $(haskell_defn)
 	@echo "== kompile: $@"
 	kompile --backend haskell                                       \
 	    --directory $(haskell_dir) -I $(haskell_dir)                \
-	    --main-module WASM-TEST --syntax-module WASM-TEST-SYNTAX $<
+	    --main-module WASM-TEST --syntax-module WASM-TEST-SYNTAX $< \
+	    $(KOMPILE_OPTIONS)
 
 $(llvm_kompiled): $(llvm_defn)
 	@echo "== kompile: $@"
 	kompile --backend llvm                                          \
 	    --directory $(llvm_dir) -I $(llvm_dir)                      \
-	    --main-module WASM-TEST --syntax-module WASM-TEST-SYNTAX $<
+	    --main-module WASM-TEST --syntax-module WASM-TEST-SYNTAX $< \
+	    $(KOMPILE_OPTIONS)
 
 # Testing
 # -------

--- a/Makefile
+++ b/Makefile
@@ -137,12 +137,14 @@ $(llvm_kompiled): $(llvm_defn)
 # Testing
 # -------
 
-TEST_CONCRETE_BACKEND:=ocaml
-TEST_FLOAT_CONCRETE_BACKEND:=java
-TEST_SYMBOLIC_BACKEND:=java
-TEST:=./kwasm
-KPROVE_MODULE:=KWASM-LEMMAS
-CHECK:=git --no-pager diff --no-index --ignore-all-space
+TEST  := ./kwasm
+CHECK := git --no-pager diff --no-index --ignore-all-space
+
+TEST_CONCRETE_BACKEND       := llvm
+TEST_FLOAT_CONCRETE_BACKEND := java
+TEST_SYMBOLIC_BACKEND       := java
+
+KPROVE_MODULE := KWASM-LEMMAS
 
 tests/%/make.timestamp:
 	git submodule update --init -- tests/$*

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,18 @@ llvm_dir:=$(DEFN_DIR)/llvm
 llvm_defn:=$(patsubst %, $(llvm_dir)/%, $(wasm_files))
 llvm_kompiled:=$(llvm_dir)/test-kompiled/interpreter
 
+$(ocaml_dir):
+	mkdir -p $@
+
+$(java_dir):
+	mkdir -p $@
+
+$(haskell_dir):
+	mkdir -p $@
+
+$(llvm_dir):
+	mkdir -p $@
+
 # Tangle definition from *.md files
 
 defn: defn-ocaml defn-java defn-haskell
@@ -75,24 +87,16 @@ defn-java: $(java_defn)
 defn-haskell: $(haskell_defn)
 defn-llvm: $(llvm_defn)
 
-$(ocaml_dir)/%.k: %.md $(PANDOC_TANGLE_SUBMODULE)/make.timestamp
-	@echo "==  tangle: $@"
-	mkdir -p $(dir $@)
+$(ocaml_dir)/%.k: %.md $(PANDOC_TANGLE_SUBMODULE)/make.timestamp $(ocaml_dir)
 	pandoc --from markdown --to $(TANGLER) --metadata=code:.k $< > $@
 
-$(java_dir)/%.k: %.md $(PANDOC_TANGLE_SUBMODULE)/make.timestamp
-	@echo "==  tangle: $@"
-	mkdir -p $(dir $@)
+$(java_dir)/%.k: %.md $(PANDOC_TANGLE_SUBMODULE)/make.timestamp $(java_dir)
 	pandoc --from markdown --to $(TANGLER) --metadata=code:.k $< > $@
 
-$(haskell_dir)/%.k: %.md $(PANDOC_TANGLE_SUBMODULE)/make.timestamp
-	@echo "==  tangle: $@"
-	mkdir -p $(dir $@)
+$(haskell_dir)/%.k: %.md $(PANDOC_TANGLE_SUBMODULE)/make.timestamp $(haskell_dir)
 	pandoc --from markdown --to $(TANGLER) --metadata=code:.k $< > $@
 
-$(llvm_dir)/%.k: %.md $(PANDOC_TANGLE_SUBMODULE)/make.timestamp
-	@echo "==  tangle: $@"
-	mkdir -p $(dir $@)
+$(llvm_dir)/%.k: %.md $(PANDOC_TANGLE_SUBMODULE)/make.timestamp $(llvm_dir)
 	pandoc --from markdown --to $(TANGLER) --metadata=code:.k $< > $@
 
 # Build definitions

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Installing/Building
 There are three backends of K available, the OCAML backend for concrete execution, the Java backend for symbolic reasoning and proofs, and the experimental Haskell backend for developers.
 This repository generates the build-products for both backends in `.build/defn/java/` and `.build/defn/ocaml/`.
 
-### System Dependencies
+### Dependencies
 
 The following are needed for building/running KWasm:
 
@@ -72,11 +72,12 @@ The following are needed for building/running KWasm:
 On Ubuntu >= 15.04 (for example):
 
 ```sh
-sudo apt install                                                    \
-         autoconf curl flex gcc libffi-dev libmpfr-dev libtool llvm \
-         maven opam openjdk-8-jdk pandoc pkg-config python3         \
-         python-pygments python-recommonmark python-sphinx time     \
-         zlib1g-dev
+sudo apt-get install --yes                                                            \
+    autoconf bison clang++-8 clang-8 cmake curl flex gcc libboost-test-dev libffi-dev \
+    libgmp-dev libjemalloc-dev libmpfr-dev libprocps-dev libprotobuf-dev libtool      \
+    libyaml-dev lld-8 llvm llvm-8 llvm-8-tools maven opam openjdk-8-jdk pandoc        \
+    pkg-config protobuf-compiler python3 python-pygments python-recommonmark          \
+    python-sphinx time zlib1g-dev
 ```
 
 To upgrade `stack` (if needed):
@@ -86,21 +87,16 @@ stack upgrade
 export PATH=$HOME/.local/bin:$PATH
 ```
 
-The LLVM backend has additional dependencies
-
-```
-sudo apt install
-         bison cmake clang-8 clang++-8 llvm-8 llvm-8-tools lld-8 \
-         libboost-test-dev libgmp-dev libprocps-dev libyaml-dev  \
-         libjemalloc-dev curl protobuf-compiler libprotobuf-dev
-```
-
-### Building
-
 After installing the above dependencies, make sure the submodules are setup:
 
 ```sh
 git submodule update --init --recursive
+```
+
+Similarly, you'll need to setup K's Rust dependencies:
+
+```sh
+./deps/k/llvm-backend/src/main/native/llvm-backend/install-rust
 ```
 
 If you haven't already setup K's OCaml dependencies more recently than February 1, 2019, then you also need to setup the K OCaml dependencies:
@@ -109,20 +105,13 @@ If you haven't already setup K's OCaml dependencies more recently than February 
 ./deps/k/k-distribution/src/main/scripts/bin/k-configure-opam-dev
 ```
 
-**NOTE**: It may prove useful to first do `rm -rf ~/.opam` if you've setup K projcets in the past and are experiencing trouble with the newest opam libraries.
-          This is a fairly destructive operation, and will break any other projects that depend on specific locally installed ocaml packages.
-
-Similarly, you'll need to setup K's Rust dependencies:
-
-```sh
-./deps/k/llvm-backend/src/main/native/llvm-backend/install-rust
-```
-
 Install repository specific dependencies:
 
 ```sh
 make deps
 ```
+
+### Building
 
 And then build the semantics:
 
@@ -130,7 +119,7 @@ And then build the semantics:
 make build
 ```
 
-To only build specific backends, you can do `make build-java`, `make build-ocaml`, or `make build-haskell`.
+To only build specific backends, you can do `make build-llvm`, `make build-java`, `make build-ocaml`, or `make build-haskell`.
 
 ### Media and documents
 

--- a/kwasm
+++ b/kwasm
@@ -81,9 +81,9 @@ view_klab() {
 
 usage() {
     echo "
-    usage: $0 run        [--backend (ocaml|llvm|java|haskell)] <pgm>  <K args>*
-           $0 kast       [--backend (ocaml|llvm|java|haskell)] <pgm>  <output format> <K args>*
-           $0 prove      [--backend (java|haskell)]            <spec> <K args>* -m <def_module>
+    usage: $0 run        [--backend (llvm|ocaml|haskell|java)] <pgm>  <K args>*
+           $0 kast       [--backend (llvm|ocaml|haskell|java)] <pgm>  <output format> <K args>*
+           $0 prove      [--backend (haskell|java)]            <spec> <K args>* -m <def_module>
            $0 klab-run                                         <pgm>  <K arg>*
            $0 klab-prove                                       <spec> <K arg>* -m <def_module>
            $0 klab-view                                        [<pgm>|<spec>]
@@ -119,7 +119,7 @@ run_command="$1"; shift
 
 [[ ! -z ${1:-} ]] || usage_fatal "Must supply a file to work on."
 
-backend="ocaml"
+backend="llvm"
 [[ ! "$run_command" == 'prove' ]] || backend='java'
 [[ ! "$run_command" =~ klab*   ]] || backend='java'
 if [[ $# -gt 1 ]] && [[ $1 == '--backend' ]] || [[ $1 == '--definition' ]]; then
@@ -135,9 +135,9 @@ run_file="$1" ; shift
 [[ -f "$run_file" ]] || fatal "File does not exist: $run_file"
 
 case "$run_command-$backend" in
-    run-@(ocaml|llvm|java|haskell)  ) run_krun                        "$@" ;;
-    kast-@(ocaml|llvm|java|haskell) ) run_kast                        "$@" ;;
-    prove-@(java|haskell)           ) run_prove                       "$@" ;;
+    run-@(llvm|ocaml|haskell|java)  ) run_krun                        "$@" ;;
+    kast-@(llvm|ocaml|haskell|java) ) run_kast                        "$@" ;;
+    prove-@(haskell|java)           ) run_prove                       "$@" ;;
     klab-@(run|prove)-java          ) run_klab "${run_command#klab-}" "$@" ;;
     klab-view-java                  ) view_klab                       "$@" ;;
     *) usage_fatal "Unknown command on '$backend' backend: $run_command" ;;

--- a/kwasm
+++ b/kwasm
@@ -81,9 +81,9 @@ view_klab() {
 
 usage() {
     echo "
-    usage: $0 run        [--backend (llvm|ocaml|haskell|java)] <pgm>  <K args>*
-           $0 kast       [--backend (llvm|ocaml|haskell|java)] <pgm>  <output format> <K args>*
-           $0 prove      [--backend (haskell|java)]            <spec> <K args>* -m <def_module>
+    usage: $0 run        [--backend (llvm|ocaml|java|haskell)] <pgm>  <K args>*
+           $0 kast       [--backend (llvm|ocaml|java|haskell)] <pgm>  <output format> <K args>*
+           $0 prove      [--backend (java|haskell)]            <spec> <K args>* -m <def_module>
            $0 klab-run                                         <pgm>  <K arg>*
            $0 klab-prove                                       <spec> <K arg>* -m <def_module>
            $0 klab-view                                        [<pgm>|<spec>]
@@ -141,9 +141,9 @@ fi
 [[ -f "$run_file" ]] || fatal "File does not exist: $run_file"
 
 case "$run_command-$backend" in
-    run-@(llvm|ocaml|haskell|java)  ) run_krun                        "$@" ;;
-    kast-@(llvm|ocaml|haskell|java) ) run_kast                        "$@" ;;
-    prove-@(haskell|java)           ) run_prove                       "$@" ;;
+    run-@(llvm|ocaml|java|haskell)  ) run_krun                        "$@" ;;
+    kast-@(llvm|ocaml|java|haskell) ) run_kast                        "$@" ;;
+    prove-@(java|haskell)           ) run_prove                       "$@" ;;
     klab-@(run|prove)-java          ) run_klab "${run_command#klab-}" "$@" ;;
     klab-view-java                  ) view_klab                       "$@" ;;
     *) usage_fatal "Unknown command on '$backend' backend: $run_command" ;;

--- a/kwasm
+++ b/kwasm
@@ -132,6 +132,12 @@ backend_dir="$defn_dir/$backend"
 # get the run file
 [[ ! -z ${1:-} ]] || usage_fatal "Must supply a file to run on."
 run_file="$1" ; shift
+if [[ "$run_file" == '-' ]]; then
+    tmp_input="$(mktemp)"
+    trap "rm -rf $tmp_input" INT TERM EXIT
+    cat - > "$tmp_input"
+    run_file="$tmp_input"
+fi
 [[ -f "$run_file" ]] || fatal "File does not exist: $run_file"
 
 case "$run_command-$backend" in


### PR DESCRIPTION
-   Better dependencies on generated directories.
-   Quieter tangling and kompiling.
-   Switch to LLVM backend default in runner script/Makefile.
-   Allow passing options to `kompile` when using Makefile.
-   Guard against performance regressions in the tests.