### PR TITLE
Concrete #setRange

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,6 @@ TEST_CONCRETE_BACKEND       := llvm
 TEST_FLOAT_CONCRETE_BACKEND := java
 TEST_SYMBOLIC_BACKEND       := haskell
 
-tests/proofs/memory-concrete-type-spec.k%prove: PROVE_OPTIONS=--z3-tactic "(or-else (using-params smt :random-seed 1))" --z3-impl-timeout 5000
 tests/proofs/memory-concrete-type-spec.k%prove: KPROVE_MODULE=MEMORY-CONCRETE-TYPE-LEMMAS
 tests/proofs/wrc20-spec.k%prove: KPROVE_MODULE=WRC20-LEMMAS
 tests/proofs/locals-spec.k.prove: TEST_SYMBOLIC_BACKEND=haskell

--- a/data.md
+++ b/data.md
@@ -275,7 +275,8 @@ The `#wrap` function wraps an integer to a given bit width.
 
     syntax Int  ::= #wrap(Int, Int) [function, functional]
  // ------------------------------------------------------
-    rule #wrap(WIDTH, N) => N &Int ((1 <<Int WIDTH) -Int 1) [concrete]
+    rule #wrap(WIDTH, N) => N &Int ((1 <<Int WIDTH) -Int 1) requires         WIDTH >Int 0 [concrete]
+    rule #wrap(WIDTH, N) => 0                               requires notBool WIDTH >Int 0
 ```
 
 In `K` all `Float` numbers are of 64-bits width by default, so we need to downcast a `f32` float to 32-bit manually.

--- a/data.md
+++ b/data.md
@@ -273,8 +273,8 @@ The `#wrap` function wraps an integer to a given bit width.
  // -----------------------------------------
     rule #chop(< ITYPE > N) => < ITYPE > (N modInt #pow(ITYPE))
 
-    syntax Int  ::= #wrap(Int, Int) [function]
- // ------------------------------------------
+    syntax Int  ::= #wrap(Int, Int) [function, functional]
+ // ------------------------------------------------------
     rule #wrap(WIDTH, N) => N modInt (1 <<Int WIDTH) [concrete]
 ```
 

--- a/data.md
+++ b/data.md
@@ -503,10 +503,11 @@ However, `ByteMap` is just a wrapper around regular `Map`s.
 ```k
     syntax ByteMap ::= #setRange(ByteMap, Int, Int, Int) [function]
  // ---------------------------------------------------------------
-    rule #setRange(BM, IDX,   _, WIDTH) => BM
+    rule #setRange(BM,   _,   _, WIDTH) => BM
       requires notBool (WIDTH >Int 0)
     rule #setRange(BM, IDX, VAL, WIDTH) => #setRange(#set(BM, IDX, VAL modInt 256), IDX +Int 1, VAL /Int 256, WIDTH -Int 1)
       requires          WIDTH >Int 0
+      [concrete]
 ```
 
 `#getRange(BM, START, WIDTH)` reads off `WIDTH` elements from `BM` beginning at position `START`, and converts it into an unsigned integer.
@@ -515,10 +516,11 @@ The function interprets the range of bytes as little-endian.
 ```k
     syntax Int ::= #getRange (ByteMap, Int , Int) [function, functional, smtlib(getRange)]
  // --------------------------------------------------------------------------------------
-    rule #getRange(BM, START, WIDTH) => 0
-      requires notBool (WIDTH >Int 0)  [concrete]
+    rule #getRange( _,     _, WIDTH) => 0
+      requires notBool (WIDTH >Int 0)
     rule #getRange(BM, START, WIDTH) => #get(BM, START) +Int (#getRange(BM, START +Int 1, WIDTH -Int 1) *Int 256)
-      requires          WIDTH >Int 0   [concrete]
+      requires          WIDTH >Int 0
+      [concrete]
 ```
 
 `#get` looks up a key in a map, defaulting to 0 if the map does not contain the key.

--- a/data.md
+++ b/data.md
@@ -275,7 +275,7 @@ The `#wrap` function wraps an integer to a given bit width.
 
     syntax Int  ::= #wrap(Int, Int) [function, functional]
  // ------------------------------------------------------
