### PR TITLE
Remove float test command without target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ tests/%.cannot-prove: tests/%
 
 ### Execution Tests
 
-test-execution: test-simple test-simple-float
+test-execution: test-simple
 
 simple_tests         := $(wildcard tests/simple/*.wast)
 simple_tests_failing := $(shell cat tests/failing.simple)


### PR DESCRIPTION
This lingering `float` test broke `make test`, which is a convenient way to run all tests.