### PR TITLE
Remove contextlookup for functions

### DIFF
--- a/test.md
+++ b/test.md
@@ -85,9 +85,8 @@ We allow 2 kinds of actions:
     rule <k> invoke MODIDX:Int ENAME:WasmString => ( invoke FADDR ):Instr ... </k>
          <moduleInst>
            <modIdx> MODIDX </modIdx>
-           <exports> ... ENAME |-> TFIDX ... </exports>
-           <funcIds> IDS </funcIds>
-           <funcAddrs> ... #ContextLookup(IDS , TFIDX) |-> FADDR ... </funcAddrs>
+           <exports> ... ENAME |-> IDX ... </exports>
+           <funcAddrs> ... IDX |-> FADDR ... </funcAddrs>
            ...
          </moduleInst>
 
@@ -346,12 +345,11 @@ This simply checks that the given function exists in the `<funcs>` cell and has 
 ```k
     syntax Assertion ::= "#assertFunction" Index FuncType VecType WasmString
  // ------------------------------------------------------------------------
-    rule <k> #assertFunction TFIDX FTYPE LTYPE _ => . ... </k>
+    rule <k> #assertFunction IDX FTYPE LTYPE _ => . ... </k>
          <curModIdx> CUR </curModIdx>
          <moduleInst>
            <modIdx> CUR </modIdx>
-           <funcIds> IDS </funcIds>
-           <funcAddrs> ... #ContextLookup(IDS , TFIDX) |-> FADDR ... </funcAddrs>
+           <funcAddrs> ... IDX |-> FADDR ... </funcAddrs>
            ...
          </moduleInst>
          <funcs>

--- a/tests/proofs/wrc20-spec.k
+++ b/tests/proofs/wrc20-spec.k
@@ -22,7 +22,6 @@ module WRC20-SPEC
           <memAddrs> 0 |-> MEMADDR </memAddrs>
           <types> TYPES => ?_ </types>
           <nextTypeIdx> NEXTTYPEIDX => NEXTTYPEIDX +Int 1 </nextTypeIdx>
-          <funcIds> _ => ?_ </funcIds>
           <funcAddrs> _ => ?_ </funcAddrs>
           <nextFuncIdx> NEXTFUNCIDX => NEXTFUNCIDX +Int 1 </nextFuncIdx>
           ...

--- a/tests/simple/functions_call.wast
+++ b/tests/simple/functions_call.wast
@@ -26,7 +26,7 @@
     (return)
 )
 
-#assertFunction $add [ i32 i32 ] -> [ i32 ] [ ] "function string-named add"
+#assertFunction 1 [ i32 i32 ] -> [ i32 ] [ ] "function string-named add"
 #assertNextTypeIdx 1
 
 ;; Remove return statement
@@ -46,7 +46,7 @@
 (i32.const 0)
 (call_indirect (type $a-cool-type))
 #assertTopStack < i32 > 15 "call function 0 no return"
-#assertFunction $0 [ i32 i32 ] -> [ i32 ] [ ] "call function 0 exists no return"
+#assertFunction 2 [ i32 i32 ] -> [ i32 ] [ ] "call function 0 exists no return"
 #assertNextTypeIdx 1
 
 ;; More complicated function with locals
@@ -61,7 +61,7 @@
 ( export "export-1" (func $1) )
 
 (assert_return (invoke "export-1" (i64.const 100) (i64.const 43) (i64.const 22)) (i64.const -121))
-#assertFunction $1 [ i64 i64 i64 ] -> [ i64 ] [ i64 ] "call function 1 exists"
+#assertFunction 3 [ i64 i64 i64 ] -> [ i64 ] [ i64 ] "call function 1 exists"
 #assertType 1 [ i64 i64 i64 ] -> [ i64 ]
 #assertNextTypeIdx 2
 
@@ -79,7 +79,7 @@
    )
 )
 (assert_return (invoke "out-of-order-type-declaration") (i32.const 7))
-#assertFunction $2 [ i32 i64 i64 ] -> [ i32 ] [ i32 ] "out of order type declarations"
+#assertFunction 0 [ i32 i64 i64 ] -> [ i32 ] [ i32 ] "out of order type declarations"
 #assertNextTypeIdx 2
 
 ;; Function with empty declarations of types
@@ -102,16 +102,18 @@
 )
 
 (assert_return (invoke "cool") (i64.const 10))
-#assertFunction $1 [ i64 i64 ] -> [ i64 ] [ ] "empty type declarations"
+#assertFunction 1 [ i64 i64 ] -> [ i64 ] [ ] "empty type declarations"
 #assertNextTypeIdx 2
 
 ;; Function with just a name
 
-(func $3)
-(export "return-null" (func $3) )
+(module
+  (func $3)
+  (export "return-null" (func $3) )
+)
 (assert_return (invoke "return-null"))
 
-#assertFunction $3 [ ] -> [ ] [ ] "no domain/range or locals"
+#assertFunction 0 [ ] -> [ ] [ ] "no domain/range or locals"
 
 (module
     (func $add (export "add")
@@ -153,9 +155,10 @@
 (assert_return (invoke "sub" (i32.const 12) (i32.const 5)) (i32.const 7))
 (assert_return (invoke "xor" (i32.const 3) (i32.const 5)) (i32.const 6))
 
-#assertFunction $add [ i32 i32 ] -> [ i32 ] [ ] "add function typed correctly"
-#assertFunction $mul [ i32 i32 ] -> [ i32 ] [ ] "mul function typed correctly"
-#assertFunction $xor [ i32 i32 ] -> [ i32 ] [ ] "xor function typed correctly"
+#assertFunction 0 [ i32 i32 ] -> [ i32 ] [ ] "add function typed correctly"
+#assertFunction 1 [ i32 i32 ] -> [ i32 ] [ ] "sub function typed correctly"
+#assertFunction 2 [ i32 i32 ] -> [ i32 ] [ ] "mul function typed correctly"
+#assertFunction 3 [ i32 i32 ] -> [ i32 ] [ ] "xor function typed correctly"
 #assertNextTypeIdx 1
 
 (module
@@ -193,8 +196,8 @@
 )
 
 (assert_return (invoke "nested-method-call") (i32.const 14247936))
-#assertFunction $f2 [ i32 i32 i32 ] -> [ i32 ] [ i32 i32 ] "outer calling method"
-#assertFunction $f1 [ i32 i32 ] -> [ i32 ] [ i32 ] "inner calling method"
+#assertFunction 0 [ i32 i32 ] -> [ i32 ] [ i32 ] "inner calling method"
+#assertFunction 1 [ i32 i32 i32 ] -> [ i32 ] [ i32 i32 ] "outer calling method"
 
 (module
     (func $func (param i32 i32) (result i32) (local.get 0))
@@ -219,7 +222,7 @@
 (assert_return (invoke "cool-align-1" (i32.const 7) (i64.const 8) (i64.const 3)) (i32.const 7))
 (assert_return (invoke "cool-align-2" (i32.const 1) (i64.const 5) (i64.const 7)) (i32.const 1))
 
-#assertFunction $2 [ i32 i64 i64 ] -> [ i32 ] [ i32 ] "out of order type declarations"
+#assertFunction 0 [ i32 i64 i64 ] -> [ i32 ] [ i32 ] "out of order type declarations"
 
 (module
   (func (export "foo") (result i32)

--- a/tests/simple/functions_call.wast
+++ b/tests/simple/functions_call.wast
@@ -66,24 +66,26 @@
 #assertNextTypeIdx 2
 
 ;; Function with complicated declaration of types
-
-(func $2 result i32 param i32 i64 param i64 local i32
-    (local.get 0)
-    (return)
+(module
+  (func $2 result i32 param i32 i64 param i64 local i32
+      (local.get 0)
+      (return)
+  )
+  (func (export "out-of-order-type-declaration") (result i32)
+    (i32.const 7)
+    (i64.const 8)
+    (i64.const 5)
+    (call $2)
+   )
 )
-
-(i32.const 7)
-(i64.const 8)
-(i64.const 5)
-(call $2)
-#assertTopStack < i32 > 7 "out of order type declaration"
+(assert_return (invoke "out-of-order-type-declaration") (i32.const 7))
 #assertFunction $2 [ i32 i64 i64 ] -> [ i32 ] [ i32 ] "out of order type declarations"
-#assertNextTypeIdx 3
+#assertNextTypeIdx 2
 
 ;; Function with empty declarations of types
 
 (module
-  (func $1 param i64 i64 result result i64 param local
+  (func $0 param i64 i64 result result i64 param local
       (local.get 0)
       (return)
   )
@@ -178,15 +180,19 @@
         (i32.mul)
         (return)
     )
+
+    (func (export "nested-method-call") (result i32)
+        (i32.const 3)
+        (i32.const 5)
+        (call $f1)
+        (i32.const 5)
+        (i32.const 8)
+        (call $f2)
+    )
+
 )
 
-(i32.const 3)
-(i32.const 5)
-(call $f1)
-(i32.const 5)
-(i32.const 8)
-(call $f2)
-#assertTopStack < i32 > 14247936 "nested method call"
+(assert_return (invoke "nested-method-call") (i32.const 14247936))
 #assertFunction $f2 [ i32 i32 i32 ] -> [ i32 ] [ i32 i32 ] "outer calling method"
 #assertFunction $f1 [ i32 i32 ] -> [ i32 ] [ i32 ] "inner calling method"
 

--- a/tests/simple/functions_call.wast
+++ b/tests/simple/functions_call.wast
@@ -41,7 +41,7 @@
 (i32.const 8)
 
 (table 1 funcref)
-(elem (i32.const 0) $0)
+(elem 0 (i32.const 0) 2)
 
 (i32.const 0)
 (call_indirect (type $a-cool-type))

--- a/tests/simple/functions_call.wast
+++ b/tests/simple/functions_call.wast
@@ -11,7 +11,7 @@
     (i32.add)
     (return)
 )
-(export "000" (func $0))
+(export "000" (func 0))
 
 #assertNextTypeIdx 1
 (assert_return (invoke "000" (i32.const 7) (i32.const 8)) (i32.const 15))
@@ -58,7 +58,7 @@
     (return)
 )
 
-( export "export-1" (func $1) )
+( export "export-1" (func 3) )
 
 (assert_return (invoke "export-1" (i64.const 100) (i64.const 43) (i64.const 22)) (i64.const -121))
 #assertFunction 3 [ i64 i64 i64 ] -> [ i64 ] [ i64 ] "call function 1 exists"

--- a/tests/simple/identifiers.wast
+++ b/tests/simple/identifiers.wast
@@ -9,7 +9,7 @@
     (return)
 )
 
-#assertFunction $oeauth [ i32 i32 ] -> [ i32 ] [ ] "simple function name"
+#assertFunction 0 [ i32 i32 ] -> [ i32 ] [ ] "simple function name"
 
 (func $023eno!thu324
     (param i32 i32)
@@ -20,7 +20,7 @@
     (return)
 )
 
-#assertFunction $023eno!thu324 [ i32 i32 ] -> [ i32 ] [ ] "identifier function name 1"
+#assertFunction 1 [ i32 i32 ] -> [ i32 ] [ ] "identifier function name 1"
 
 (func $02$3e%no!t&hu324
     (param i32 i32)
@@ -31,7 +31,7 @@
     (return)
 )
 
-#assertFunction $02$3e%no!t&hu324 [ i32 i32 ] -> [ i32 ] [ ] "identifier function name 2"
+#assertFunction 2 [ i32 i32 ] -> [ i32 ] [ ] "identifier function name 2"
 
 (func $02$3e%no!t&hu3'24*32++2ao-eunth
     (param i32 i32)
@@ -42,7 +42,7 @@
     (return)
 )
 
-#assertFunction $02$3e%no!t&hu3'24*32++2ao-eunth [ i32 i32 ] -> [ i32 ] [ ] "identifier function name 3"
+#assertFunction 3 [ i32 i32 ] -> [ i32 ] [ ] "identifier function name 3"
 
 (func $02$3e%no!t&hu3'24*32++2ao-eu//n<t>h?
     (param i32 i32)
@@ -53,7 +53,7 @@
     (return)
 )
 
-#assertFunction $02$3e%no!t&hu3'24*32++2ao-eu//n<t>h? [ i32 i32 ] -> [ i32 ] [ ] "identifier function name 3"
+#assertFunction 4 [ i32 i32 ] -> [ i32 ] [ ] "identifier function name 3"
 
 (func $aenuth_ae`st|23~423
     (param i32 i32)
