### PR TITLE
Update mod-on-negative-spec.k.expected

### DIFF
--- a/tests/bad-proofs/mod-on-negative-spec.k.expected
+++ b/tests/bad-proofs/mod-on-negative-spec.k.expected
@@ -1,6 +1,30 @@
+  #Not ( #Not ( {
+      N
+    #Equals
+      0
+    } )
+  #And
+    {
+      X
+    #Equals
+      X modInt N
+    }
+  #And
+    {
+      X <=Int 0 andBool 0 <Int N
+    #Equals
+      true
+    } )
+#And
+  #Not ( {
+    N
+  #Equals
+    0
+  } )
+#And
   <wasm>
     <k>
-      nop ~> X modInt N ~> DotVar2
+      X modInt N ~> DotVar2
     </k>
     <valstack>
       _00


### PR DESCRIPTION
The previous version assumed that the backend would not take any steps, which is
not correct: the backend should take one step to remove `nop` before getting
stuck.