### PR TITLE
Cleanups and organization

### DIFF
--- a/data.md
+++ b/data.md
@@ -288,10 +288,10 @@ The `#round` function casts a `f64` float to a `f32` float.
 ```k
     syntax FVal ::= #round ( FValType , Number ) [function]
  // -------------------------------------------------------
-    rule #round( f64 , N:Float) => < f64 > roundFloat(N, 53, 11) [concrete]
-    rule #round( f32 , N:Float) => < f32 > roundFloat(N, 24, 8)  [concrete]
-    rule #round( f64 , N:Int  ) => < f64 >  Int2Float(N, 53, 11) [concrete]
-    rule #round( f32 , N:Int  ) => < f32 >  Int2Float(N, 24, 8)  [concrete]
+    rule #round(f64 , N:Float) => < f64 > roundFloat(N, 53, 11) [concrete]
+    rule #round(f32 , N:Float) => < f32 > roundFloat(N, 24, 8)  [concrete]
+    rule #round(f64 , N:Int  ) => < f64 >  Int2Float(N, 53, 11) [concrete]
+    rule #round(f32 , N:Int  ) => < f32 >  Int2Float(N, 24, 8)  [concrete]
 ```
 
 ### Signed Interpretation

--- a/data.md
+++ b/data.md
@@ -276,8 +276,8 @@ The `#wrap` function wraps an integer to a given byte width.
 
     syntax Int ::= #wrap ( Int , Int ) [function, functional]
  // ---------------------------------------------------------
-    rule #wrap(WIDTH, N) => N &Int ((1 <<Int (WIDTH *Int 8)) -Int 1) requires         WIDTH >Int 0 [concrete]
-    rule #wrap(WIDTH, N) => 0                                        requires notBool WIDTH >Int 0
+    rule #wrap(WIDTH, N) => N &Int ((1 <<Int (WIDTH *Int 8)) -Int 1) requires         0 <Int WIDTH [concrete]
+    rule #wrap(WIDTH, N) => 0                                        requires notBool 0 <Int WIDTH
 ```
 
 In `K` all `Float` numbers are of 64-bits width by default, so we need to downcast a `f32` float to 32-bit manually.

--- a/data.md
+++ b/data.md
@@ -512,8 +512,8 @@ However, `ByteMap` is just a wrapper around regular `Map`s.
 ```k
     syntax ByteMap ::= #setRange(ByteMap, Int, Int, Int) [function, functional, smtlib(setRange)]
  // ---------------------------------------------------------------------------------------------
-    rule #setRange(BM, ADDR, VAL, WIDTH) => BM                                                                                 requires notBool (0 <=Int ADDR andBool 0 <Int WIDTH andBool 0 <=Int VAL)
-    rule #setRange(BM, ADDR, VAL, WIDTH) => #setRange(#set(BM, ADDR, VAL modInt 256), ADDR +Int 1, VAL /Int 256, WIDTH -Int 1) requires          0 <=Int ADDR andBool 0 <Int WIDTH andBool 0 <=Int VAL
+    rule #setRange(BM, ADDR, VAL, WIDTH) => BM                                                                                 requires notBool (0 <Int WIDTH andBool 0 <=Int VAL andBool 0 <=Int ADDR)
+    rule #setRange(BM, ADDR, VAL, WIDTH) => #setRange(#set(BM, ADDR, VAL modInt 256), ADDR +Int 1, VAL /Int 256, WIDTH -Int 1) requires          0 <Int WIDTH andBool 0 <=Int VAL andBool 0 <=Int ADDR
       [concrete]
 ```
 

--- a/data.md
+++ b/data.md
@@ -325,7 +325,7 @@ Function `#bool` converts a `Bool` into an `Int`.
 ```k
     syntax Int ::= #bool ( Bool ) [function, functional]
  // ----------------------------------------------------
-    rule #bool( B:Bool ) => 1 requires B
+    rule #bool( B:Bool ) => 1 requires         B
     rule #bool( B:Bool ) => 0 requires notBool B
 ```
 

--- a/kwasm-lemmas.md
+++ b/kwasm-lemmas.md
@@ -354,17 +354,6 @@ Lemmas about `#getRange` and `#setRange` simplification:
        andBool WIDTH1 *Int 8 ==Int SHIFT
       [simplification]
 
-    rule #getRange(#setRange(BM, EA, VALUE, SET_WIDTH), EA, GET_WIDTH)
-      => #wrap(GET_WIDTH, VALUE)
-      requires         GET_WIDTH <=Int SET_WIDTH
-      [simplification]
-
-    rule #getRange(#setRange(BM, EA, VALUE, SET_WIDTH), EA, GET_WIDTH)
-      => #wrap(SET_WIDTH, VALUE)
-      requires (notBool GET_WIDTH <=Int SET_WIDTH)
-       andBool #getRange(BM, EA +Int SET_WIDTH, GET_WIDTH -Int SET_WIDTH) ==Int 0
-      [simplification]
-
     rule #getRange(ByteMap <| .Map |>, _, _) => 0 [simplification]
 
     rule #getRange(#setRange(BM, ADDR, VAL, WIDTH), ADDR', WIDTH') => #getRange(BM, ADDR', WIDTH') requires ADDR' +Int WIDTH' <=Int ADDR  [simplification]

--- a/kwasm-lemmas.md
+++ b/kwasm-lemmas.md
@@ -313,8 +313,6 @@ We want to make the variant explicit, so we introduce the following helper, whic
 Bounds on `#getRange`:
 
 ```k
-    rule #getRange(ByteMap <| .Map |>, _, _) => 0 [simplification]
-
     rule 0 <=Int #getRange(_, _, _) => true                                             [simplification]
     rule 0 <=Int VAL <<Int SHIFT    => true requires 0 <=Int VAL  andBool 0 <=Int SHIFT [simplification]
     rule 0 <=Int VAL1 +Int VAL2     => true requires 0 <=Int VAL1 andBool 0 <=Int VAL2  [simplification]


### PR DESCRIPTION
-   Several lemmas over `#get` removed.
-   Re-organize and minor documentation of `kwasm-lemmas.md`.
-   Standardization of comparison directions (eg. `0 <Int WIDTH` instead of `WIDTH >Int 0`)

This may be easier to review commit-by-commit with `git log -p`, and in some cases `git show COMMIT_ID -b`