### PR TITLE
Several updates to allow running proofs in Haskell.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,10 +145,8 @@ TEST_CONCRETE_BACKEND       := llvm
 TEST_FLOAT_CONCRETE_BACKEND := java
 TEST_SYMBOLIC_BACKEND       := haskell
 
-tests/proofs/memory-concrete-type-spec.k.prove: TEST_SYMBOLIC_BACKEND=java
 tests/proofs/memory-concrete-type-spec.k%prove: PROVE_OPTIONS=--z3-tactic "(or-else (using-params smt :random-seed 1))" --z3-impl-timeout 5000
 tests/proofs/memory-concrete-type-spec.k%prove: KPROVE_MODULE=MEMORY-CONCRETE-TYPE-LEMMAS
-tests/proofs/locals-spec.k.prove: TEST_SYMBOLIC_BACKEND=java
 
 KPROVE_MODULE := KWASM-LEMMAS
 

--- a/kwasm-lemmas.md
+++ b/kwasm-lemmas.md
@@ -109,10 +109,13 @@ module MEMORY-CONCRETE-TYPE-LEMMAS
 
     rule #getRange(BM, START, WIDTH) => 0
       requires notBool (WIDTH >Int 0)
+      [simplification]
     rule #getRange(BM, START, WIDTH) => #get(BM, START) +Int (#getRange(BM, START +Int 1, WIDTH -Int 1) *Int 256)
       requires          WIDTH >Int 0
+      [simplification]
 
     rule #wrap(WIDTH, N) => N modInt (1 <<Int WIDTH)
+      [simplification]
 
 endmodule
 ```

--- a/tests/proofs/locals-spec.k
+++ b/tests/proofs/locals-spec.k
@@ -1,7 +1,6 @@
 requires "kwasm-lemmas.k"
 
 module LOCALS-SPEC
-    imports WASM-TEXT
     imports KWASM-LEMMAS
 
     rule <k> (local.get X:Int) (local.set X:Int) => . ... </k>

--- a/tests/proofs/loops-spec.k
+++ b/tests/proofs/loops-spec.k
@@ -1,7 +1,6 @@
 requires "kwasm-lemmas.k"
 
 module LOOPS-SPEC
-    imports WASM-TEXT
     imports KWASM-LEMMAS
 
     // Lemma

--- a/tests/proofs/memory-concrete-type-spec.k
+++ b/tests/proofs/memory-concrete-type-spec.k
@@ -1,7 +1,6 @@
 requires "kwasm-lemmas.k"
 
 module MEMORY-CONCRETE-TYPE-SPEC
-    imports WASM-TEXT
     imports MEMORY-CONCRETE-TYPE-LEMMAS
 
     rule <k> (i64.store16 (i32.const ADDR) (i64.load32_u (i32.const ADDR)):FoldedInstr):FoldedInstr

--- a/tests/proofs/memory-symbolic-type-spec.k
+++ b/tests/proofs/memory-symbolic-type-spec.k
@@ -1,7 +1,6 @@
 requires "kwasm-lemmas.k"
 
 module MEMORY-SYMBOLIC-TYPE-SPEC
-    imports WASM-TEXT
     imports KWASM-LEMMAS
 
     rule <k> (ITYPE:IValType.store (i32.const ADDR) (ITYPE.load (i32.const ADDR)):Instr):Instr => . ... </k>

--- a/tests/proofs/simple-arithmetic-spec.k
+++ b/tests/proofs/simple-arithmetic-spec.k
@@ -1,7 +1,6 @@
 requires "kwasm-lemmas.k"
 
 module SIMPLE-ARITHMETIC-SPEC
-    imports WASM-TEXT
     imports KWASM-LEMMAS
 
     rule <k> (ITYPE:IValType . const X:Int) => . ... </k>


### PR DESCRIPTION
* `kwasm-lemmas.md`: marked some simplification rules as such
* `tests/proofs/*-spec.k`: workaround a claims-detection frontend bug
* `Makefile`: updated to run all proofs with the Haskell backend