-    rule #wrap(WIDTH, N) => N modInt (1 <<Int WIDTH) [concrete]
+    rule #wrap(WIDTH, N) => N &Int ((1 <<Int WIDTH) -Int 1) [concrete]
 ```
 
 In `K` all `Float` numbers are of 64-bits width by default, so we need to downcast a `f32` float to 32-bit manually.

--- a/kwasm-lemmas.md
+++ b/kwasm-lemmas.md
@@ -372,15 +372,19 @@ module MEMORY-CONCRETE-TYPE-LEMMAS
 ```
 
 ```k
-    rule #getRange(BM, START, WIDTH) => 0
-      requires notBool (WIDTH >Int 0)
-      [simplification]
-    rule #getRange(BM, START, WIDTH) => #get(BM, START) +Int (#getRange(BM, START +Int 1, WIDTH -Int 1) *Int 256)
-      requires          WIDTH >Int 0
-       andBool #isByteMap(BM)
-      [simplification]
+//  rule #getRange(BM, START, WIDTH) => 0
+//    requires notBool (WIDTH >Int 0)
+//    [simplification]
+//  rule #getRange(BM, START, WIDTH) => #get(BM, START) +Int (#getRange(BM, START +Int 1, WIDTH -Int 1) *Int 256)
+//    requires          WIDTH >Int 0
+//     andBool #isByteMap(BM)
+//    [simplification]
 
-    rule #wrap(WIDTH, N) => N modInt (1 <<Int WIDTH)
+//  rule #wrap(WIDTH, N) => N modInt (1 <<Int WIDTH)
+//    [simplification]
+
+    rule #wrap(N, #getRange(BM, ADDR, WIDTH)) => #getRange(BM, ADDR, WIDTH -Int (N /Int 8))
+      requires N modInt 8 ==Int 0
       [simplification]
 
 endmodule

--- a/kwasm-lemmas.md
+++ b/kwasm-lemmas.md
@@ -145,7 +145,7 @@ x mod m + y = r + y
 
 #### Bit Shifting
 
-We want Z3 to understand what a bit-shift is.
+We want K to understand what a bit-shift is.
 
 ```k
     rule X <<Int N modInt M ==Int 0 => true
@@ -170,6 +170,7 @@ We want Z3 to understand what a bit-shift is.
 ```
 
 Proof:
+
 ```
 Let x' = x << m
 => The least m bits of x' are 0.

--- a/kwasm-lemmas.md
+++ b/kwasm-lemmas.md
@@ -346,12 +346,6 @@ They are non-trivial in their implementation, but the following should obviously
          andBool GET_ADDR >Int SET_ADDR
          andBool GET_ADDR <Int SET_ADDR +Int WIDTH
         [simplification]
-
-// rule #get(#setRange(BM, SET_ADDR, VAL, WIDTH), GET_ADDR) => #get(BM, GET_ADDR)
-//   requires #isByteMap(BM)
-//    andBool notBool(
-//      andBool GET_ADDR >Int SET_ADDR
-//      andBool GET_ADDR <Int SET_ADDR +Int WIDTH
 ```
 
 ```k
@@ -372,21 +366,12 @@ module MEMORY-CONCRETE-TYPE-LEMMAS
 ```
 
 ```k
-//  rule #getRange(BM, START, WIDTH) => 0
-//    requires notBool (WIDTH >Int 0)
-//    [simplification]
-//  rule #getRange(BM, START, WIDTH) => #get(BM, START) +Int (#getRange(BM, START +Int 1, WIDTH -Int 1) *Int 256)
-//    requires          WIDTH >Int 0
-//     andBool #isByteMap(BM)
-//    [simplification]
-
-//  rule #wrap(WIDTH, N) => N modInt (1 <<Int WIDTH)
-//    [simplification]
-
     rule #wrap(N, #getRange(BM, ADDR, WIDTH)) => #getRange(BM, ADDR, WIDTH -Int (N /Int 8))
       requires N modInt 8 ==Int 0
       [simplification]
+```
 
+```k
 endmodule
 ```
 
@@ -428,7 +413,7 @@ Perhaps using `requires N ==Int 2 ^Int log2Int(N)`?
     rule (X <<Int N) +Int (Y <<Int M) => (X +Int (Y <<Int (M -Int N))) <<Int N
       requires N <=Int M
       [simplification]
-      
+
     rule (X <<Int N) +Int (Y <<Int M) => ((X <<Int (N -Int M)) +Int Y) <<Int M
       requires N >Int M
       [simplification]

--- a/kwasm-lemmas.md
+++ b/kwasm-lemmas.md
@@ -369,8 +369,9 @@ module MEMORY-CONCRETE-TYPE-LEMMAS
 ```
 
 ```k
-    rule #wrap(N, #getRange(BM, ADDR, WIDTH)) => #getRange(BM, ADDR, WIDTH -Int (N /Int 8))
+    rule #wrap(N, #getRange(BM, ADDR, WIDTH)) => #getRange(BM, ADDR, N /Int 8)
       requires 0 <=Int N
+       andBool N /Int 8 <=Int WIDTH
        andBool N modInt 8 ==Int 0
       [simplification]
 ```

