### PR TITLE
Bump time for conformance step in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,7 +80,7 @@ pipeline {
           }
         }
         stage('Test Proofs') {
-          options { timeout(time: 15, unit: 'MINUTES') }
+          options { timeout(time: 20, unit: 'MINUTES') }
           parallel {
             stage('Normal') {
               steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,7 @@ pipeline {
           }
         }
         stage('Test Conformance') {
-          options { timeout(time: 15, unit: 'MINUTES') }
+          options { timeout(time: 20, unit: 'MINUTES') }
           parallel {
             stage('Parse') {
               steps {


### PR DESCRIPTION
Seems the conformance step is getting timed out. Not sure if that's a regression on our end, of the server capacity or of K. But seeing how it is blocking other PRs, I say we bump the available time.

EDIT: Some other PRs saw a timeout in the proving step, even after the time was increased in #299. I added some margin there as well.