### PR TITLE
Make some functions total

### DIFF
--- a/data.md
+++ b/data.md
@@ -350,19 +350,21 @@ One needs to unname the `ValTypes` first before calling the `#take` or `#drop` f
 
 ```k
     syntax ValStack ::= #zero ( ValTypes )            [function]
-                      | #take ( Int , ValStack )      [function]
-                      | #drop ( Int , ValStack )      [function]
+                      | #take ( Int , ValStack )      [function, functional]
+                      | #drop ( Int , ValStack )      [function, functional]
                       | #revs ( ValStack )            [function]
                       | #revs ( ValStack , ValStack ) [function, klabel(#revsAux)]
  // ------------------------------------------------------------------------------
     rule #zero(.ValTypes)             => .ValStack
     rule #zero(ITYPE:IValType VTYPES) => < ITYPE > 0 : #zero(VTYPES)
 
-    rule #take(N, _)      => .ValStack               requires notBool N >Int 0
-    rule #take(N, V : VS) => V : #take(N -Int 1, VS) requires         N >Int 0
+    rule #take(N, .ValStack) => .ValStack               requires         N >Int 0
+    rule #take(N, _)         => .ValStack               requires notBool N >Int 0
+    rule #take(N, V : VS)    => V : #take(N -Int 1, VS) requires         N >Int 0
 
-    rule #drop(N, VS)     => VS                  requires notBool N >Int 0
-    rule #drop(N, _ : VS) => #drop(N -Int 1, VS) requires         N >Int 0
+    rule #drop(N, .ValStack) => .ValStack           requires         N >Int 0
+    rule #drop(N, VS)        => VS                  requires notBool N >Int 0
+    rule #drop(N, _ : VS)    => #drop(N -Int 1, VS) requires         N >Int 0
 
     rule #revs(VS) => #revs(VS, .ValStack)
 

--- a/data.md
+++ b/data.md
@@ -336,9 +336,9 @@ Operator `_++_` implements an append operator for sort `ValStack`.
 
 ```k
     syntax ValStack ::= ".ValStack"
-                   | Val      ":"  ValStack
-                   | ValStack "++" ValStack [function]
- // --------------------------------------------------
+                      | Val      ":"  ValStack
+                      | ValStack "++" ValStack [function, functional]
+ // -----------------------------------------------------------------
     rule .ValStack       ++ VALSTACK' => VALSTACK'
     rule (SI : VALSTACK) ++ VALSTACK' => SI : (VALSTACK ++ VALSTACK')
 ```

--- a/data.md
+++ b/data.md
@@ -346,7 +346,10 @@ Operator `_++_` implements an append operator for sort `ValStack`.
 `#zero` will create a specified stack of zero values in a given type.
 `#take` will take the prefix of a given stack.
 `#drop` will drop the prefix of a given stack.
-One needs to unname the `ValTypes` first before calling the `#take` or `#drop` function.
+`#revs` will reverse a given stack.
+
+**NOTE**: `#take` and `#drop` are _total_, so in case they could not take/drop enough values before running out, they just return the empty `.ValStack`.
+Each call site _must_ ensure that this is desired behavior before using these functions.
 
 ```k
     syntax ValStack ::= #zero ( ValTypes )            [function]

--- a/data.md
+++ b/data.md
@@ -352,9 +352,9 @@ One needs to unname the `ValTypes` first before calling the `#take` or `#drop` f
     syntax ValStack ::= #zero ( ValTypes )            [function]
                       | #take ( Int , ValStack )      [function, functional]
                       | #drop ( Int , ValStack )      [function, functional]
-                      | #revs ( ValStack )            [function]
-                      | #revs ( ValStack , ValStack ) [function, klabel(#revsAux)]
- // ------------------------------------------------------------------------------
+                      | #revs ( ValStack )            [function, functional]
+                      | #revs ( ValStack , ValStack ) [function, functional, klabel(#revsAux)]
+ // ------------------------------------------------------------------------------------------
     rule #zero(.ValTypes)             => .ValStack
     rule #zero(ITYPE:IValType VTYPES) => < ITYPE > 0 : #zero(VTYPES)
 

--- a/data.md
+++ b/data.md
@@ -358,12 +358,12 @@ One needs to unname the `ValTypes` first before calling the `#take` or `#drop` f
     rule #zero(.ValTypes)             => .ValStack
     rule #zero(ITYPE:IValType VTYPES) => < ITYPE > 0 : #zero(VTYPES)
 
-    rule #take(N, .ValStack) => .ValStack               requires         N >Int 0
     rule #take(N, _)         => .ValStack               requires notBool N >Int 0
+    rule #take(N, .ValStack) => .ValStack               requires         N >Int 0
     rule #take(N, V : VS)    => V : #take(N -Int 1, VS) requires         N >Int 0
 
-    rule #drop(N, .ValStack) => .ValStack           requires         N >Int 0
     rule #drop(N, VS)        => VS                  requires notBool N >Int 0
+    rule #drop(N, .ValStack) => .ValStack           requires         N >Int 0
     rule #drop(N, _ : VS)    => #drop(N -Int 1, VS) requires         N >Int 0
 
     rule #revs(VS) => #revs(VS, .ValStack)

--- a/wasm.md
+++ b/wasm.md
@@ -1196,7 +1196,7 @@ The offset can either be specified explicitly with the `offset` key word, or be 
 
 ### Table initialization
 
-Tables can be initialized with element and the element type is always `funcref".
+Tables can be initialized with element and the element type is always `funcref`.
 The initialization of a table needs an offset and a list of functions, given as `Index`s.
 A table index is optional and will be default to zero.
 


### PR DESCRIPTION
This makes `_++_`, `#take`, and `#drop` total (and adds the `functional` attribute for them).

This should make many definedness conditions in proofs simplify out a lot sooner.

The one catch is that now `#take` and `#drop` have weird behavior on the empty `.ValStack`, that is they always return the empty `.ValStack` instead of beind undefined. Because of the type-safety proof on the semantics, this should be OK. I checked all the call sites of `#take` and `#drop` and they should be covered by the type-safety proof.