### PR TITLE
More total functions

### DIFF
--- a/data.md
+++ b/data.md
@@ -142,19 +142,19 @@ There are two basic type-constructors: sequencing (`[_]`) and function spaces (`
 We need helper functions to remove the identifiers from `FuncType`.
 
 ```k
-    syntax FuncType ::= unnameFuncType ( FuncType ) [function]
- // ----------------------------------------------------------
+    syntax FuncType ::= unnameFuncType ( FuncType ) [function, functional]
+ // ----------------------------------------------------------------------
     rule unnameFuncType ( [ V1 ]->[ V2 ] ) => [ unnameValTypes ( V1 ) ]->[ V2 ]
 ```
 
 We need helper functions to remove all the identifiers from a `ValTypes`.
 
 ```k
-    syntax ValTypes ::= unnameValTypes ( ValTypes ) [function]
- // ----------------------------------------------------------
-    rule unnameValTypes ( .ValTypes     ) => .ValTypes
-    rule unnameValTypes ( V:AValType VS ) => V unnameValTypes ( VS )
-    rule unnameValTypes ( { ID V } VS )   => V unnameValTypes ( VS )
+    syntax ValTypes ::= unnameValTypes ( ValTypes ) [function, functional]
+ // ----------------------------------------------------------------------
+    rule unnameValTypes ( .ValTypes   ) => .ValTypes
+    rule unnameValTypes ( { ID V } VS ) => V unnameValTypes ( VS )
+    rule unnameValTypes ( V        VS ) => V unnameValTypes ( VS ) [owise]
 ```
 
 All told, a `Type` can be a value type, vector of types, or function type.

--- a/data.md
+++ b/data.md
@@ -353,14 +353,16 @@ Operator `_++_` implements an append operator for sort `ValStack`.
 Each call site _must_ ensure that this is desired behavior before using these functions.
 
 ```k
-    syntax ValStack ::= #zero ( ValTypes )            [function]
+    syntax ValStack ::= #zero ( ValTypes )            [function, functional]
                       | #take ( Int , ValStack )      [function, functional]
                       | #drop ( Int , ValStack )      [function, functional]
                       | #revs ( ValStack )            [function, functional]
                       | #revs ( ValStack , ValStack ) [function, functional, klabel(#revsAux)]
  // ------------------------------------------------------------------------------------------
     rule #zero(.ValTypes)             => .ValStack
-    rule #zero(ITYPE:IValType VTYPES) => < ITYPE > 0 : #zero(VTYPES)
+    rule #zero(ITYPE:IValType VTYPES) => < ITYPE > 0   : #zero(VTYPES)
+    rule #zero(FTYPE:FValType VTYPES) => < FTYPE > 0.0 : #zero(VTYPES)
+    rule #zero({ ID VT }      VTYPES) => #zero(VT VTYPES)
 
     rule #take(N, _)         => .ValStack               requires notBool N >Int 0
     rule #take(N, .ValStack) => .ValStack               requires         N >Int 0

--- a/data.md
+++ b/data.md
@@ -133,8 +133,8 @@ There are two basic type-constructors: sequencing (`[_]`) and function spaces (`
     syntax FuncType ::= VecType "->" VecType
  // ----------------------------------------
 
-    syntax Int ::= lengthValTypes ( ValTypes ) [function]
- // -----------------------------------------------------
+    syntax Int ::= lengthValTypes ( ValTypes ) [function, functional]
+ // -----------------------------------------------------------------
     rule lengthValTypes(.ValTypes) => 0
     rule lengthValTypes(V VS)      => 1 +Int lengthValTypes(VS)
 ```
@@ -176,9 +176,9 @@ We can append two `ValTypes`s with the `_+_` operator.
 Also we can reverse a `ValTypes` with `#revt`
 
 ```k
-    syntax ValTypes ::= #revt ( ValTypes )            [function]
-                      | #revt ( ValTypes , ValTypes ) [function, klabel(#revtAux)]
- // ------------------------------------------------------------------------------
+    syntax ValTypes ::= #revt ( ValTypes )            [function, functional]
+                      | #revt ( ValTypes , ValTypes ) [function, functional, klabel(#revtAux)]
+ // ------------------------------------------------------------------------------------------
     rule #revt(VT) => #revt(VT, .ValTypes)
 
     rule #revt(.ValTypes, VT') => VT'
@@ -216,6 +216,7 @@ For the core language, only regular integers are allowed.
 
 ```k
     syntax WasmInt ::= Int
+ // ----------------------
 ```
 
 ### Type Mutability

--- a/data.md
+++ b/data.md
@@ -167,10 +167,10 @@ All told, a `Type` can be a value type, vector of types, or function type.
 We can append two `ValTypes`s with the `_+_` operator.
 
 ```k
-    syntax ValTypes ::= ValTypes "+" ValTypes [function]
- // ----------------------------------------------------
-    rule .ValTypes + VTYPES            => VTYPES
-    rule (VT:ValType VTYPES) + VTYPES' => VT (VTYPES + VTYPES')
+    syntax ValTypes ::= ValTypes "+" ValTypes [function, functional]
+ // ----------------------------------------------------------------
+    rule .ValTypes   + VTYPES' => VTYPES'
+    rule (VT VTYPES) + VTYPES' => VT (VTYPES + VTYPES')
 ```
 
 Also we can reverse a `ValTypes` with `#revt`

