### PR TITLE
Unfold definitions

### DIFF
--- a/data.md
+++ b/data.md
@@ -36,7 +36,6 @@ And we use `OptionalId` to handle the case where an identifier could be omitted.
 ```k
     syntax Identifier ::= IdentifierToken
                         | #freshId ( Int )
-                        | #freshIdRuntime ( Int )
     syntax OptionalId ::= "" [klabel(.Identifier)]
                         | Identifier
  // --------------------------------

--- a/data.md
+++ b/data.md
@@ -36,6 +36,7 @@ And we use `OptionalId` to handle the case where an identifier could be omitted.
 ```k
     syntax Identifier ::= IdentifierToken
                         | #freshId ( Int )
+                        | #freshIdRuntime ( Int )
     syntax OptionalId ::= "" [klabel(.Identifier)]
                         | Identifier
  // --------------------------------

--- a/test.md
+++ b/test.md
@@ -481,7 +481,6 @@ The modules are cleaned all together after the test file is executed.
          <locals>          _ => .Map      </locals>
          <labelDepth>      _ => 0         </labelDepth>
          <labelIds>        _ => .Map      </labelIds>
-         <nextFreshId>     _ => 0         </nextFreshId>
          <moduleInstances> _ => .Bag      </moduleInstances>
          <moduleIds>       _ => .Map      </moduleIds>
          <nextModuleIdx>   _ => 0         </nextModuleIdx>

--- a/tests/bad-proofs/mod-on-negative-spec.k.expected
+++ b/tests/bad-proofs/mod-on-negative-spec.k.expected
@@ -66,9 +66,6 @@
     <deterministicMemoryGrowth>
       _70
     </deterministicMemoryGrowth>