@@ -64,7 +64,7 @@
     (return)
 )
 
-#assertFunction $aenuth_ae`st|23~423 [ i32 i32 ] -> [ i32 ] [ ] "identifier function name 3"
+#assertFunction 5 [ i32 i32 ] -> [ i32 ] [ ] "identifier function name 3"
 
 (func $bioi::..@@?^
     (param i32 i32)
@@ -75,6 +75,6 @@
     (return)
 )
 
-#assertFunction $bioi::..@@?^ [ i32 i32 ] -> [ i32 ] [ ] "identifier function name 3"
+#assertFunction 6 [ i32 i32 ] -> [ i32 ] [ ] "identifier function name 3"
 
 #clearConfig

--- a/tests/simple/start.wast
+++ b/tests/simple/start.wast
@@ -1,18 +1,20 @@
-(memory 1)
-(func $inc
-  (i32.store8
-    (i32.const 0)
-    (i32.add
-      (i32.load8_u (i32.const 0))
-      (i32.const 1)))
+(module
+  (memory 1)
+  (func $inc
+    (i32.store8
+      (i32.const 0)
+      (i32.add
+        (i32.load8_u (i32.const 0))
+        (i32.const 1)))
+  )
+  (func $main
+    (i32.store (i32.const 0) (i32.const 65))
+    (call $inc)
+    (call $inc)
+    (call $inc)
+  )
+  (start $main)
 )
-(func $main
-  (i32.store (i32.const 0) (i32.const 65))
-  (call $inc)
-  (call $inc)
-  (call $inc)
-)
-(start $main)
 
 #assertMemoryData (0, 68) "start inc"
 #assertFunction $inc  [ ] -> [ ] [ ] ""
@@ -21,8 +23,10 @@
 
 #clearConfig
 
-(func $foo (unreachable))
-(start $foo)
+(module
+  (func $foo (unreachable))
+  (start $foo)
+)
 #assertTrap "Trap propagates through start invocation"
 #assertFunction $foo  [ ] -> [ ] [ ] ""
 

--- a/tests/simple/start.wast
+++ b/tests/simple/start.wast
@@ -17,8 +17,8 @@
 )
 
 #assertMemoryData (0, 68) "start inc"
