### PR TITLE
Makefile: Take K_RELEASE from environment, if set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DEPS_DIR  := deps
 DEFN_DIR  := $(BUILD_DIR)/defn
 
 K_SUBMODULE := $(DEPS_DIR)/k
-K_RELEASE   := $(K_SUBMODULE)/k-distribution/target/release/k
+K_RELEASE   ?= $(K_SUBMODULE)/k-distribution/target/release/k
 K_BIN       := $(K_RELEASE)/bin
 K_LIB       := $(K_RELEASE)/lib
 


### PR DESCRIPTION
This lets me use a different K build without forcibly overriding the submodule by setting `K_RELEASE` in my shell environment. The `kwasm` script already reads this variable.