-    <nextFreshId>
-      _80
-    </nextFreshId>
   </wasm>
 #And
   {

--- a/tests/simple/data.wast
+++ b/tests/simple/data.wast
@@ -1,7 +1,11 @@
 ;; Instantiating with data
 
+(module
 (memory $an-ident (data "WASM" "2\2E0"))
+)
+
 (memory.size)
+
 #assertTopStack < i32 > 1 "size of stack"
 #assertMemoryData (0, 87) "text to ascii W"
 #assertMemoryData (1, 65) "text to ascii A"
@@ -14,8 +18,10 @@
 
 #clearConfig
 
+(module
 (memory 1 1)
 (data (offset (i32.const 100)) "W" "AS" "M")
+)
 #assertMemoryData (100, 87) "text to ascii W"
 #assertMemoryData (101, 65) "text to ascii A"
 #assertMemoryData (102, 83) "text to ascii S"
@@ -24,17 +30,22 @@
 
 #clearConfig
 
+(module
 (memory (data))
-
+)
 #clearConfig
 
+(module
 (memory (data "W"))
+)
 #assertMemoryData (0, 87) "text to ascii W"
 #assertMemory 0 1 1 "memorys string length"
 
 #clearConfig
 
+(module
 (memory (data "\"\t\n\n\t\'\"\r\u{090A}"))
+)
 #assertMemoryData (0, 34) "text to ascii special"
 #assertMemoryData (1, 9) "text to ascii special"
 #assertMemoryData (2, 10) "text to ascii special"

--- a/tests/simple/functions_call.wast
+++ b/tests/simple/functions_call.wast
@@ -5,12 +5,13 @@
 #assertType 0 [ i32 i32 ] -> [ i32 ]
 #assertNextTypeIdx 1
 
-(func $0 (export "000") (type $a-cool-type)
+(func $0 (type $a-cool-type)
     (local.get 0)
     (local.get 1)
     (i32.add)
     (return)
 )
+(export "000" (func $0))
 
 #assertNextTypeIdx 1
 (assert_return (invoke "000" (i32.const 7) (i32.const 8)) (i32.const 15))
@@ -81,24 +82,26 @@
 
 ;; Function with empty declarations of types
 
-(func $1 param i64 i64 result result i64 param local
-    (local.get 0)
-    (return)
-)
+(module
+  (func $1 param i64 i64 result result i64 param local
+      (local.get 0)
+      (return)
+  )
 
-(func $1 (param i64 i64) (result i64)
-    (local.get 0)
-    (return)
-)
-(func (export "cool") (result i64)
-     i64.const 10
-     i64.const 11
-     call $1
+  (func $1 (param i64 i64) (result i64)
+      (local.get 0)
+      (return)
+  )
+  (func (export "cool") (result i64)
+      i64.const 10
+      i64.const 11
+      call $1
+  )
 )
 
 (assert_return (invoke "cool") (i64.const 10))
 #assertFunction $1 [ i64 i64 ] -> [ i64 ] [ ] "empty type declarations"
-#assertNextTypeIdx 5
+#assertNextTypeIdx 2
 
 ;; Function with just a name
 

--- a/tests/simple/functions_call.wast
+++ b/tests/simple/functions_call.wast
@@ -38,7 +38,10 @@
 
 (i32.const 7)
 (i32.const 8)
-(table funcref (elem $0))
+
+(table 1 funcref)
+(elem (i32.const 0) $0)
+
 (i32.const 0)
 (call_indirect (type $a-cool-type))
 #assertTopStack < i32 > 15 "call function 0 no return"

--- a/tests/simple/text2abstract.wast
+++ b/tests/simple/text2abstract.wast
@@ -92,23 +92,26 @@
 
 #clearConfig
 
-(func (export "foo") (param $a i32) (result i32)
+(func $foo (param $a i32) (result i32)
   local.get $a
 )
+(export "foo" (func $foo))
 
-(func (export "bar") (param $a i32) (result i32)
+(func $bar (param $a i32) (result i32)
   block (result i32)
     local.get $a
   end
 )
+ (export "bar" (func $bar))
 
-(func (export "baz") (param $a i32) (result i32)
+(func $baz (param $a i32) (result i32)
   loop (result i32)
     local.get $a
   end
 )
+(export "baz" (func $baz))
 
-(func (export "baf") (param $a i32) (result i32)
+(func $baf (param $a i32) (result i32)
   i32.const 1
   if (result i32)
     local.get $a
@@ -116,8 +119,9 @@
     local.get $a
   end
 )
+(export "baf" (func $baf))
 
-(func (export "bag") (param $a i32) (result i32)
+(func $bag (param $a i32) (result i32)
   i32.const 0
   if (result i32)
     local.get $a
@@ -125,6 +129,7 @@
     local.get $a
   end
 )
+(export "bag" (func $bag))
 
 (func $far (param $a i32) (result i32) (local $b i64)
   local.get $a

--- a/tests/success-llvm.out
+++ b/tests/success-llvm.out
@@ -60,7 +60,4 @@
   <deterministicMemoryGrowth>
     true
   </deterministicMemoryGrowth>
-  <nextFreshId>
-    0
-  </nextFreshId>
 </wasm >

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -254,19 +254,6 @@ Note that it is possible to define multiple exports inline, i.e. export a single
           ...
          </k>
 
-    syntax FuncSpec   ::= InlineExport FuncSpec
- // -------------------------------------------
-    rule <k> ( func                         EXPO:InlineExport SPEC:FuncSpec )
-          => ( func #freshIdRuntime(NEXTID) EXPO              SPEC          )
-          ...
-         </k>
-         <nextFreshId> NEXTID => NEXTID +Int 1 </nextFreshId>
-
-    rule <k> ( func ID:Identifier ( export ENAME ) SPEC:FuncSpec )
-          => ( export ENAME ( func ID ) )
-          ~> ( func ID SPEC )
-          ...
-         </k>
 ```
 
 ### Imports
@@ -278,10 +265,8 @@ Imports can be declared like regular functions, memories, etc., by giving an inl
  // --------------------------------------------------------------
 
     syntax GlobalSpec ::= InlineImport TextFormatGlobalType
-    syntax FuncSpec   ::= InlineImport TypeUse
  // --------------------------------------------
     rule ( global OID:OptionalId (import MOD NAME) TYP          ) => ( import MOD NAME (global OID TYP ) )  [macro]
-    rule ( func   OID:OptionalId (import MOD NAME) TUSE         ) => ( import MOD NAME (func   OID TUSE) )  [macro]
 ```
 
 Desugaring
@@ -304,6 +289,23 @@ Other desugarings are either left for runtime or expressed as macros (for now).
     rule unfoldDefns(DS) => #unfoldDefns(DS, 0)
     rule #unfoldDefns(.Defns, _) => .Defns
     rule #unfoldDefns(D:Defn DS, I) => D #unfoldDefns(DS, I) [owise]
+```
+
+#### Unfolding Functions
+
+```k
+    syntax FuncSpec   ::= InlineImport TypeUse
+ // ------------------------------------------
+    rule #unfoldDefns(( func OID:OptionalId (import MOD NAME) TUSE) DS, I)
+      => ( import MOD NAME (func OID TUSE) ) #unfoldDefns(DS, I)
+
+    syntax FuncSpec   ::= InlineExport FuncSpec
+ // -------------------------------------------
+    rule #unfoldDefns(( func EXPO:InlineExport SPEC:FuncSpec ) DS, I)
+      => #unfoldDefns(( func #freshId(I) EXPO  SPEC) DS, I +Int 1)
+
+    rule #unfoldDefns(( func ID:Identifier ( export ENAME ) SPEC:FuncSpec ) DS, I)
+      => ( export ENAME ( func ID ) ) #unfoldDefns(( func ID SPEC ) DS, I)
 ```
 
 #### Unfolding Tables

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -377,6 +377,7 @@ Other desugarings are either left for runtime or expressed as macros (for now).
 -   Give the text format and abstract format different sorts, and have `text2abstract` handle the conversion.
     Then identifiers and other text-only constructs can be completely removed from the abstract format.
 
+
 ### The Context
 
 The `Context` contains information of how to map text-level identifiers to corresponding indices.

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -264,9 +264,14 @@ Other desugarings are either left for runtime or expressed as macros (for now).
 ### Unfolding Abbreviations
 
 ```k
+    syntax Stmts ::= unfoldStmts  ( Stmts )
     syntax Defns ::= unfoldDefns  ( Defns )       [function]
                    | #unfoldDefns ( Defns , Int ) [function]
  // --------------------------------------------------------
+    rule unfoldStmts(( module OID:OptionalId DS) SS) => ( module OID unfoldDefns(DS) ) unfoldStmts(SS)
+    rule unfoldStmts(.Stmts) => .Stmts
+    rule unfoldStmts(S SS) => S unfoldStmts(SS) [owise]
+
     rule unfoldDefns(DS) => #unfoldDefns(DS, 0)
     rule #unfoldDefns(.Defns, _) => .Defns
     rule #unfoldDefns(D:Defn DS, I) => D #unfoldDefns(DS, I) [owise]
@@ -406,9 +411,9 @@ Since we do not have polymorphic functions available, we define one function per
     syntax LocalDecl ::= "#t2aLocalDecl"  "<" Context ">" "(" LocalDecl  ")" [function]
  // -----------------------------------------------------------------------------------
     rule text2abstract(DS:Defns) => text2abstract(( module DS ) .Stmts)
-    rule text2abstract(SS)       => #t2aStmts<ctx( ... localIds: .Map)>(SS) [owise]
+    rule text2abstract(SS)       => #t2aStmts<ctx( ... localIds: .Map)>(unfoldStmts(SS)) [owise]
 
-    rule #t2aStmt<C>(( module OID:OptionalId DS )) => ( module OID #t2aDefns<C>(unfoldDefns(DS)) )
+    rule #t2aStmt<C>(( module OID:OptionalId DS )) => ( module OID #t2aDefns<C>(DS) )
     rule #t2aStmt<C>(D:Defn)  => #t2aDefn<C>(D)
     rule #t2aStmt<C>(I:Instr) => #t2aInstr<C>(I)
     rule #t2aStmt<_>(S) => S [owise]

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -264,7 +264,7 @@ Other desugarings are either left for runtime or expressed as macros (for now).
 ### Unfolding Abbreviations
 
 ```k
-    syntax Stmts ::= unfoldStmts  ( Stmts )
+    syntax Stmts ::= unfoldStmts  ( Stmts )       [function]
     syntax Defns ::= unfoldDefns  ( Defns )       [function]
                    | #unfoldDefns ( Defns , Int ) [function]
  // --------------------------------------------------------

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -404,7 +404,8 @@ Since we do not have polymorphic functions available, we define one function per
     syntax TypeUse   ::= "#t2aTypeUse"    "<" Context ">" "(" TypeUse    ")" [function]
     syntax LocalDecl ::= "#t2aLocalDecl"  "<" Context ">" "(" LocalDecl  ")" [function]
  // -----------------------------------------------------------------------------------
-    rule text2abstract(SS) => #t2aStmts<ctx( ... localIds: .Map)>(SS)
+    rule text2abstract(DS:Defns) => text2abstract(( module DS ) .Stmts)
+    rule text2abstract(SS)       => #t2aStmts<ctx( ... localIds: .Map)>(SS) [owise]
 
     rule #t2aStmt<C>(( module OID:OptionalId DS )) => ( module OID #t2aDefns<C>(unfoldDefns(DS)) )
     rule #t2aStmt<C>(D:Defn)  => #t2aDefn<C>(D)

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -292,8 +292,8 @@ Note that it is possible to define multiple exports inline, i.e. export a single
 
     syntax GlobalSpec ::= InlineExport GlobalSpec
  // ---------------------------------------------
-    rule <k> ( global                  EXPO:InlineExport SPEC:GlobalSpec )
-          => ( global #freshId(NEXTID) EXPO              SPEC            )
+    rule <k> ( global                         EXPO:InlineExport SPEC:GlobalSpec )
+          => ( global #freshIdRuntime(NEXTID) EXPO              SPEC            )
           ...
          </k>
          <nextFreshId> NEXTID => NEXTID +Int 1 </nextFreshId>
@@ -306,8 +306,8 @@ Note that it is possible to define multiple exports inline, i.e. export a single
 
     syntax FuncSpec   ::= InlineExport FuncSpec
  // -------------------------------------------
-    rule <k> ( func                  EXPO:InlineExport SPEC:FuncSpec )
-          => ( func #freshId(NEXTID) EXPO              SPEC          )
+    rule <k> ( func                         EXPO:InlineExport SPEC:FuncSpec )
+          => ( func #freshIdRuntime(NEXTID) EXPO              SPEC          )
           ...
          </k>
          <nextFreshId> NEXTID => NEXTID +Int 1 </nextFreshId>
@@ -320,8 +320,8 @@ Note that it is possible to define multiple exports inline, i.e. export a single
 
     syntax TableSpec  ::= InlineExport TableSpec
  // --------------------------------------------
-    rule <k> ( table                  EXPO:InlineExport SPEC:TableSpec )
-          => ( table #freshId(NEXTID) EXPO              SPEC           )
+    rule <k> ( table                         EXPO:InlineExport SPEC:TableSpec )
+          => ( table #freshIdRuntime(NEXTID) EXPO              SPEC           )
           ...
          </k>
          <nextFreshId> NEXTID => NEXTID +Int 1 </nextFreshId>
@@ -377,6 +377,19 @@ Some classes of invalid programs, such as those where an identifier appears in a
 The function deals with the desugarings which are context dependent.
 Other desugarings are either left for runtime or expressed as macros (for now).
 
+### Unfolding Definitions
+
+```k
+    syntax Defns ::= unfoldDefns  ( Defns )       [function]
+                   | #unfoldDefns ( Defns , Int ) [function]
+ // --------------------------------------------------------
+    rule unfoldDefns(DS) => #unfoldDefns(DS, 0)
+    rule #unfoldDefns(.Defns, _) => .Defns
+    rule #unfoldDefns(D:Defn DS, I) => D #unfoldDefns(DS, I) [owise]
+```
+
+## Replacing Identifiers and Unfolding Instructions
+
 **TODO:**
 
 -   Get rid of inline type declarations.
@@ -417,7 +430,7 @@ Since we do not have polymorphic functions available, we define one function per
  // -----------------------------------------------------------------------------------
     rule text2abstract(SS) => #t2aStmts<ctx( ... localIds: .Map)>(SS)
 
-    rule #t2aStmt<C>(( module OID:OptionalId DS )) => ( module OID #t2aDefns<C>(DS) )
+    rule #t2aStmt<C>(( module OID:OptionalId DS )) => ( module OID #t2aDefns<C>(unfoldDefns(DS)) )
     rule #t2aStmt<C>(D:Defn)  => #t2aDefn<C>(D)
     rule #t2aStmt<C>(I:Instr) => #t2aInstr<C>(I)
     rule #t2aStmt<_>(S) => S [owise]

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -258,6 +258,10 @@ This is useful when specifying modules in the more lax KWasm format, where they 
           ...
          </k>
 
+    syntax Int ::= #lengthDataPages ( DataString ) [function]
+ // ---------------------------------------------------------
+    rule #lengthDataPages(DS:DataString) => lengthBytes(#DS2Bytes(DS)) up/Int #pageSize()
+
     syntax TableSpec ::= TableElemType "(" "elem" ElemSegment ")"
  // -------------------------------------------------------------
     rule ( table funcref ( elem ES ) ) => ( table .TableIdentifier funcref (elem ES) ) [macro]

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -310,7 +310,7 @@ Other desugarings are either left for runtime or expressed as macros (for now).
     syntax TableSpec  ::= InlineExport TableSpec
  // --------------------------------------------
     rule #unfoldDefns(( table EXPO:InlineExport SPEC:TableSpec ) DS, I)
-      => #unfoldDefns(( table #freshId(I) EXPO SPEC ), I +Int 1)
+      => #unfoldDefns(( table #freshId(I) EXPO SPEC ) DS, I +Int 1)
 
     rule #unfoldDefns(( table ID:Identifier ( export ENAME ) SPEC:TableSpec ) DS, I)
       => ( export ENAME ( table ID ) ) #unfoldDefns(( table ID SPEC ) DS, I)

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -372,7 +372,7 @@ Other desugarings are either left for runtime or expressed as macros (for now).
     The text format allows specifying the type directly in the function header using the `param` and `result` keywords.
     However, these will either be desugared to a new top-level `type` declaration or they must match an existing one.
     In the abstract format, a function's type is a pointer to a top-level `type` declaration.
-    This could either be done by doing an initial pass to gather all type declarations, or they could be desugared locally, which is similar to what we do currently: `(func (type X) TDS:TDecls ... ) => (func (type X))` and `(func TDS:TDecls ...) => (type TDECLS) (func (type NEXT_TYPE_ID)`.
+    This could either be done by doing an initial pass to gather all type declarations, or they could be desugared locally, which is similar to what we do currently: `(func (type X) TDS:TDecls ... ) => (func (type X))` and `(func TDS:TDecls ...) => (type TDECLS) (func (type NEXT_TYPE_ID))`.
 -   Remove module names.
 -   Give the text format and abstract format different sorts, and have `text2abstract` handle the conversion.
     Then identifiers and other text-only constructs can be completely removed from the abstract format.

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -261,7 +261,7 @@ Some classes of invalid programs, such as those where an identifier appears in a
 The function deals with the desugarings which are context dependent.
 Other desugarings are either left for runtime or expressed as macros (for now).
 
-### Unfolding Definitions
+### Unfolding Abbreviations
 
 ```k
     syntax Defns ::= unfoldDefns  ( Defns )       [function]
@@ -272,7 +272,7 @@ Other desugarings are either left for runtime or expressed as macros (for now).
     rule #unfoldDefns(D:Defn DS, I) => D #unfoldDefns(DS, I) [owise]
 ```
 
-#### Unfolding Functions
+#### Functions
 
 ```k
     syntax FuncSpec   ::= InlineImport TypeUse
@@ -289,12 +289,12 @@ Other desugarings are either left for runtime or expressed as macros (for now).
       => ( export ENAME ( func ID ) ) #unfoldDefns(( func ID SPEC ) DS, I)
 ```
 
-#### Unfolding Tables
+#### Tables
 
 ```k
     syntax TableSpec ::= TableElemType "(" "elem" ElemSegment ")"
  // -------------------------------------------------------------
-    rule #unfoldDefns(( table funcref         ( elem ELEM ) ) DS, I)
+    rule #unfoldDefns(( table funcref ( elem ELEM ) ) DS, I)
       => #unfoldDefns(( table #freshId(I) funcref ( elem ELEM ) ) DS, I +Int 1)
 
     rule #unfoldDefns(( table ID:Identifier funcref ( elem ELEM ) ) DS, I)
@@ -316,12 +316,12 @@ Other desugarings are either left for runtime or expressed as macros (for now).
       => ( export ENAME ( table ID ) ) #unfoldDefns(( table ID SPEC ) DS, I)
 ```
 
-#### Unfolding Memories
+#### Memories
 
 ```k
     syntax MemorySpec ::= "(" "data" DataString ")"
  // -----------------------------------------------
-    rule #unfoldDefns(( memory             ( data DATA ) ) DS, I)
+    rule #unfoldDefns(( memory ( data DATA ) ) DS, I)
       => #unfoldDefns(( memory #freshId(I) ( data DATA ) ) DS, I +Int 1)
 
     rule #unfoldDefns(( memory ID:Identifier ( data DATA ) ) DS, I)
@@ -340,35 +340,28 @@ Other desugarings are either left for runtime or expressed as macros (for now).
 
     syntax MemorySpec ::= InlineExport MemorySpec
  // ---------------------------------------------
-    rule #unfoldDefns(( memory                 EXPO:InlineExport SPEC:MemorySpec ) DS, I)
-      => #unfoldDefns(( memory #freshId(I:Int) EXPO              SPEC            ) DS, I +Int 1)
+    rule #unfoldDefns(( memory EXPO:InlineExport SPEC:MemorySpec ) DS, I)
+      => #unfoldDefns(( memory #freshId(I:Int) EXPO SPEC ) DS, I +Int 1)
 
     rule #unfoldDefns(( memory ID:Identifier ( export ENAME ) SPEC:MemorySpec ) DS, I)
       => ( export ENAME ( memory ID ) ) #unfoldDefns( ( memory ID SPEC ) DS, I)
-
 ```
 
-#### Unfolding Globals
+#### Globals
 
 ```k
     syntax GlobalSpec ::= InlineImport TextFormatGlobalType
  // -------------------------------------------------------
     rule #unfoldDefns(( global OID:OptionalId (import MOD NAME) TYP ) DS, I)
-      => ( import MOD NAME (global OID TYP ) ) #unfoldDefns(DS, I)
+      => ( import MOD NAME (global OID TYP ) ) #unfoldDefns(DS, I) 
 
     syntax GlobalSpec ::= InlineExport GlobalSpec
  // ---------------------------------------------
-    rule #unfoldDefns(( memory                 EXPO:InlineExport SPEC:MemorySpec ) DS, I)
-      => #unfoldDefns(( memory #freshId(I:Int) EXPO              SPEC            ) DS, I +Int 1)
-
-    rule #unfoldDefns(( memory ID:Identifier ( export ENAME ) SPEC:MemorySpec ) DS, I)
-      => ( export ENAME ( memory ID ) ) #unfoldDefns( ( memory ID SPEC ) DS, I)
-
     rule #unfoldDefns(( global EXPO:InlineExport SPEC:GlobalSpec ) DS, I)
       => #unfoldDefns(( global #freshId(I) EXPO SPEC ) DS, I +Int 1)
 
     rule #unfoldDefns(( global ID:Identifier ( export ENAME ) SPEC:GlobalSpec ) DS, I)
-          => ( export ENAME ( global ID ) ) #unfoldDefns(( global ID SPEC ) DS, I)
+      => ( export ENAME ( global ID ) ) #unfoldDefns(( global ID SPEC ) DS, I)
 ```
 
 ## Replacing Identifiers and Unfolding Instructions

--- a/wasm.md
+++ b/wasm.md
@@ -85,7 +85,6 @@ Configuration
           <nextGlobAddr> 0 </nextGlobAddr>
         </mainStore>
         <deterministicMemoryGrowth> true </deterministicMemoryGrowth>
-        <nextFreshId> 0 </nextFreshId>
       </wasm>
 ```
 

--- a/wasm.md
+++ b/wasm.md
@@ -1257,10 +1257,6 @@ The `data` initializer simply puts these bytes into the specified memory, starti
            ...
          </memInst>
 
-    syntax Int ::= #lengthDataPages ( DataString ) [function]
- // ---------------------------------------------------------
-    rule #lengthDataPages(DS:DataString) => lengthBytes(#DS2Bytes(DS)) up/Int #pageSize()
-
     syntax Int ::= Int "up/Int" Int [function]
  // ------------------------------------------
     rule I1 up/Int I2 => (I1 +Int (I2 -Int 1)) /Int I2 requires I2 >Int 0


### PR DESCRIPTION
In preparation for the extraction of identifiers and removing `#ContextLookup` for definitions of tables, functions, globals, and memories.

This passes each module through an `unfoldDefns` function. Previously we were doing some of this unfolding at parse time, with macros, and some at runtime. Now we do it all ahead of time.

Some tests are updated to reflect that we no longer support unfolding at runtime, so only definitions that are declared properly in modules can be desugared. We could in principle support all the syntactic sugars, but I think it would make the desugaring code a lot messier and verbose (and departing from the official spec), since we would have to deal with definitions interleaved with statements while keeping track of which module we are in.

This one might be easiest to review commit-by-commit.