### PR TITLE
Sort text module

### DIFF
--- a/test.md
+++ b/test.md
@@ -19,6 +19,18 @@ module WASM-TEST
     imports WASM-TEXT
 ```
 
+Bare Allocations
+----------------
+
+We allow allocations to appear outside of modules, for example interleaved with assertions in tests.
+This is purely a KWasm feature, which is useful for testing.
+
+```k
+    rule <k> A:Alloc => ( module .Defns ) ~> A ... </k>
+         <curModIdx> .Int </curModIdx>
+      [owise]
+```
+
 Auxiliary
 ---------
 

--- a/test.md
+++ b/test.md
@@ -26,7 +26,7 @@ We allow allocations to appear outside of modules, for example interleaved with 
 This is purely a KWasm feature, which is useful for testing.
 
 ```k
-    rule <k> A:Alloc => ( module .Defns ) ~> A ... </k>
+    rule <k> A:Alloc => #emptyModule() ~> A ... </k>
          <curModIdx> .Int </curModIdx>
       [owise]
 ```
@@ -238,7 +238,7 @@ Except `assert_return` and `assert_trap`, the remaining rules are directly reduc
     rule <k> (assert_malformed  MOD            DESC) => . ... </k>
     rule <k> (assert_invalid    MOD            DESC) => . ... </k>
     rule <k> (assert_unlinkable MOD            DESC) => . ... </k>
-    rule <k> (assert_trap       MOD:ModuleDecl DESC) => MOD ~> #assertTrap DESC ... </k>
+    rule <k> (assert_trap       MOD:ModuleDecl DESC) => text2abstract(MOD .Stmts) ~> #assertTrap DESC ... </k>
 ```
 
 And we implement some helper assertions to help testing.

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -389,27 +389,27 @@ In doing so, the respective ordering of all types of definitions are preserved.
 ```k
     syntax Stmts ::= structureModules ( Stmts ) [function]
  // ------------------------------------------------------
-    rule structureModules((module OID:OptionalId DS) SS) => sortModule((module OID DS)) structureModules(SS)
+    rule structureModules((module OID:OptionalId DS) SS) => structureModule((module OID DS)) structureModules(SS)
     rule structureModules(.Stmts) => .Stmts
     rule structureModules(S SS) => S strucutreModules(SS) [owise]
 
-    syntax ModuleDecl ::=  sortModule ( Defns , OptionalId ) [function]
-                        | #sortModule ( Defns , ModuleDecl ) [function]
- // -------------------------------------------------------------------
-    rule sortModule(DEFNS, OID) => #sortModule(#reverse(DEFNS, .Defns), #emptyModule(OID))
+    syntax ModuleDecl ::=  structureModule ( Defns , OptionalId ) [function]
+                        | #structureModule ( Defns , ModuleDecl ) [function]
+ // ------------------------------------------------------------------------
+    rule structureModule(DEFNS, OID) => #structureModule(#reverse(DEFNS, .Defns), #emptyModule(OID))
 
-    rule #sortModule(.Defns, SORTED_MODULE) => SORTED_MODULE
+    rule #structureModule(.Defns, SORTED_MODULE) => SORTED_MODULE
 
-    rule #sortModule((T:TypeDefn   DS:Defns => DS), #module(... types: (TS => T TS)))
-    rule #sortModule((I:ImportDefn DS:Defns => DS), #module(... importDefns: (IS => I IS)))
-    rule #sortModule((X:FuncDefn   DS:Defns => DS), #module(... funcs: (FS => X FS)))
-    rule #sortModule((X:GlobalDefn DS:Defns => DS), #module(... globals: (GS => X GS)))
-    rule #sortModule((T:TableDefn  DS:Defns => DS), #module(... tables: (TS => T TS)))
-    rule #sortModule((M:MemoryDefn DS:Defns => DS), #module(... mems: (MS => M MS)))
-    rule #sortModule((E:ExportDefn DS:Defns => DS), #module(... exports: (ES => E ES)))
-    rule #sortModule((I:DataDefn   DS:Defns => DS), #module(... data: (IS => I IS)))
-    rule #sortModule((I:ElemDefn   DS:Defns => DS), #module(... elem: (IS => I IS)))
-    rule #sortModule((S:StartDefn  DS:Defns => DS), #module(... start: (_ => S .Defns)))
+    rule #structureModule((T:TypeDefn   DS:Defns => DS), #module(... types: (TS => T TS)))
+    rule #structureModule((I:ImportDefn DS:Defns => DS), #module(... importDefns: (IS => I IS)))
+    rule #structureModule((X:FuncDefn   DS:Defns => DS), #module(... funcs: (FS => X FS)))
+    rule #structureModule((X:GlobalDefn DS:Defns => DS), #module(... globals: (GS => X GS)))
+    rule #structureModule((T:TableDefn  DS:Defns => DS), #module(... tables: (TS => T TS)))
+    rule #structureModule((M:MemoryDefn DS:Defns => DS), #module(... mems: (MS => M MS)))
+    rule #structureModule((E:ExportDefn DS:Defns => DS), #module(... exports: (ES => E ES)))
+    rule #structureModule((I:DataDefn   DS:Defns => DS), #module(... data: (IS => I IS)))
+    rule #structureModule((I:ElemDefn   DS:Defns => DS), #module(... elem: (IS => I IS)))
+    rule #structureModule((S:StartDefn  DS:Defns => DS), #module(... start: (_ => S .Defns)))
 
     syntax Defns ::= #reverse(Defns, Defns) [function]
  // --------------------------------------------------

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -395,20 +395,14 @@ In doing so, the respective ordering of all types of definitions are preserved.
     rule #sortModule(.Defns, SORTED_MODULE) => SORTED_MODULE
 
     rule #sortModule((T:TypeDefn   DS:Defns => DS), #module(... types: (TS => T TS)))
-
     rule #sortModule((I:ImportDefn DS:Defns => DS), #module(... importDefns: (IS => I IS)))
-
-    rule #sortModule((X:FuncDefn   DS:Defns => DS), #module(... funcsGlobals: (FGS => X FGS)))
-    rule #sortModule((X:GlobalDefn DS:Defns => DS), #module(... funcsGlobals: (FGS => X FGS)))
-
-    rule #sortModule((A:TableDefn  DS:Defns => DS), #module(... memsTables: (AS => A AS)))
-    rule #sortModule((A:MemoryDefn DS:Defns => DS), #module(... memsTables: (AS => A AS)))
-
+    rule #sortModule((X:FuncDefn   DS:Defns => DS), #module(... funcs: (FS => X FS)))
+    rule #sortModule((X:GlobalDefn DS:Defns => DS), #module(... globals: (GS => X GS)))
+    rule #sortModule((T:TableDefn  DS:Defns => DS), #module(... tables: (TS => T TS)))
+    rule #sortModule((M:MemoryDefn DS:Defns => DS), #module(... mems: (MS => M MS)))
     rule #sortModule((E:ExportDefn DS:Defns => DS), #module(... exports: (ES => E ES)))
-
-    rule #sortModule((I:DataDefn   DS:Defns => DS), #module(... inits: (IS => I IS)))
-    rule #sortModule((I:ElemDefn   DS:Defns => DS), #module(... inits: (IS => I IS)))
-
+    rule #sortModule((I:DataDefn   DS:Defns => DS), #module(... data: (IS => I IS)))
+    rule #sortModule((I:ElemDefn   DS:Defns => DS), #module(... elem: (IS => I IS)))
     rule #sortModule((S:StartDefn  DS:Defns => DS), #module(... start: (_ => S .Defns)))
 
     syntax Defns ::= #reverse(Defns, Defns) [function]

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -259,7 +259,6 @@ The only requirements are that all imports must precede all other definitions, a
     syntax Stmt       ::= ModuleDecl
     syntax ModuleDecl ::= "(" "module" OptionalId Defns ")"
  // -------------------------------------------------------
-    rule <k> ( module OID:OptionalId DEFNS ) => sortModule(DEFNS, OID) ... </k>
 
     syntax ModuleDecl ::=  sortModule ( Defns , OptionalId ) [function]
                         | #sortModule ( Defns , ModuleDecl ) [function]
@@ -454,7 +453,7 @@ Since we do not have polymorphic functions available, we define one function per
     rule text2abstract(DS:Defns) => text2abstract(( module DS ) .Stmts)
     rule text2abstract(SS)       => #t2aStmts<ctx( ... localIds: .Map)>(unfoldStmts(SS)) [owise]
 
-    rule #t2aStmt<C>(( module OID:OptionalId DS )) => ( module OID #t2aDefns<C>(DS) )
+    rule #t2aStmt<C>(( module OID:OptionalId DS )) => sortModule(#t2aDefns<C>(DS), OID)
     rule #t2aStmt<C>(D:Defn)  => #t2aDefn<C>(D)
     rule #t2aStmt<C>(I:Instr) => #t2aInstr<C>(I)
     rule #t2aStmt<_>(S) => S [owise]
@@ -462,12 +461,10 @@ Since we do not have polymorphic functions available, we define one function per
     rule #t2aDefn<C>(( func OID:OptionalId FS:FuncSpec )) => ( func OID #t2aFuncSpec<C>(FS))
     rule #t2aDefn<C>(D:Defn) => D [owise]
 
-    rule #t2aFuncSpec<C> (( export WS ) FS:FuncSpec ) => ( export WS ) #t2aFuncSpec<C>(FS)
     rule #t2aFuncSpec<C>(T:TypeUse LS:LocalDecls IS:Instrs)
       => #t2aTypeUse   <#updateLocalIds(C, #ids2Idxs(T, LS))>(T)
          #t2aLocalDecls<#updateLocalIds(C, #ids2Idxs(T, LS))>(LS)
          #t2aInstrs    <#updateLocalIds(C, #ids2Idxs(T, LS))>(IS)
-
 
     rule #t2aTypeUse<_>((type TYP) TDS:TypeDecls      ) => (type TYP)
     rule #t2aTypeUse<C>((param ID:Identifier AVT) TDS ) => (param AVT) {#t2aTypeUse<C>(TDS)}:>TypeDecls

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -438,7 +438,7 @@ Record updates can currently not be done in a function rule which also does othe
     rule #updateLocalIdsAux(C, _, true) => C
 ```
 
