### PR TITLE
Makefile: memory-spec.k.prove: Use the Haskell backend

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,7 +69,7 @@ pipeline {
           steps {
             sh '''
               nprocs=$(nproc)
-              [ "$nprocs" -gt '2' ] && nprocs=2
+              [ "$nprocs" -gt '4' ] && nprocs=2
               make test-conformance-parse -j"$nprocs"
             '''
           }

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,6 @@ TEST_CONCRETE_BACKEND       := llvm
 TEST_FLOAT_CONCRETE_BACKEND := java
 TEST_SYMBOLIC_BACKEND       := haskell
 
-tests/proofs/memory-spec.k.prove: TEST_SYMBOLIC_BACKEND=java
 tests/proofs/locals-spec.k.prove: TEST_SYMBOLIC_BACKEND=java
 
 KPROVE_MODULE := KWASM-LEMMAS


### PR DESCRIPTION
Now that the dependencies are updated, this proof should pass.