### PR TITLE
Modify funcs cell in wrc20

### DIFF
--- a/tests/proofs/wrc20-spec.k
+++ b/tests/proofs/wrc20-spec.k
@@ -33,7 +33,7 @@ module WRC20-SPEC
           <nextFuncIdx> NEXTFUNCIDX => NEXTFUNCIDX +Int 1 </nextFuncIdx>
           ...
         </moduleInst>
-        <funcs> _ => _ </funcs>
+        <funcs> .Bag => _ </funcs>
         <nextFuncAddr> NEXTADDR => NEXTADDR +Int 1 </nextFuncAddr>
         <memInst>
           <mAddr> MEMADDR  </mAddr>


### PR DESCRIPTION
This PR should fix a bug found when running the spec with the Haskell backend. 
Note that the spec was run on the following branch of `wasm-semantics` https://github.com/kframework/wasm-semantics/tree/kore-1395, with this modification.