### PR TITLE
Use Dockerhub images for CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,4 @@ RUN    apt-get update         \
 
 ARG USER_ID=1000
 ARG GROUP_ID=1000
-RUN    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers    \
-    && groupadd -g $GROUP_ID user                             \
-    && useradd -m -u $USER_ID -s /bin/sh -g user -G sudo user
+RUN groupadd -g $GROUP_ID user && useradd -m -u $USER_ID -s /bin/sh -g user user

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM runtimeverificationinc/kframework-k:ubuntu-bionic-524fd49
+ARG K_COMMIT
+FROM runtimeverificationinc/kframework-k:ubuntu-bionic-${K_COMMIT}
 
 RUN    sudo apt-get update         \
     && sudo apt-get upgrade --yes  \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,54 +1,34 @@
-FROM runtimeverificationinc/ubuntu:bionic
+FROM runtimeverificationinc/kframework-k:ubuntu-bionic-c88df08
 
-RUN    apt-get update           \
-    && apt-get upgrade --yes    \
-    && apt-get install --yes    \
-            autoconf            \
-            bison               \
-            clang-8             \
-            cmake               \
-            curl                \
-            flex                \
-            gcc                 \
-            libboost-test-dev   \
-            libcrypto++-dev     \
-            libffi-dev          \
-            libjemalloc-dev     \
-            libmpfr-dev         \
-            libprocps-dev       \
-            libprotobuf-dev     \
-            libsecp256k1-dev    \
-            libssl-dev          \
-            libtool             \
-            libyaml-dev         \
-            libz3-dev           \
-            lld-8               \
-            llvm-8-tools        \
-            make                \
-            maven               \
-            netcat-openbsd      \
-            openjdk-11-jdk      \
-            pandoc              \
-            pkg-config          \
-            protobuf-compiler   \
-            python3             \
-            python-pygments     \
-            python-recommonmark \
-            python-sphinx       \
-            rapidjson-dev       \
-            time                \
-            z3                  \
-            zlib1g-dev
-
-ADD deps/k/haskell-backend/src/main/native/haskell-backend/scripts/install-stack.sh /.install-stack/
-RUN /.install-stack/install-stack.sh
-
-USER user:user
-
-ADD --chown=user:user deps/k/haskell-backend/src/main/native/haskell-backend/stack.yaml /home/user/.tmp-haskell/
-ADD --chown=user:user deps/k/haskell-backend/src/main/native/haskell-backend/kore/package.yaml /home/user/.tmp-haskell/kore/
-RUN    cd /home/user/.tmp-haskell \
-    && stack build --only-snapshot
+RUN    sudo apt-get update           \
+    && sudo apt-get upgrade --yes    \
+    && sudo apt-get install --yes    \
+                 autoconf            \
+                 cmake               \
+                 curl                \
+                 libboost-test-dev   \
+                 libcrypto++-dev     \
+                 libffi-dev          \
+                 libprocps-dev       \
+                 libprotobuf-dev     \
+                 libsecp256k1-dev    \
+                 libssl-dev          \
+                 libtool             \
+                 llvm-8-tools        \
+                 make                \
+                 maven               \
+                 netcat-openbsd      \
+                 openjdk-11-jdk      \
+                 pandoc              \
+                 pkg-config          \
+                 protobuf-compiler   \
+                 python3             \
+                 python-pygments     \
+                 python-recommonmark \
+                 python-sphinx       \
+                 rapidjson-dev       \
+                 time                \
+                 zlib1g-dev
 
 ENV LD_LIBRARY_PATH=/usr/local/lib
 ENV PATH=/home/user/.local/bin:/home/user/.cargo/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,9 @@
 FROM runtimeverificationinc/kframework-k:ubuntu-bionic-524fd49
 