-### Traversing the Text Format
+### Traversing Modules
 
 The program is traversed in full once, context beting gathered along the way.
 Since we do not have polymorphic functions available, we define one function per sort of syntactic construct we need to traverse, and for each type of list we encounter.

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -387,6 +387,12 @@ The following functions convert the text format module, given as a list of defin
 In doing so, the respective ordering of all types of definitions are preserved.
 
 ```k
+    syntax Stmts ::= structureModules ( Stmts ) [function]
+ // ------------------------------------------------------
+    rule structureModules((module OID:OptionalId DS) SS) => sortModule((module OID DS)) structureModules(SS)
+    rule structureModules(.Stmts) => .Stmts
+    rule structureModules(S SS) => S strucutreModules(SS) [owise]
+
     syntax ModuleDecl ::=  sortModule ( Defns , OptionalId ) [function]
                         | #sortModule ( Defns , ModuleDecl ) [function]
  // -------------------------------------------------------------------
@@ -457,7 +463,7 @@ Since we do not have polymorphic functions available, we define one function per
     syntax LocalDecl ::= "#t2aLocalDecl"  "<" Context ">" "(" LocalDecl  ")" [function]
  // -----------------------------------------------------------------------------------
     rule text2abstract(DS:Defns) => text2abstract(( module DS ) .Stmts)
-    rule text2abstract(SS)       => #t2aStmts<ctx( ... localIds: .Map)>(unfoldStmts(SS)) [owise]
+    rule text2abstract(SS)       => #t2aStmts<ctx( ... localIds: .Map)>(structureModules(unfoldStmts(SS))) [owise]
 
     rule #t2aStmt<C>(( module OID:OptionalId DS )) => sortModule(#t2aDefns<C>(DS), OID)
     rule #t2aStmt<C>(D:Defn)  => #t2aDefn<C>(D)

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -250,6 +250,47 @@ Imports can be declared like regular functions, memories, etc., by giving an inl
  // --------------------------------------------------------------
 ```
 
