### PR TITLE
Standardize Makefile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
     stage('Build and Test') {
       when { changeRequest() }
       stages {
-        stage('Build') { steps { sh 'make build -j4' } }
+        stage('Build') { steps { sh 'make build -j4 RELEASE=true' } }
         stage('Test') {
           options { timeout(time: 25, unit: 'MINUTES') }
           parallel {

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,10 @@ $(K_JAR):
 # Building Definition
 # -------------------
 
+KOMPILE_OPTS         :=
+LLVM_KOMPILE_OPTS    :=
+HASKELL_KOMPILE_OPTS :=
+
 SOURCE_FILES       := data         \
                       kwasm-lemmas \
                       numeric      \
@@ -68,19 +72,13 @@ ALL_SOURCE_FILES   := $(patsubst %, %.k, $(SOURCE_FILES) $(EXTRA_SOURCE_FILES))
 defn:  defn-haskell defn-llvm
 build: build-llvm build-haskell
 
-KOMPILE_OPTS :=
-
 ifneq (,$(RELEASE))
     KOMPILE_OPTS += -O2
 endif
 
-LLVM_KOMPILE_OPTS :=
-
 ifeq (,$(RELEASE))
     LLVM_KOMPILE_OPTS += -g
 endif
-
-HASKELL_KOMPILE_OPTS :=
 
 KOMPILE_LLVM := kompile --debug --backend llvm            \
                 $(KOMPILE_OPTS)                           \
@@ -144,8 +142,7 @@ TEST_CONCRETE_BACKEND := llvm
 TEST_SYMBOLIC_BACKEND := haskell
 
 KPROVE_MODULE := KWASM-LEMMAS
-
-KPROVE_OPTS ?=
+KPROVE_OPTS   :=
 
 tests/proofs/functions-spec.k.prove: KPROVE_MODULE = FUNCTIONS-LEMMAS
 tests/proofs/wrc20-spec.k.prove:     KPROVE_MODULE = WRC20-LEMMAS

--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,12 @@ clean:
 # Build Dependencies (K Submodule)
 # --------------------------------
 
-deps: $(K_SUBMODULE)/make.timestamp $(TANGLER)
+K_JAR := $(K_SUBMODULE)/k-distribution/target/release/k/lib/java/kernel-1.0-SNAPSHOT.jar
 
-$(K_SUBMODULE)/make.timestamp:
+deps: $(K_JAR) $(TANGLER)
+
+$(K_JAR):
 	cd $(K_SUBMODULE) && mvn package -DskipTests -Dproject.build.type=$(K_BUILD_TYPE)
-	touch $(K_SUBMODULE)/make.timestamp
 
 # Building Definition
 # -------------------

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DEFN_DIR  := $(BUILD_DIR)/defn
 
 K_SUBMODULE := $(DEPS_DIR)/k
 ifneq (,$(wildcard deps/k/k-distribution/target/release/k/bin/*))
-  K_RELEASE ?= $(K_SUBMODULE)/k-distribution/target/release/k
+  K_RELEASE ?= $(abspath $(K_SUBMODULE)/k-distribution/target/release/k)
 else
   K_RELEASE ?= $(dir $(shell which kompile))..
 endif

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ SOURCE_FILES       := data         \
                       wasm-text    \
                       wrc20
 EXTRA_SOURCE_FILES :=
-ALL_FILES          := $(patsubst %, %.k, $(SOURCE_FILES) $(EXTRA_SOURCE_FILES))
+ALL_SOURCE_FILES   := $(patsubst %, %.k, $(SOURCE_FILES) $(EXTRA_SOURCE_FILES))
 
 defn:  defn-haskell defn-llvm
 build: build-llvm build-haskell
@@ -93,7 +93,7 @@ KOMPILE_HASKELL := kompile --debug --backend haskell \
 ### LLVM
 
 llvm_dir           := $(DEFN_DIR)/llvm
-llvm_files         := $(patsubst %, $(llvm_dir)/%, $(ALL_FILES))
+llvm_files         := $(patsubst %, $(llvm_dir)/%, $(ALL_SOURCE_FILES))
 llvm_main_module   := WASM-TEST
 llvm_syntax_module := $(llvm_main_module)-SYNTAX
 llvm_main_file     := test
@@ -115,7 +115,7 @@ $(llvm_kompiled): $(llvm_files)
 ### Haskell
 
 haskell_dir           := $(DEFN_DIR)/haskell
-haskell_files         := $(patsubst %, $(haskell_dir)/%, $(ALL_FILES))
+haskell_files         := $(patsubst %, $(haskell_dir)/%, $(ALL_SOURCE_FILES))
 haskell_main_module   := WASM-TEST
 haskell_syntax_module := $(haskell_main_module)-SYNTAX
 haskell_main_file     := test

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,6 @@ all: build
 
 clean:
 	rm -rf $(BUILD_DIR)
-	git submodule update --init --recursive
 
 # Build Dependencies (K Submodule)
 # --------------------------------
@@ -45,12 +44,8 @@ clean:
 deps: $(K_SUBMODULE)/make.timestamp $(TANGLER)
 
 $(K_SUBMODULE)/make.timestamp:
-	git submodule update --init --recursive
 	cd $(K_SUBMODULE) && mvn package -DskipTests -Dproject.build.type=$(K_BUILD_TYPE)
 	touch $(K_SUBMODULE)/make.timestamp
-
-$(TANGLER):
-	git submodule update --init -- $(PANDOC_TANGLE_SUBMODULE)
 
 # Building Definition
 # -------------------
@@ -119,10 +114,6 @@ KPROVE_OPTIONS ?=
 
 tests/proofs/functions-spec.k.prove: KPROVE_MODULE = FUNCTIONS-LEMMAS
 tests/proofs/wrc20-spec.k.prove:     KPROVE_MODULE = WRC20-LEMMAS
-
-tests/%/make.timestamp:
-	git submodule update --init -- tests/$*
-	touch $@
 
 test: test-execution test-prove
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,11 @@ K_BIN := $(K_RELEASE)/bin
 K_LIB := $(K_RELEASE)/lib
 export K_RELEASE
 
-K_BUILD_TYPE := Debug
+ifneq ($(RELEASE),)
+    K_BUILD_TYPE := Release
+else
+    K_BUILD_TYPE := Debug
+endif
 
 PATH := $(K_BIN):$(PATH)
 export PATH
@@ -81,7 +85,13 @@ $(haskell_dir)/%.k: %.md $(TANGLER)
 
 # Build definitions
 
-KOMPILE_OPTIONS    :=
+KOMPILE_OPTIONS :=
+
+ifneq $(,$(RELEASE))
+    KOMPILE_OPTIONS += -O3
+else
+    KOMPILE_OPTIONS += -ccopt -g
+endif
 
 build: build-llvm build-haskell
 build-llvm:    $(llvm_kompiled)

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ build: build-llvm build-haskell
 KOMPILE_OPTS :=
 
 ifneq (,$(RELEASE))
-    KOMPILE_OPTS += -O3
+    KOMPILE_OPTS += -O2
 endif
 
 LLVM_KOMPILE_OPTS :=

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ haskell_files         := $(patsubst %, $(haskell_dir)/%, $(ALL_FILES))
 haskell_main_module   := WASM-TEST
 haskell_syntax_module := $(haskell_main_module)-SYNTAX
 haskell_main_file     := test
-haskell_kompiled      := $(haskell_dir)/$(haskell_main_file)-kompiled/interpreter
+haskell_kompiled      := $(haskell_dir)/$(haskell_main_file)-kompiled/definition.kore
 
 defn-haskell:  $(haskell_defn)
 build-haskell: $(haskell_kompiled)


### PR DESCRIPTION
In refactoring the KEVM and KMichelson makefiles, I came up with several improvements over the original structure.

This implements those improvements on this Makefile as well.

-   Per-build `*_main_file`, `*_main_module`, and `*_syntax_module`
-   Separate `LLVM_KOMPILE_OPTS` and `HASKELL_KOMPILE_OPTS`
-   Using `RELEASE` to control both `K_BUILD_TYPE` and optimization level when kompiling.
-   Remove use of `git submodule update --init --recursive` from Makefile (makes it easier to experiment with custom submodules without having to commit them.