-RUN    sudo apt-get update           \
-    && sudo apt-get upgrade --yes    \
-    && sudo apt-get install --yes    \
-                 autoconf            \
-                 cmake               \
-                 curl                \
-                 libboost-test-dev   \
-                 libcrypto++-dev     \
-                 libffi-dev          \
-                 libprocps-dev       \
-                 libprotobuf-dev     \
-                 libsecp256k1-dev    \
-                 libssl-dev          \
-                 libtool             \
-                 llvm-8-tools        \
-                 make                \
-                 maven               \
-                 netcat-openbsd      \
-                 openjdk-11-jdk      \
-                 pandoc              \
-                 pkg-config          \
-                 protobuf-compiler   \
-                 python3             \
-                 python-pygments     \
-                 python-recommonmark \
-                 python-sphinx       \
-                 rapidjson-dev       \
-                 time                \
-                 zlib1g-dev
+RUN    sudo apt-get update         \
+    && sudo apt-get upgrade --yes  \
+    && sudo apt-get install --yes  \
+                            pandoc
 
 ENV LD_LIBRARY_PATH=/usr/local/lib
 ENV PATH=/home/user/.local/bin:/home/user/.cargo/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,3 @@ RUN    sudo apt-get update         \
     && sudo apt-get upgrade --yes  \
     && sudo apt-get install --yes  \
                             pandoc
-
-ENV LD_LIBRARY_PATH=/usr/local/lib
-ENV PATH=/home/user/.local/bin:/home/user/.cargo/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,3 +9,6 @@ RUN    apt-get update         \
 ARG USER_ID=1000
 ARG GROUP_ID=1000
 RUN groupadd -g $GROUP_ID user && useradd -m -u $USER_ID -s /bin/sh -g user user
+
+USER user:user
+WORKDIR /home/user

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
 ARG K_COMMIT
 FROM runtimeverificationinc/kframework-k:ubuntu-bionic-${K_COMMIT}
 