+### Modules
+
+Modules are defined as a sequence of definitions, that may come in any order.
+The only requirements are that all imports must precede all other definitions, and that there may be at most one start function.
+
+```k
+    syntax Stmt       ::= ModuleDecl
+    syntax ModuleDecl ::= "(" "module" OptionalId Defns ")"
+ // -------------------------------------------------------
+    rule <k> ( module OID:OptionalId DEFNS ) => sortModule(DEFNS, OID) ... </k>
+
+    syntax ModuleDecl ::=  sortModule ( Defns , OptionalId ) [function]
+                        | #sortModule ( Defns , ModuleDecl ) [function]
+ // -------------------------------------------------------------------
+    rule sortModule(DEFNS, OID) => #sortModule(#reverse(DEFNS, .Defns), #emptyModule(OID))
+
+    rule #sortModule(.Defns, SORTED_MODULE) => SORTED_MODULE
+
+    rule #sortModule((T:TypeDefn   DS:Defns => DS), #module(... types: (TS => T TS)))
+
+    rule #sortModule((I:ImportDefn DS:Defns => DS), #module(... importDefns: (IS => I IS)))
+
+    rule #sortModule((X:FuncDefn   DS:Defns => DS), #module(... funcsGlobals: (FGS => X FGS)))
+    rule #sortModule((X:GlobalDefn DS:Defns => DS), #module(... funcsGlobals: (FGS => X FGS)))
+
+    rule #sortModule((A:TableDefn  DS:Defns => DS), #module(... memsTables: (AS => A AS)))
+    rule #sortModule((A:MemoryDefn DS:Defns => DS), #module(... memsTables: (AS => A AS)))
+
+    rule #sortModule((E:ExportDefn DS:Defns => DS), #module(... exports: (ES => E ES)))
+
+    rule #sortModule((I:DataDefn   DS:Defns => DS), #module(... inits: (IS => I IS)))
+    rule #sortModule((I:ElemDefn   DS:Defns => DS), #module(... inits: (IS => I IS)))
+
+    rule #sortModule((S:StartDefn  DS:Defns => DS), #module(... start: (_ => S .Defns)))
+
+    syntax Defns ::= #reverse(Defns, Defns) [function]
+ // --------------------------------------------------
+    rule #reverse(       .Defns  , ACC) => ACC
+    rule #reverse(D:Defn DS:Defns, ACC) => #reverse(DS, D ACC)
+```
+
 Desugaring
 ----------
 