--- a/data.md
+++ b/data.md
@@ -152,9 +152,9 @@ We need helper functions to remove all the identifiers from a `ValTypes`.
 ```k
     syntax ValTypes ::= unnameValTypes ( ValTypes ) [function, functional]
  // ----------------------------------------------------------------------
-    rule unnameValTypes ( .ValTypes   ) => .ValTypes
-    rule unnameValTypes ( { ID V } VS ) => V unnameValTypes ( VS )
-    rule unnameValTypes ( V        VS ) => V unnameValTypes ( VS ) [owise]
+    rule unnameValTypes ( .ValTypes     ) => .ValTypes
+    rule unnameValTypes ( { ID V }   VS ) => V unnameValTypes ( VS )
+    rule unnameValTypes ( V:AValType VS ) => V unnameValTypes ( VS )
 ```
 
 All told, a `Type` can be a value type, vector of types, or function type.

--- a/data.md
+++ b/data.md
@@ -271,7 +271,7 @@ The `#wrap` function wraps an integer to a given bit width.
 
 ```k
     syntax IVal ::= #chop ( IVal ) [function, functional]
- // -----------------------------------------
+ // -----------------------------------------------------
     rule #chop(< ITYPE > N) => < ITYPE > (N modInt #pow(ITYPE))
 
     syntax Int  ::= #wrap(Int, Int) [function, functional]

--- a/numeric.md
+++ b/numeric.md
@@ -91,9 +91,9 @@ There are 7 unary operators for floats: `abs`, `neg`, `sqrt`, `floor`, `ceil`, `
     rule FTYPE . floor   F => < FTYPE > floorFloat (F)
     rule FTYPE . ceil    F => < FTYPE >  ceilFloat (F)
     rule FTYPE . trunc   F => < FTYPE > truncFloat (F)
-    rule FTYPE . nearest F => < FTYPE >  F                requires #isInfinityOrNaN (F)
-    rule FTYPE . nearest F => #round(FTYPE, Float2Int(F)) requires (notBool #isInfinityOrNaN (F)) andBool (Float2Int(F) =/=Int 0 orBool notBool signFloat(F))
-    rule FTYPE . nearest F => < FTYPE > -0.0              requires (notBool #isInfinityOrNaN (F)) andBool Float2Int(F) ==Int 0 andBool signFloat(F)
+    rule FTYPE . nearest F => < FTYPE >  F                requires          #isInfinityOrNaN (F)
+    rule FTYPE . nearest F => #round(FTYPE, Float2Int(F)) requires (notBool #isInfinityOrNaN (F)) andBool notBool (Float2Int(F) ==Int 0 andBool signFloat(F))
+    rule FTYPE . nearest F => < FTYPE > -0.0              requires (notBool #isInfinityOrNaN (F)) andBool          Float2Int(F) ==Int 0 andBool signFloat(F)
 ```
 
 ### Binary Operators

--- a/wasm.md
+++ b/wasm.md
@@ -1086,8 +1086,8 @@ The `align` parameter is for optimization only and is not allowed to influence t
     syntax AlignArg  ::= "align="  WasmInt
  // --------------------------------------
 
-    syntax Int ::= #getOffset ( MemArg ) [function]
- // -----------------------------------------------
+    syntax Int ::= #getOffset ( MemArg ) [function, functional]
+ // -----------------------------------------------------------
     rule #getOffset(           _:AlignArg) => 0
     rule #getOffset(offset= OS           ) => OS
     rule #getOffset(offset= OS _:AlignArg) => OS


### PR DESCRIPTION
This takes several functions which cause `#Ceil` conditions to happen in rule-merging and either (i) marks them as total if they aren't, or (ii) makes them total if they aren't and then marks them so.

One thing that is a bugfix is that `#set` was not total before. If the key was present in the Map, but _was not_ an `Int`, then `#set` was undefined. By having the other case be `[owise]`, we make it actually total here.