### PR TITLE
Remove empty statements rule

### DIFF
--- a/test.md
+++ b/test.md
@@ -26,8 +26,8 @@ Here we extend the sort `Stmt` by adding a new subsort called `Auxil`.
 This subsort contains Auxiliary functions that only used in our KWASM semantics but not in the official specification including assertions, initializing a global variable and the invocation of a function by exported name.
 
 ```k
-    syntax Stmt ::= Auxil
- // ---------------------
+    syntax Instr ::= Auxil
+ // ----------------------
 ```
 
 We also add `token` as a value in order to implement some test assertions.

--- a/wasm.md
+++ b/wasm.md
@@ -155,9 +155,8 @@ The sorts `EmptyStmt` and `EmptyStmts` are administrative so that the empty list
     syntax Defns  ::= EmptyStmts
     syntax Stmts  ::= Instrs | Defns
  // --------------------------------
-    rule          <k> .Stmts                => .       ... </k>
-    rule          <k> (S:Stmt .Stmts):KItem => S       ... </k>
-    rule [step] : <k> (S:Stmt SS)           => S ~> SS ... </k> requires SS =/=K .Stmts
+    rule          <k> .Stmts      => .       ... </k>
+    rule [step] : <k> (S:Stmt SS) => S ~> SS ... </k>
 ```
 
 ### Traps

--- a/wasm.md
+++ b/wasm.md
@@ -155,8 +155,9 @@ The sorts `EmptyStmt` and `EmptyStmts` are administrative so that the empty list
     syntax Defns  ::= EmptyStmts
     syntax Stmts  ::= Instrs | Defns
  // --------------------------------
-    rule          <k> .Stmts      => .       ... </k>
-    rule [step] : <k> (S:Stmt SS) => S ~> SS ... </k>
+    rule               <k> .Stmts              => .       ... </k>
+    rule [stepStmt]  : <k> (S:Stmt  SS)        => S ~> SS ... </k> requires notBool isInstr(S)
+    rule [stepInstr] : <k> (I:Instr IS:Instrs) => I ~> IS ... </k>
 ```
 
 ### Traps

--- a/wasm.md
+++ b/wasm.md
@@ -156,8 +156,9 @@ The sorts `EmptyStmt` and `EmptyStmts` are administrative so that the empty list
     syntax Stmts  ::= Instrs | Defns
  // --------------------------------
     rule               <k> .Stmts              => .       ... </k>
-    rule [stepStmt]  : <k> (S:Stmt  SS)        => S ~> SS ... </k> requires notBool isInstr(S)
+    rule [stepStmt]  : <k> (S:Stmt  SS)        => S ~> SS ... </k> requires notBool (isInstr(S) orBool isDefn(S))
     rule [stepInstr] : <k> (I:Instr IS:Instrs) => I ~> IS ... </k>
+    rule [stepDefn]  : <k> (D:Defn  DS:Defns)  => D ~> DS ... </k>
 ```
 
 ### Traps


### PR DESCRIPTION
This PR enables doing all rule-merges of length 10 on Polkadot without crashing.

I'm not sure I love the changes here, so maybe we need to discuss.