--- a/wasm.md
+++ b/wasm.md
@@ -1447,49 +1447,15 @@ The groups are chosen to represent different stages of allocation and instantiat
     syntax ModuleDecl ::= #module ( id: OptionalId, types: Defns, importDefns: Defns, funcsGlobals: Defns, memsTables: Defns, exports: Defns, inits: Defns, start: Defns )
  // ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    syntax ModuleDecl ::= #emptyModule() [function, functional]
- // -----------------------------------------------------------
-    rule #emptyModule() => #module(... id: OID, types: .Defns, importDefns: .Defns, funcsGlobals: .Defns, memsTables: .Defns, exports: .Defns, inits: .Defns, start: .Defns)
-
-    syntax ModuleDecl ::=  sortModule ( Defns , OptionalId ) [function]
-                        | #sortModule ( Defns , ModuleDecl ) [function]
- // -------------------------------------------------------------------
-    rule sortModule(DEFNS, OID) => #sortModule(#reverse(DEFNS, .Defns), #emptyModule())
-
-    rule #sortModule(.Defns, SORTED_MODULE) => SORTED_MODULE
-
-    rule #sortModule((T:TypeDefn   DS:Defns => DS), #module(... types: (TS => T TS)))
-
-    rule #sortModule((I:ImportDefn DS:Defns => DS), #module(... importDefns: (IS => I IS)))
-
-    rule #sortModule((X:FuncDefn   DS:Defns => DS), #module(... funcsGlobals: (FGS => X FGS)))
-    rule #sortModule((X:GlobalDefn DS:Defns => DS), #module(... funcsGlobals: (FGS => X FGS)))
-
-    rule #sortModule((A:TableDefn  DS:Defns => DS), #module(... memsTables: (AS => A AS)))
-    rule #sortModule((A:MemoryDefn DS:Defns => DS), #module(... memsTables: (AS => A AS)))
-
-    rule #sortModule((E:ExportDefn DS:Defns => DS), #module(... exports: (ES => E ES)))
-
-    rule #sortModule((I:DataDefn   DS:Defns => DS), #module(... inits: (IS => I IS)))
-    rule #sortModule((I:ElemDefn   DS:Defns => DS), #module(... inits: (IS => I IS)))
-
-    rule #sortModule((S:StartDefn  DS:Defns => DS), #module(... start: (_ => S .Defns)))
-
-    syntax Defns ::= #reverse(Defns, Defns) [function]
- // --------------------------------------------------
-    rule #reverse(       .Defns  , ACC) => ACC
-    rule #reverse(D:Defn DS:Defns, ACC) => #reverse(DS, D ACC)
+    syntax ModuleDecl ::= #emptyModule(OptionalId) [function, functional]
+ // ---------------------------------------------------------------------
+    rule #emptyModule(OID) => #module(... id: OID, types: .Defns, importDefns: .Defns, funcsGlobals: .Defns, memsTables: .Defns, exports: .Defns, inits: .Defns, start: .Defns)
 ```
 
 A new module instance gets allocated.
 Then, the surrounding `module` tag is discarded, and the definitions are executed, putting them into the module currently being defined.
 
 ```k
