### PR TITLE
Use macros for block instructions

### DIFF
--- a/wasm-text.md
+++ b/wasm-text.md
@@ -13,6 +13,7 @@ endmodule
 module WASM-SYNTAX
     imports WASM-TOKEN-SYNTAX
     imports WASM-DATA
+
 endmodule
 ```
 
@@ -131,20 +132,27 @@ Another type of folded instruction is control flow blocks wrapped in parentheses
 ```k
     syntax FoldedInstr ::= "(" "block" OptionalId TypeDecls Instrs ")"
  // ------------------------------------------------------------------
-    rule <k> ( block               TDECLS:TypeDecls INSTRS:Instrs ) => block    TDECLS INSTRS end ... </k>
-    rule <k> ( block ID:Identifier TDECLS:TypeDecls INSTRS:Instrs ) => block ID TDECLS INSTRS end ... </k>
+    rule ( block               TDECLS:TypeDecls INSTRS:Instrs ) => block    TDECLS INSTRS end [macro]
+    rule ( block ID:Identifier TDECLS:TypeDecls INSTRS:Instrs ) => block ID TDECLS INSTRS end [macro]
 
     syntax FoldedInstr ::= "(" "if" OptionalId TypeDecls Instrs "(" "then" Instrs ")" ")"
                          | "(" "if" OptionalId TypeDecls Instrs "(" "then" Instrs ")" "(" "else" Instrs ")" ")"
  // -----------------------------------------------------------------------------------------------------------
-    rule <k> ( if OID:OptionalId TDECLS:TypeDecls C:Instrs ( then IS ) )              => C ~> if OID TDECLS IS          end ... </k>
-    rule <k> ( if                TDECLS:TypeDecls C:Instrs ( then IS ) ( else IS' ) ) => C ~> if     TDECLS IS else IS' end ... </k>
-    rule <k> ( if  ID:Identifier TDECLS:TypeDecls C:Instrs ( then IS ) ( else IS' ) ) => C ~> if  ID TDECLS IS else IS' end ... </k>
+    rule ( if OID:OptionalId TDECLS:TypeDecls C:Instrs ( then IS ) )              IS'' => C ++ if OID TDECLS IS          end IS'' [macro]
+    rule ( if                TDECLS:TypeDecls C:Instrs ( then IS ) ( else IS' ) ) IS'' => C ++ if     TDECLS IS else IS' end IS'' [macro]
+    rule ( if  ID:Identifier TDECLS:TypeDecls C:Instrs ( then IS ) ( else IS' ) ) IS'' => C ++ if  ID TDECLS IS else IS' end IS'' [macro]
 
     syntax FoldedInstr ::= "(" "loop" OptionalId TypeDecls Instrs ")"
  // -----------------------------------------------------------------
-    rule <k> ( loop               TDECLS:TypeDecls IS ) => loop    TDECLS IS end ... </k>
-    rule <k> ( loop ID:Identifier TDECLS:TypeDecls IS ) => loop ID TDECLS IS end ... </k>
+    rule ( loop               TDECLS:TypeDecls IS ) => loop    TDECLS IS end [macro]
+    rule ( loop ID:Identifier TDECLS:TypeDecls IS ) => loop ID TDECLS IS end [macro]
+```
+
+```k
+    syntax Instrs ::= Instrs "++" Instrs [function, functional]
+ // -----------------------------------------------------------
+    rule .Instrs       ++ IS' => IS'
+    rule (I IS:Instrs) ++ IS' => I (IS ++ IS')
 ```
 
 ### Identifiers

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -123,8 +123,9 @@ One type of folded instruction are `PlainInstr`s wrapped in parentheses and opti
     syntax FoldedInstr ::= "(" PlainInstr Instrs ")"
                          | "(" PlainInstr        ")" [prefer]
  // ---------------------------------------------------------
-    rule <k> ( PI:PlainInstr IS:Instrs ):FoldedInstr => IS ~> PI ... </k>
-    rule <k> ( PI:PlainInstr           ):FoldedInstr =>       PI ... </k>
+    rule ( PI:PlainInstr IS:Instrs ):FoldedInstr IS':Instrs =>  IS ++Instrs PI                  IS' [macro]
+    rule ( PI:PlainInstr IS:Instrs ):FoldedInstr SS:Stmts   => (IS ++Instrs PI .Instrs) ++Stmts SS  [macro]
+    rule ( PI:PlainInstr           ):FoldedInstr            => PI                                   [macro]
 ```
 
 Another type of folded instruction is control flow blocks wrapped in parentheses, in which case the `end` keyword is omitted.
@@ -138,9 +139,9 @@ Another type of folded instruction is control flow blocks wrapped in parentheses
     syntax FoldedInstr ::= "(" "if" OptionalId TypeDecls Instrs "(" "then" Instrs ")" ")"
                          | "(" "if" OptionalId TypeDecls Instrs "(" "then" Instrs ")" "(" "else" Instrs ")" ")"
  // -----------------------------------------------------------------------------------------------------------
-    rule ( if OID:OptionalId TDECLS:TypeDecls C:Instrs ( then IS ) )              IS'' => C ++ if OID TDECLS IS          end IS'' [macro]
-    rule ( if                TDECLS:TypeDecls C:Instrs ( then IS ) ( else IS' ) ) IS'' => C ++ if     TDECLS IS else IS' end IS'' [macro]
-    rule ( if  ID:Identifier TDECLS:TypeDecls C:Instrs ( then IS ) ( else IS' ) ) IS'' => C ++ if  ID TDECLS IS else IS' end IS'' [macro]
+    rule ( if OID:OptionalId TDECLS:TypeDecls C:Instrs ( then IS ) )              IS'' => C ++Instrs if OID TDECLS IS          end IS'' [macro]
+    rule ( if                TDECLS:TypeDecls C:Instrs ( then IS ) ( else IS' ) ) IS'' => C ++Instrs if     TDECLS IS else IS' end IS'' [macro]
+    rule ( if  ID:Identifier TDECLS:TypeDecls C:Instrs ( then IS ) ( else IS' ) ) IS'' => C ++Instrs if  ID TDECLS IS else IS' end IS'' [macro]
 
     syntax FoldedInstr ::= "(" "loop" OptionalId TypeDecls Instrs ")"
  // -----------------------------------------------------------------
@@ -149,10 +150,14 @@ Another type of folded instruction is control flow blocks wrapped in parentheses
 ```
 
 ```k
-    syntax Instrs ::= Instrs "++" Instrs [function, functional]
- // -----------------------------------------------------------
-    rule .Instrs       ++ IS' => IS'
-    rule (I IS:Instrs) ++ IS' => I (IS ++ IS')
+    syntax Instrs ::= Instrs "++Instrs" Instrs [function, functional]
+    syntax Stmts  ::= Stmts  "++Stmts"  Stmts  [function, functional]
+ // -----------------------------------------------------------------
+    rule .Instrs       ++Instrs IS' => IS'
+    rule (I IS:Instrs) ++Instrs IS' => I (IS ++Instrs IS')
+
+    rule .Stmts       ++Stmts SS' => SS'
+    rule (S SS:Stmts) ++Stmts SS' => S (SS ++Stmts SS')
 ```
 
 ### Identifiers


### PR DESCRIPTION
This helps when we do preprocessing, because it gives us fewer cases to deal with in the text format when we do simplifications.