-RUN    sudo apt-get update         \
-    && sudo apt-get upgrade --yes  \
-    && sudo apt-get install --yes  \
-                            pandoc
+RUN    apt-get update         \
+    && apt-get upgrade --yes  \
+    && apt-get install --yes  \
+                       pandoc
+
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+RUN    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers    \
+    && groupadd -g $GROUP_ID user                             \
+    && useradd -m -u $USER_ID -s /bin/sh -g user -G sudo user

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM runtimeverificationinc/kframework-k:ubuntu-bionic-c88df08
+FROM runtimeverificationinc/kframework-k:ubuntu-bionic-524fd49
 
 RUN    sudo apt-get update           \
     && sudo apt-get upgrade --yes    \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
   agent {
     dockerfile {
       label 'docker'
-      additionalBuildArgs '--build-arg K_COMMIT=$(cd deps/k && git rev-parse --short=7 HEAD)'
+      additionalBuildArgs '--build-arg K_COMMIT=$(cd deps/k && git rev-parse --short=7 HEAD) --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
     }
   }
   options { ansiColor('xterm') }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,10 @@
 pipeline {
-  agent { dockerfile { reuseNode true } }
+  agent {
+    dockerfile {
+      additionalBuildArgs '--build-arg K_COMMIT=$(cd deps/k && git rev-parse --short=7 HEAD)'
+      reuseNode true
+    }
+  }
   options { ansiColor('xterm') }
   stages {
     stage('Init title') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,8 +9,7 @@ pipeline {
     stage('Build and Test') {
       when { changeRequest() }
       stages {
-        stage('Dependencies') { steps { sh 'make deps'      } }
-        stage('Build')        { steps { sh 'make build -j4' } }
+        stage('Build') { steps { sh 'make build -j4' } }
         stage('Test') {
           options { timeout(time: 25, unit: 'MINUTES') }
           parallel {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,8 @@
 pipeline {
   agent {
     dockerfile {
+      label 'docker'
       additionalBuildArgs '--build-arg K_COMMIT=$(cd deps/k && git rev-parse --short=7 HEAD)'
-      reuseNode true
     }
   }
   options { ansiColor('xterm') }

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,13 @@ DEPS_DIR  := deps
 DEFN_DIR  := $(BUILD_DIR)/defn
 
 K_SUBMODULE := $(DEPS_DIR)/k
-K_RELEASE   ?= $(K_SUBMODULE)/k-distribution/target/release/k
-K_BIN       := $(K_RELEASE)/bin
-K_LIB       := $(K_RELEASE)/lib
+ifneq (,$(shell which kompile))
+  K_RELEASE ?= $(dir $(shell which kompile))..
+else
+  K_RELEASE ?= $(K_SUBMODULE)/k-distribution/target/release/k
+endif
+K_BIN := $(K_RELEASE)/bin
+K_LIB := $(K_RELEASE)/lib
 
 K_BUILD_TYPE := Debug
 

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ DEPS_DIR  := deps
 DEFN_DIR  := $(BUILD_DIR)/defn
 
 K_SUBMODULE := $(DEPS_DIR)/k
-ifneq (,$(shell which kompile))
-  K_RELEASE ?= $(dir $(shell which kompile))..
-else
+ifneq (,$(wildcard deps/k/k-distribution/target/release/k/bin/*))
   K_RELEASE ?= $(K_SUBMODULE)/k-distribution/target/release/k
+else
+  K_RELEASE ?= $(dir $(shell which kompile))..
 endif
 K_BIN := $(K_RELEASE)/bin
 K_LIB := $(K_RELEASE)/lib

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ else
 endif
 K_BIN := $(K_RELEASE)/bin
 K_LIB := $(K_RELEASE)/lib
+export K_RELEASE
 
 K_BUILD_TYPE := Debug
 

--- a/Makefile
+++ b/Makefile
@@ -88,13 +88,13 @@ build-llvm:    $(llvm_kompiled)
 build-haskell: $(haskell_kompiled)
 
 $(llvm_kompiled): $(llvm_defn)
-	$(K_BIN)/kompile --backend llvm                                           \
+	kompile --backend llvm                                                    \
 	    --directory $(llvm_dir) -I $(llvm_dir)                                \
 	    --main-module $(MAIN_MODULE) --syntax-module $(MAIN_SYNTAX_MODULE) $< \
 	    $(KOMPILE_OPTIONS)
 
 $(haskell_kompiled): $(haskell_defn)
-	$(K_BIN)/kompile --backend haskell                                        \
+	kompile --backend haskell                                                 \
 	    --directory $(haskell_dir) -I $(haskell_dir)                          \
 	    --main-module $(MAIN_MODULE) --syntax-module $(MAIN_SYNTAX_MODULE) $< \
 	    $(KOMPILE_OPTIONS)

--- a/kwasm
+++ b/kwasm
@@ -3,11 +3,21 @@
 set -euo pipefail
 shopt -s extglob
 
+notif() { echo "== $@" >&2 ; }
+fatal() { echo "[FATAL] $@" ; exit 1 ; }
+
 kwasm_dir="${KWASM_DIR:-$(dirname $0)}"
 build_dir="$kwasm_dir/.build"
 defn_dir="${KWASM_DEFN_DIR:-$build_dir/defn}"
 lib_dir="$build_dir/local/lib"
 k_release_dir="${K_RELEASE:-$kwasm_dir/deps/k/k-distribution/target/release/k}"
+if [[ ! -f "${k_release_dir}/bin/kompile" ]]; then
+    if which kompile &> /dev/null; then
+        k_release_dir="$(dirname $(which kompile))/.."
+    else
+        fatal "Cannot find K Installation!"
+    fi
+fi
 
 export PATH="$k_release_dir/lib/native/linux:$k_release_dir/lib/native/linux64:$k_release_dir/bin/:$PATH"
 export LD_LIBRARY_PATH="$k_release_dir/lib/native/linux64:$lib_dir:${LD_LIBRARY_PATH:-}"
@@ -20,13 +30,6 @@ export K_OPTS="${K_OPTS:--Xmx16G}"
 
 # Utilities
 # ---------
-
-notif() { echo "== $@" >&2 ; }
-fatal() { echo "[FATAL] $@" ; exit 1 ; }
-
-pretty_diff() {
-    git --no-pager diff --no-index --ignore-all-space "$@"
-}
 
 preprocess() {
     local this_script_dir tmp_dir tmp_input


### PR DESCRIPTION
This uses the published Dockerhub images for K on CI instead of building it in the Jenkinsfile, which will make the overall CI time less.

Both the `Makefile` and the `kwasm` script are modified to have the following behavior about where to pull `K_RELEASE` from (and thus `krun`, `kprove`, `kore-exec`, etc...):

-   If the user sets `K_RELEASE`, use that version.
-   If the submodule is built, use the submodule version.
-   Otherwise, use `which kompile` to find a global or user install of K, and use that build.