-    syntax Stmt       ::= ModuleDecl
-    syntax ModuleDecl ::= "(" "module" OptionalId Defns ")"
- // -------------------------------------------------------
-    rule <k> ( module OID:OptionalId DEFNS ) => sortModule(DEFNS, OID) ... </k>
-
     rule <k> #module(... id: OID, types: TS, importDefns: IS, funcsGlobals: FGS, memsTables: AS, exports: ES, inits: INIS, start: S)
           => TS ~> IS ~> FGS ~> AS ~> ES ~> INIS ~> S
          ...

--- a/wasm.md
+++ b/wasm.md
@@ -1504,14 +1504,6 @@ Then, the surrounding `module` tag is discarded, and the definitions are execute
          </moduleInstances>
 ```
 
-It is permissible to define modules without the `module` keyword, by simply stating the definitions at the top level in the file.
-
-```k
-    rule <k> A:Alloc => ( module .Defns ) ~> A ... </k>
-         <curModIdx> .Int </curModIdx>
-      [owise]
-```
-
 After a module is instantiated, it should be saved somewhere.
 How this is done is up to the embedder.
 

--- a/wasm.md
+++ b/wasm.md
@@ -1444,32 +1444,36 @@ A subtle point is related to tables with inline `elem` definitions: since these 
 The groups are chosen to represent different stages of allocation and instantiation.
 
 ```k
-    syntax ModuleDecl ::= sortedModule ( id: OptionalId, types: Defns, importDefns: Defns, funcsGlobals: Defns, memsTables: Defns, exports: Defns, inits: Defns, start: Defns )
- // ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    syntax ModuleDecl ::= #module ( id: OptionalId, types: Defns, importDefns: Defns, funcsGlobals: Defns, memsTables: Defns, exports: Defns, inits: Defns, start: Defns )
+ // ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+    syntax ModuleDecl ::= #emptyModule() [function, functional]
+ // -----------------------------------------------------------
+    rule #emptyModule() => #module(... id: OID, types: .Defns, importDefns: .Defns, funcsGlobals: .Defns, memsTables: .Defns, exports: .Defns, inits: .Defns, start: .Defns)
 
     syntax ModuleDecl ::=  sortModule ( Defns , OptionalId ) [function]
                         | #sortModule ( Defns , ModuleDecl ) [function]
  // -------------------------------------------------------------------
-    rule sortModule(DEFNS, OID) => #sortModule(#reverse(DEFNS, .Defns), sortedModule(... id: OID, types: .Defns, importDefns: .Defns, funcsGlobals: .Defns, memsTables: .Defns, exports: .Defns, inits: .Defns, start: .Defns))
+    rule sortModule(DEFNS, OID) => #sortModule(#reverse(DEFNS, .Defns), #emptyModule())
 
     rule #sortModule(.Defns, SORTED_MODULE) => SORTED_MODULE
 
-    rule #sortModule((T:TypeDefn   DS:Defns => DS), sortedModule(... types: (TS => T TS)))
+    rule #sortModule((T:TypeDefn   DS:Defns => DS), #module(... types: (TS => T TS)))
 
-    rule #sortModule((I:ImportDefn DS:Defns => DS), sortedModule(... importDefns: (IS => I IS)))
+    rule #sortModule((I:ImportDefn DS:Defns => DS), #module(... importDefns: (IS => I IS)))
 
-    rule #sortModule((X:FuncDefn   DS:Defns => DS), sortedModule(... funcsGlobals: (FGS => X FGS)))
-    rule #sortModule((X:GlobalDefn DS:Defns => DS), sortedModule(... funcsGlobals: (FGS => X FGS)))
+    rule #sortModule((X:FuncDefn   DS:Defns => DS), #module(... funcsGlobals: (FGS => X FGS)))
+    rule #sortModule((X:GlobalDefn DS:Defns => DS), #module(... funcsGlobals: (FGS => X FGS)))
 
-    rule #sortModule((A:TableDefn  DS:Defns => DS), sortedModule(... memsTables: (AS => A AS)))
-    rule #sortModule((A:MemoryDefn DS:Defns => DS), sortedModule(... memsTables: (AS => A AS)))
+    rule #sortModule((A:TableDefn  DS:Defns => DS), #module(... memsTables: (AS => A AS)))
+    rule #sortModule((A:MemoryDefn DS:Defns => DS), #module(... memsTables: (AS => A AS)))
 
