### PR TITLE
Pyk updates, kwasm allows overriding K_OPTS

### DIFF
--- a/kwasm
+++ b/kwasm
@@ -20,7 +20,7 @@ KLAB_OUT="${KLAB_OUT:-$build_dir/klab}"
 KLAB_NODE_STACK_SIZE="${KLAB_NODE_STACK_SIZE:-30000}"
 export KLAB_OUT
 
-export K_OPTS="-Xmx8G"
+export K_OPTS="${K_OPTS:--Xmx8G}"
 
 # Utilities
 # ---------


### PR DESCRIPTION
-   K_OPTS has a default, but can be overridden in `./kwasm`
-   Update K submodule to include new pyk changes.