--- a/kwasm-lemmas.md
+++ b/kwasm-lemmas.md
@@ -151,7 +151,7 @@ x mod m + y = r + y
 We want K to understand what a bit-shift is.
 
 ```k
-    rule X <<Int N modInt M ==Int 0 => true
+    rule (X <<Int N) modInt M ==Int 0 => true
       requires M modInt (2 ^Int N) ==Int 0
       [simplification]
 

--- a/kwasm-lemmas.md
+++ b/kwasm-lemmas.md
@@ -42,7 +42,8 @@ Not however that K defines `X modInt N ==Int X modInt (-N)`.
       [simplification]
 
     rule #wrap(N, X) => X
-      requires 0 <=Int X
+      requires 0 <=Int N
+       andBool 0 <=Int X
        andBool X  <Int (1 <<Int N)
       [simplification]
 
@@ -101,11 +102,13 @@ x = m * q + r, for a unique q and r s.t. 0 <= r < m
       [simplification]
 
     rule #wrap(N, (X <<Int M) +Int Y) => #wrap(N, Y)
-      requires M >=Int N
+      requires 0 <=Int N
+       andBool N <=Int M
       [simplification]
 
     rule #wrap(N, Y +Int (X <<Int M)) => #wrap(N, Y)
-      requires M >=Int N
+      requires 0 <=Int N
+       andBool N <=Int M
       [simplification]
 ```
 
@@ -367,7 +370,8 @@ module MEMORY-CONCRETE-TYPE-LEMMAS
 
 ```k
     rule #wrap(N, #getRange(BM, ADDR, WIDTH)) => #getRange(BM, ADDR, WIDTH -Int (N /Int 8))
-      requires N modInt 8 ==Int 0
+      requires 0 <=Int N
+       andBool N modInt 8 ==Int 0
       [simplification]
 ```
 

--- a/kwasm-lemmas.md
+++ b/kwasm-lemmas.md
@@ -344,7 +344,7 @@ They are non-trivial in their implementation, but the following should obviously
         [simplification]
 
     rule #get(#setRange(BM, SET_ADDR       , VAL        , WIDTH       ), GET_ADDR)
-        => #get(#setRange(BM, SET_ADDR +Int 1, VAL >>Int 8, WIDTH -Int 1), GET_ADDR)
+      => #get(#setRange(BM, SET_ADDR +Int 1, VAL >>Int 8, WIDTH -Int 1), GET_ADDR)
         requires #isByteMap(BM)
          andBool GET_ADDR >Int SET_ADDR
          andBool GET_ADDR <Int SET_ADDR +Int WIDTH

--- a/tests/proofs/memory-symbolic-type-spec.k
+++ b/tests/proofs/memory-symbolic-type-spec.k
@@ -16,8 +16,8 @@ module MEMORY-SYMBOLIC-TYPE-SPEC
            <mdata> BM   </mdata>
            ...
          </memInst>
-       requires #chop(<i32> ADDR) ==K <i32> EA
-        andBool EA +Int #numBytes(ITYPE) <=Int SIZE *Int #pageSize()
+       requires #chop(<i32> ADDR) ==K <i32> ?EA
+        andBool ?EA +Int #numBytes(ITYPE) <=Int SIZE *Int #pageSize()
         andBool #isByteMap(BM)
 
 endmodule


### PR DESCRIPTION
For the balance proof in Ewasm, splitting up `#getRange` and `#setRange` takes *a lot* of time. So I think it's worth keeping the expansion concrete (like we intended originally).

Also, making `#wrap` functional helps with reasoning, but `modInt` isn't functional. I suggest we change it to use `&Int` instead. I think that is a) more in line with the semantics of `#wrap`, and b) will allow us to have lemmas that rewrite `modInt` to `#wrap` when possible, without risking infinite rewrites. I would want us to rely more on `#wrap`, `&Int`, `|Int`, `<<Int` and `>>Int` in the future, because they are total and make for simpler lemmas when reasoning about bits than `modInt`, `+Int`, `/Int` and `*Int`. I'm running that locally now, to make sure it checks out, and to time it.