-    rule #sortModule((E:ExportDefn DS:Defns => DS), sortedModule(... exports: (ES => E ES)))
+    rule #sortModule((E:ExportDefn DS:Defns => DS), #module(... exports: (ES => E ES)))
 
-    rule #sortModule((I:DataDefn   DS:Defns => DS), sortedModule(... inits: (IS => I IS)))
-    rule #sortModule((I:ElemDefn   DS:Defns => DS), sortedModule(... inits: (IS => I IS)))
+    rule #sortModule((I:DataDefn   DS:Defns => DS), #module(... inits: (IS => I IS)))
+    rule #sortModule((I:ElemDefn   DS:Defns => DS), #module(... inits: (IS => I IS)))
 
-    rule #sortModule((S:StartDefn  DS:Defns => DS), sortedModule(... start: (_ => S .Defns)))
+    rule #sortModule((S:StartDefn  DS:Defns => DS), #module(... start: (_ => S .Defns)))
 
     syntax Defns ::= #reverse(Defns, Defns) [function]
  // --------------------------------------------------
@@ -1486,7 +1490,7 @@ Then, the surrounding `module` tag is discarded, and the definitions are execute
  // -------------------------------------------------------
     rule <k> ( module OID:OptionalId DEFNS ) => sortModule(DEFNS, OID) ... </k>
 
-    rule <k> sortedModule(... id: OID, types: TS, importDefns: IS, funcsGlobals: FGS, memsTables: AS, exports: ES, inits: INIS, start: S)
+    rule <k> #module(... id: OID, types: TS, importDefns: IS, funcsGlobals: FGS, memsTables: AS, exports: ES, inits: INIS, start: S)
           => TS ~> IS ~> FGS ~> AS ~> ES ~> INIS ~> S
          ...
          </k>

--- a/wasm.md
+++ b/wasm.md
@@ -1444,20 +1444,20 @@ A subtle point is related to tables with inline `elem` definitions: since these 
 The groups are chosen to represent different stages of allocation and instantiation.
 
 ```k
-    syntax ModuleDecl ::= #module ( id: OptionalId, types: Defns, importDefns: Defns, funcsGlobals: Defns, memsTables: Defns, exports: Defns, inits: Defns, start: Defns )
- // ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    syntax ModuleDecl ::= #module ( id: OptionalId, types: Defns, funcs: Defns, tables: Defns, mems: Defns, globals: Defns, elem: Defns, data: Defns, start: Defns, importDefns: Defns, exports: Defns)
+ // ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
     syntax ModuleDecl ::= #emptyModule(OptionalId) [function, functional]
  // ---------------------------------------------------------------------
-    rule #emptyModule(OID) => #module(... id: OID, types: .Defns, importDefns: .Defns, funcsGlobals: .Defns, memsTables: .Defns, exports: .Defns, inits: .Defns, start: .Defns)
+    rule #emptyModule(OID) =>  #module (... id: OID, types: .Defns, funcs: .Defns, tables: .Defns, mems: .Defns, globals: .Defns, elem: .Defns, data: .Defns, start: .Defns, importDefns: .Defns, exports: .Defns)
 ```
 
 A new module instance gets allocated.
 Then, the surrounding `module` tag is discarded, and the definitions are executed, putting them into the module currently being defined.
 
 ```k
-    rule <k> #module(... id: OID, types: TS, importDefns: IS, funcsGlobals: FGS, memsTables: AS, exports: ES, inits: INIS, start: S)
-          => TS ~> IS ~> FGS ~> AS ~> ES ~> INIS ~> S
+    rule <k> #module(... id: OID, types: TS, funcs: FS, tables: TABS, mems: MS, globals: GS, elem: EL, data: DAT, start: S,  importDefns: IS, exports: ES)
+          => TS ~> IS ~> FS ~> GS ~> MS ~> TABS ~> ES ~> EL ~> DAT ~> S
          ...
          </k>
          <curModIdx> _ => NEXT </curModIdx>


### PR DESCRIPTION
In preparation for the extraction of identifiers and removing #ContextLookup for definitions of tables, functions, globals, and memories.

Comes after #345.

This makes the module sorting part of the `text2abstract` transformation. This is both in line with how the official specification is written and will make extracting the correct identifiers cleaner and faster.