-#assertFunction $inc  [ ] -> [ ] [ ] ""
-#assertFunction $main [ ] -> [ ] [ ] ""
+#assertFunction 0  [ ] -> [ ] [ ] "$inc"
+#assertFunction 1 [ ] -> [ ] [ ] "$main"
 #assertMemory 0 1 .Int ""
 
 #clearConfig
@@ -28,7 +28,7 @@
   (start $foo)
 )
 #assertTrap "Trap propagates through start invocation"
-#assertFunction $foo  [ ] -> [ ] [ ] ""
+#assertFunction 0  [ ] -> [ ] [ ] ""
 
 (assert_trap
   (module (func $main (unreachable)) (start $main))

--- a/tests/simple/table.wast
+++ b/tests/simple/table.wast
@@ -52,8 +52,8 @@
 
 #assertTopStack < i32> 66 "call_indirect_result2"
 
-#assertFunction $const-i32-a [ ] -> [ i32 ] [ ] "call function 1 exists"
-#assertFunction $const-i32-b [ ] -> [ i32 ] [ ] "call function 2 exists"
+#assertFunction 0 [ ] -> [ i32 ] [ ] "call function 1 exists"
+#assertFunction 1 [ ] -> [ i32 ] [ ] "call function 2 exists"
 #assertFunction 2 [ ] -> [ i32 ] [ ] "call function 3 exists"
 #assertFunction 3 [ ] -> [ i32 ] [ ] "call function 4 exists"
 #assertFunction 4 [ ] -> [ i32 ] [ ] "call function 5 exists"

--- a/tests/simple/text2abstract.wast
+++ b/tests/simple/text2abstract.wast
@@ -95,21 +95,21 @@
 (func $foo (param $a i32) (result i32)
   local.get $a
 )
-(export "foo" (func $foo))
+(export "foo" (func 0))
 
 (func $bar (param $a i32) (result i32)
   block (result i32)
     local.get $a
   end
 )
- (export "bar" (func $bar))
+ (export "bar" (func 1))
 
 (func $baz (param $a i32) (result i32)
   loop (result i32)
     local.get $a
   end
 )
-(export "baz" (func $baz))
+(export "baz" (func 2))
 
 (func $baf (param $a i32) (result i32)
   i32.const 1
@@ -119,7 +119,7 @@
     local.get $a
   end
 )
-(export "baf" (func $baf))
+(export "baf" (func 3))
 
 (func $bag (param $a i32) (result i32)
   i32.const 0
@@ -129,7 +129,7 @@
     local.get $a
   end
 )
-(export "bag" (func $bag))
+(export "bag" (func 4))
 
 (func $far (param $a i32) (result i32) (local $b i64)
   local.get $a

--- a/tests/simple/text2abstract.wast
+++ b/tests/simple/text2abstract.wast
@@ -46,7 +46,7 @@
 (assert_return (invoke "baf" (i32.const 7)) (i32.const 7))
 (assert_return (invoke "bag" (i32.const 7)) (i32.const 7))
 
-#assertFunction $far [ i32 ] -> [ i32 ] [ i64 ] "identifiers are erased inside module"
+#assertFunction 5 [ i32 ] -> [ i32 ] [ i64 ] "identifiers are erased inside module"
 
 #clearConfig
 
@@ -141,10 +141,10 @@
 (assert_return (invoke "baf" (i32.const 7)) (i32.const 7))
 (assert_return (invoke "bag" (i32.const 7)) (i32.const 7))
 
-#assertFunction $far [ i32 ] -> [ i32 ] [ i64 ] "identifiers are erased outside module"
+#assertFunction 5 [ i32 ] -> [ i32 ] [ i64 ] "identifiers are erased outside module"
 
 (func $fir (local i64) (local $a i32))
 
-#assertFunction $fir [ ] -> [ ] [ i64 i32 ] "identifiers are erased inside module"
+#assertFunction 6 [ ] -> [ ] [ i64 i32 ] "identifiers are erased inside module"
 
 #clearConfig

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -380,6 +380,15 @@ Other desugarings are either left for runtime or expressed as macros (for now).
       => ( export ENAME ( global ID ) ) #unfoldDefns(( global ID SPEC ) DS, I)
 ```
 
+#### Element Segments
+
+```k
+    syntax ElemDefn ::= "(" "elem" Offset ElemSegment ")"
+ // -----------------------------------------------------
+    rule #unfoldDefns(( elem OFFSET:Offset ES ) DS, I)
+      => ( elem 0 OFFSET ES ) #unfoldDefns(DS, I)
+```
+
 ### Structuring Modules
 
 The text format allows definitions to appear in any order in a module.
@@ -487,7 +496,7 @@ Since we do not have polymorphic functions available, we define one function per
                     , tables: TABS
                     , mems: MS
                     , globals: GS
-                    , elem: EL
+                    , elem: #t2aDefns<C>(EL)
                     , data: DAT
                     , start: #t2aDefns<C>(S)
                     , importDefns: IS
@@ -522,6 +531,19 @@ Since we do not have polymorphic functions available, we define one function per
 ```k
     rule #t2aDefn<ctx(... funcIds: FIDS)>(( start ID:Identifier )) => ( start {FIDS[ID]}:>Int )
       requires ID in_keys(FIDS)
+```
+
+#### Element Segments
+
+```k
+    rule #t2aDefn<C>(( elem IDX:Index OFFSET ES )) => ( elem IDX OFFSET #t2aElemSegment<C>(ES) )
+
+    syntax ElemSegment ::= "#t2aElemSegment" "<" Context ">" "(" ElemSegment ")" [function]
+ // ---------------------------------------------------------------------------------------
+    rule #t2aElemSegment<ctx(... funcIds: FIDS) #as C>(ID:Identifier ES) => {FIDS[ID]}:>Int #t2aElemSegment<C>(ES)
+      requires ID in_keys(FIDS)
+    rule #t2aElemSegment<C>(I:Int ES) => I #t2aElemSegment<C>(ES)
+    rule #t2aElemSegment<C>(.ElemSegment) => .ElemSegment
 ```
 
 #### Other Definitions

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -500,7 +500,7 @@ Since we do not have polymorphic functions available, we define one function per
                     , data: DAT
                     , start: #t2aDefns<C>(S)
                     , importDefns: IS
-                    , exports: ES
+                    , exports: #t2aDefns<C>(ES)
                 )
 ```
 
@@ -544,6 +544,13 @@ Since we do not have polymorphic functions available, we define one function per
       requires ID in_keys(FIDS)
     rule #t2aElemSegment<C>(I:Int ES) => I #t2aElemSegment<C>(ES)
     rule #t2aElemSegment<C>(.ElemSegment) => .ElemSegment
+```
+
+#### Exports
+
+```k
+    rule #t2aDefn<ctx(... funcIds: FIDS)>(( export ENAME ( func ID:Identifier ) )) => ( export ENAME (func {FIDS[ID]}:>Int) )
+      requires ID in_keys(FIDS)
 ```
 
 #### Other Definitions

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -489,7 +489,7 @@ Since we do not have polymorphic functions available, we define one function per
                     , globals: GS
                     , elem: EL
                     , data: DAT
-                    , start: S
+                    , start: #t2aDefns<C>(S)
                     , importDefns: IS
                     , exports: ES
                 )
@@ -515,6 +515,13 @@ Since we do not have polymorphic functions available, we define one function per
 
     rule #t2aLocalDecl<C>(local ID:Identifier AVT:AValType) => local AVT .ValTypes
     rule #t2aLocalDecl<C>(LD) => LD [owise]
+```
+
+#### Start Function
+
+```k
+    rule #t2aDefn<ctx(... funcIds: FIDS)>(( start ID:Identifier )) => ( start {FIDS[ID]}:>Int )
+      requires ID in_keys(FIDS)
 ```
 
 #### Other Definitions

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -531,6 +531,7 @@ Since we do not have polymorphic functions available, we define one function per
 ```k
     rule #t2aDefn<ctx(... funcIds: FIDS)>(( start ID:Identifier )) => ( start {FIDS[ID]}:>Int )
       requires ID in_keys(FIDS)
+    rule #t2aDefn<_>(( start I:Int )) => ( start I )
 ```
 
 #### Element Segments
@@ -551,6 +552,7 @@ Since we do not have polymorphic functions available, we define one function per
 ```k
     rule #t2aDefn<ctx(... funcIds: FIDS)>(( export ENAME ( func ID:Identifier ) )) => ( export ENAME (func {FIDS[ID]}:>Int) )
       requires ID in_keys(FIDS)
+    rule #t2aDefn<_>(( export ENAME ( func I:Int ) )) => ( export ENAME (func I) )
 ```
 
 #### Other Definitions

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -446,12 +446,18 @@ Record updates can currently not be done in a function rule which also does othe
                      | #freshCtx ( )                               [function, functional]
                      | #updateLocalIds    ( Context , Map )        [function, functional]
                      | #updateLocalIdsAux ( Context , Map , Bool ) [function, functional]
+                     | #updateFuncIds     ( Context , Map )        [function, functional]
+                     | #updateFuncIdsAux  ( Context , Map , Bool ) [function, functional]
  // -------------------------------------------------------------------------------------
     rule #freshCtx ( ) => ctx(... localIds: .Map, funcIds: .Map)
 
     rule #updateLocalIds(C, M) => #updateLocalIdsAux(C, M, false)
     rule #updateLocalIdsAux(ctx(... localIds: (_ => M)), M, false => true)
     rule #updateLocalIdsAux(C, _, true) => C
+
+    rule #updateFuncIds(C, M) => #updateFuncIdsAux(C, M, false)
+    rule #updateFuncIdsAux(ctx(... funcIds: (_ => M)), M, false => true)
+    rule #updateFuncIdsAux(C, _, true) => C
 ```
 
 ### Traversing the Full Program
@@ -462,6 +468,7 @@ Since we do not have polymorphic functions available, we define one function per
 ```k
     syntax Stmt       ::= "#t2aStmt"       "<" Context ">" "(" Stmt       ")" [function]
     syntax ModuleDecl ::= "#t2aModuleDecl" "<" Context ">" "(" ModuleDecl ")" [function]
+    syntax ModuleDecl ::= "#t2aModule"     "<" Context ">" "(" ModuleDecl ")" [function]
     syntax Defn       ::= "#t2aDefn"       "<" Context ">" "(" Defn       ")" [function]
     syntax FuncSpec   ::= "#t2aFuncSpec"   "<" Context ">" "(" FuncSpec   ")" [function]
     syntax TypeUse    ::= "#t2aTypeUse"    "<" Context ">" "(" TypeUse    ")" [function]
@@ -475,7 +482,8 @@ Since we do not have polymorphic functions available, we define one function per
     rule #t2aStmt<C>(I:Instr) => #t2aInstr<C>(I)
     rule #t2aStmt<_>(S) => S [owise]
 
-    rule #t2aModuleDecl<C>(#module(... id: OID, types: TS, funcs: FS, tables: TABS, mems: MS, globals: GS, elem: EL, data: DAT, start: S,  importDefns: IS, exports: ES))
+    rule #t2aModuleDecl<_>(#module(... funcs: FS, importDefns: IS) #as M) => #t2aModule<ctx(... localIds: .Map, funcIds: #idcFuncs(IS, FS))>(M)
+    rule #t2aModule<C>(#module(... id: OID, types: TS, funcs: FS, tables: TABS, mems: MS, globals: GS, elem: EL, data: DAT, start: S,  importDefns: IS, exports: ES))
       => #module( ... id: OID
                     , types: TS
                     , funcs: #t2aDefns<C>(FS)
@@ -519,13 +527,16 @@ Since we do not have polymorphic functions available, we define one function per
 #### Basic Instructions
 
 ```k
-    rule #t2aInstr<_>(unreachable)      => unreachable
-    rule #t2aInstr<_>(nop)              => nop
-    rule #t2aInstr<_>(br L)             => br L
-    rule #t2aInstr<_>(br_if L)          => br_if L
-    rule #t2aInstr<_>(br_table ES)      => br_table ES
-    rule #t2aInstr<_>(return)           => return
-    rule #t2aInstr<_>(call F)           => call F
+    rule #t2aInstr<_>(unreachable) => unreachable
+    rule #t2aInstr<_>(nop)         => nop
+    rule #t2aInstr<_>(br L)        => br L
+    rule #t2aInstr<_>(br_if L)     => br_if L
+    rule #t2aInstr<_>(br_table ES) => br_table ES
+    rule #t2aInstr<_>(return)      => return
+
+    rule #t2aInstr<ctx(... funcIds: FIDS)>(call ID:Identifier) => call {FIDS[ID]}:>Int
+    rule #t2aInstr<_>                     (call I:Int)         => call I
+
     rule #t2aInstr<_>(call_indirect TU) => call_indirect TU
 ```
 

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -470,9 +470,6 @@ Since we do not have polymorphic functions available, we define one function per
     syntax ModuleDecl ::= "#t2aModuleDecl" "<" Context ">" "(" ModuleDecl ")" [function]
     syntax ModuleDecl ::= "#t2aModule"     "<" Context ">" "(" ModuleDecl ")" [function]
     syntax Defn       ::= "#t2aDefn"       "<" Context ">" "(" Defn       ")" [function]
-    syntax FuncSpec   ::= "#t2aFuncSpec"   "<" Context ">" "(" FuncSpec   ")" [function]
-    syntax TypeUse    ::= "#t2aTypeUse"    "<" Context ">" "(" TypeUse    ")" [function]
-    syntax LocalDecl  ::= "#t2aLocalDecl"  "<" Context ">" "(" LocalDecl  ")" [function]
  // ------------------------------------------------------------------------------------
     rule text2abstract(DS:Defns) => text2abstract(( module DS ) .Stmts)
     rule text2abstract(SS)       => #t2aStmts<#freshCtx()>(structureModules(unfoldStmts(SS))) [owise]
@@ -496,10 +493,17 @@ Since we do not have polymorphic functions available, we define one function per
                     , importDefns: IS
                     , exports: ES
                 )
+```
 
+#### Functions
+
+```k
     rule #t2aDefn<C>(( func OID:OptionalId FS:FuncSpec )) => ( func OID #t2aFuncSpec<C>(FS))
-    rule #t2aDefn<C>(D:Defn) => D [owise]
 
+    syntax FuncSpec   ::= "#t2aFuncSpec"  "<" Context ">" "(" FuncSpec   ")" [function]
+    syntax TypeUse    ::= "#t2aTypeUse"   "<" Context ">" "(" TypeUse    ")" [function]
+    syntax LocalDecl  ::= "#t2aLocalDecl" "<" Context ">" "(" LocalDecl  ")" [function]
+ // -----------------------------------------------------------------------------------
     rule #t2aFuncSpec<C>(T:TypeUse LS:LocalDecls IS:Instrs)
       => #t2aTypeUse   <#updateLocalIds(C, #ids2Idxs(T, LS))>(T)
          #t2aLocalDecls<#updateLocalIds(C, #ids2Idxs(T, LS))>(LS)
@@ -511,6 +515,12 @@ Since we do not have polymorphic functions available, we define one function per
 
     rule #t2aLocalDecl<C>(local ID:Identifier AVT:AValType) => local AVT .ValTypes
     rule #t2aLocalDecl<C>(LD) => LD [owise]
+```
+
+#### Other Definitions
+
+```k
+    rule #t2aDefn<C>(D:Defn) => D [owise]
 ```
 
 ### Instructions

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -535,6 +535,7 @@ Since we do not have polymorphic functions available, we define one function per
     rule #t2aInstr<_>(return)      => return
 
     rule #t2aInstr<ctx(... funcIds: FIDS)>(call ID:Identifier) => call {FIDS[ID]}:>Int
+      requires ID in_keys(FIDS)
     rule #t2aInstr<_>                     (call I:Int)         => call I
 
     rule #t2aInstr<_>(call_indirect TU) => call_indirect TU
@@ -551,8 +552,11 @@ Since we do not have polymorphic functions available, we define one function per
 
 ```k
     rule #t2aInstr<ctx(... localIds: LIDS)>(local.get ID:Identifier) => local.get {LIDS[ID]}:>Int
+      requires ID in_keys(LIDS)
     rule #t2aInstr<ctx(... localIds: LIDS)>(local.set ID:Identifier) => local.set {LIDS[ID]}:>Int
+      requires ID in_keys(LIDS)
     rule #t2aInstr<ctx(... localIds: LIDS)>(local.tee ID:Identifier) => local.tee {LIDS[ID]}:>Int
+      requires ID in_keys(LIDS)
 
     rule #t2aInstr<_>(local.get I:Int) => local.get I
     rule #t2aInstr<_>(local.set I:Int) => local.set I

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -641,6 +641,18 @@ They distribute the text-to-abstract functions above over lists.
 The following are helper functions for gathering and updating context.
 
 ```k
+    syntax Map ::= #idcFuncs    ( Defns, Defns      ) [function]
+                 | #idcFuncsAux ( Defns, Defns, Int ) [function]
+ // ------------------------------------------------------------
+    rule #idcFuncs(IMPORTS, DEFNS) => #idcFuncsAux(IMPORTS, DEFNS, 0)
+
+    rule #idcFuncsAux((import _ _ (func ID:Identifier _)) IS, FS, IDX) => (ID |-> IDX) #idcFuncsAux(IS, FS, IDX +Int 1)
+    rule #idcFuncsAux(I IS, FS, IDX) => #idcFuncsAux(IS, FS, IDX) [owise]
+
+    rule #idcFuncsAux(.Defns, (func ID:Identifier _) FS, IDX) => (ID |-> IDX) #idcFuncsAux(.Defns, FS, IDX +Int 1)
+    rule #idcFuncsAux(.Defns, (func      _:FuncSpec) FS, IDX) =>              #idcFuncsAux(.Defns, FS, IDX +Int 1)
+    rule #idcFuncsAux(.Defns, .Defns, _) => .Map
+
     syntax Map ::= #ids2Idxs(TypeUse, LocalDecls)      [function, functional]
                  | #ids2Idxs(Int, TypeUse, LocalDecls) [function, functional]
  // -------------------------------------------------------------------------

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -713,7 +713,8 @@ The following are helper functions for gathering and updating context.
     rule #idcFuncs(IMPORTS, DEFNS) => #idcFuncsAux(IMPORTS, DEFNS, 0)
 
     rule #idcFuncsAux((import _ _ (func ID:Identifier _)) IS, FS, IDX) => (ID |-> IDX) #idcFuncsAux(IS, FS, IDX +Int 1)
-    rule #idcFuncsAux(I IS, FS, IDX) => #idcFuncsAux(IS, FS, IDX) [owise]
+    rule #idcFuncsAux((import _ _ (func               _)) IS, FS, IDX) =>              #idcFuncsAux(IS, FS, IDX +Int 1)
+    rule #idcFuncsAux(I                                   IS, FS, IDX) =>              #idcFuncsAux(IS, FS, IDX) [owise]
 
     rule #idcFuncsAux(.Defns, (func ID:Identifier _) FS, IDX) => (ID |-> IDX) #idcFuncsAux(.Defns, FS, IDX +Int 1)
     rule #idcFuncsAux(.Defns, (func      _:FuncSpec) FS, IDX) =>              #idcFuncsAux(.Defns, FS, IDX +Int 1)

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -442,10 +442,13 @@ The `Context` contains information of how to map text-level identifiers to corre
 Record updates can currently not be done in a function rule which also does other updates, so we have helper functions to update specific fields.
 
 ```k
-    syntax Context ::= ctx(localIds: Map)
+    syntax Context ::= ctx(localIds: Map, funcIds: Map)
+                     | #freshCtx ( )                               [function, functional]
                      | #updateLocalIds    ( Context , Map )        [function, functional]
                      | #updateLocalIdsAux ( Context , Map , Bool ) [function, functional]
  // -------------------------------------------------------------------------------------
+    rule #freshCtx ( ) => ctx(... localIds: .Map, funcIds: .Map)
+
     rule #updateLocalIds(C, M) => #updateLocalIdsAux(C, M, false)
     rule #updateLocalIdsAux(ctx(... localIds: (_ => M)), M, false => true)
     rule #updateLocalIdsAux(C, _, true) => C
@@ -465,7 +468,7 @@ Since we do not have polymorphic functions available, we define one function per
     syntax LocalDecl  ::= "#t2aLocalDecl"  "<" Context ">" "(" LocalDecl  ")" [function]
  // ------------------------------------------------------------------------------------
     rule text2abstract(DS:Defns) => text2abstract(( module DS ) .Stmts)
-    rule text2abstract(SS)       => #t2aStmts<ctx( ... localIds: .Map)>(structureModules(unfoldStmts(SS))) [owise]
+    rule text2abstract(SS)       => #t2aStmts<#freshCtx()>(structureModules(unfoldStmts(SS))) [owise]
 
     rule #t2aStmt<C>(M:ModuleDecl) => #t2aModuleDecl<C>(M)
     rule #t2aStmt<C>(D:Defn)  => #t2aDefn<C>(D)

--- a/wasm.md
+++ b/wasm.md
@@ -33,7 +33,6 @@ Configuration
             <typeIds>     .Map </typeIds>
             <types>       .Map </types>
             <nextTypeIdx> 0    </nextTypeIdx>
-            <funcIds>     .Map </funcIds>
             <funcAddrs>   .Map </funcAddrs>
             <nextFuncIdx> 0    </nextFuncIdx>
             <tabIds>      .Map </tabIds>
@@ -685,7 +684,6 @@ The importing and exporting parts of specifications are dealt with in the respec
            <modIdx> CUR </modIdx>
            <typeIds> TYPEIDS </typeIds>
            <types>   TYPES   </types>
-           <funcIds> IDS => #saveId(IDS, OID, NEXTIDX) </funcIds>
            <nextFuncIdx> NEXTIDX => NEXTIDX +Int 1 </nextFuncIdx>
            <funcAddrs> ADDRS => ADDRS [ NEXTIDX <- NEXTADDR ] </funcAddrs>
            ...
@@ -1315,7 +1313,6 @@ The value of a global gets copied when it is imported.
            <modIdx> CUR </modIdx>
            <typeIds> TYPEIDS </typeIds>
            <types>   TYPES   </types>
-           <funcIds> IDS => #saveId(IDS, OID, NEXT) </funcIds>
            <funcAddrs> FS => FS [NEXT <- ADDR] </funcAddrs>
            <nextFuncIdx> NEXT => NEXT +Int 1 </nextFuncIdx>
            ...

--- a/wasm.md
+++ b/wasm.md
@@ -762,7 +762,7 @@ The `#take` function will return the parameter stack in the reversed order, then
 ```k
     syntax PlainInstr ::= "call" Index
  // ----------------------------------
-    rule <k> call IDX:Int => ( invoke FADDR:Int ) ... </k>
+    rule <k> call IDX:Int => ( invoke FADDR ) ... </k>
          <curModIdx> CUR </curModIdx>
          <moduleInst>
            <modIdx> CUR </modIdx>

--- a/wasm.md
+++ b/wasm.md
@@ -1323,9 +1323,8 @@ The value of a global gets copied when it is imported.
          <moduleRegistry> ... MOD |-> MODIDX ... </moduleRegistry>
          <moduleInst>
            <modIdx> MODIDX </modIdx>
-           <funcIds> IDS' </funcIds>
-           <funcAddrs> ... #ContextLookup(IDS' , TFIDX) |-> ADDR ... </funcAddrs>
-           <exports>   ... NAME |-> TFIDX                        ... </exports>
+           <funcAddrs> ... IDX |-> ADDR ... </funcAddrs>
+           <exports>   ... NAME |-> IDX ... </exports>
            ...
          </moduleInst>
          <funcDef>

--- a/wasm.md
+++ b/wasm.md
@@ -764,12 +764,11 @@ The `#take` function will return the parameter stack in the reversed order, then
 ```k
     syntax PlainInstr ::= "call" Index
  // ----------------------------------
-    rule <k> call TFIDX => ( invoke FADDR:Int ) ... </k>
+    rule <k> call IDX:Int => ( invoke FADDR:Int ) ... </k>
          <curModIdx> CUR </curModIdx>
          <moduleInst>
            <modIdx> CUR </modIdx>
-           <funcIds> IDS </funcIds>
-           <funcAddrs> ... #ContextLookup(IDS , TFIDX) |-> FADDR ... </funcAddrs>
+           <funcAddrs> ... IDX |-> FADDR ... </funcAddrs>
            ...
          </moduleInst>
 ```

--- a/wasm.md
+++ b/wasm.md
@@ -1193,32 +1193,28 @@ A table index is optional and will be default to zero.
 ```k
     syntax Defn     ::= ElemDefn
     syntax ElemDefn ::= "(" "elem"     Index Offset ElemSegment ")"
-                      | "(" "elem"           Offset ElemSegment ")"
                       |     "elem" "{" Index        ElemSegment "}"
-    syntax Stmt     ::= #initElements ( Int, Int, Map, Map, ElemSegment )
- // ---------------------------------------------------------------------
-    // Default to table with index 0.
-    rule <k> ( elem        OFFSET      ELEMSEGMENT ) =>     ( elem 0 OFFSET ELEMSEGMENT ) ... </k>
+    syntax Stmt     ::= #initElements ( Int, Int, Map, ElemSegment )
+ // ----------------------------------------------------------------
     rule <k> ( elem TABIDX IS:Instrs   ELEMSEGMENT ) => IS ~> elem { TABIDX ELEMSEGMENT } ... </k>
     rule <k> ( elem TABIDX (offset IS) ELEMSEGMENT ) => IS ~> elem { TABIDX ELEMSEGMENT } ... </k>
 
-    rule <k> elem { TABIDX ELEMSEGMENT } => #initElements ( ADDR, OFFSET, FADDRS, FIDS, ELEMSEGMENT ) ... </k>
+    rule <k> elem { TABIDX ELEMSEGMENT } => #initElements ( ADDR, OFFSET, FADDRS, ELEMSEGMENT ) ... </k>
          <curModIdx> CUR </curModIdx>
          <valstack> < i32 > OFFSET : STACK => STACK </valstack>
          <moduleInst>
            <modIdx> CUR  </modIdx>
-           <funcIds> FIDS </funcIds>
            <funcAddrs> FADDRS </funcAddrs>
            <tabIds>  TIDS </tabIds>
            <tabAddrs> #ContextLookup(TIDS, TABIDX) |-> ADDR </tabAddrs>
            ...
          </moduleInst>
 
-    rule <k> #initElements (    _,      _,      _,   _, .ElemSegment ) => . ... </k>
-    rule <k> #initElements ( ADDR, OFFSET, FADDRS, IDS,  E ES        ) => #initElements ( ADDR, OFFSET +Int 1, FADDRS, IDS, ES ) ... </k>
+    rule <k> #initElements (    _,      _,      _, .ElemSegment ) => . ... </k>
+    rule <k> #initElements ( ADDR, OFFSET, FADDRS,  E:Int ES    ) => #initElements ( ADDR, OFFSET +Int 1, FADDRS, ES ) ... </k>
          <tabInst>
            <tAddr> ADDR </tAddr>
-           <tdata> DATA => DATA [ OFFSET <- FADDRS[#ContextLookup(IDS, E)] ] </tdata>
+           <tdata> DATA => DATA [ OFFSET <- FADDRS[E] ] </tdata>
            ...
          </tabInst>
 ```

--- a/wasm.md
+++ b/wasm.md
@@ -1269,12 +1269,11 @@ The `start` component of a module declares the function index of a `start functi
     syntax Defn      ::= StartDefn
     syntax StartDefn ::= "(" "start" Index ")"
  // ------------------------------------------
-    rule <k> ( start TFIDX ) => ( invoke FADDR ) ... </k>
+    rule <k> ( start IDX:Int ) => ( invoke FADDR ) ... </k>
          <curModIdx> CUR </curModIdx>
          <moduleInst>
            <modIdx> CUR </modIdx>
-           <funcIds> IDS </funcIds>
-           <funcAddrs> ... #ContextLookup(IDS , TFIDX) |-> FADDR ... </funcAddrs>
+           <funcAddrs> ... IDX |-> FADDR ... </funcAddrs>
            ...
          </moduleInst>
 ```


### PR DESCRIPTION
The tests are updated, because we now don't support function IDs outside of modules, and the ID isn't stored, so the assertions can't check for them.