### PR TITLE
Remove named valtypes

### DIFF
--- a/data.md
+++ b/data.md
@@ -108,16 +108,11 @@ WebAssembly Types
 ### Base Types
 
 WebAssembly has four basic types, for 32 and 64 bit integers and floats.
-Here we define `AValType` which stands for `anonymous valtype`, representing values that doesn't have an identifier associated to it.
-Also we define `NValType` which stands for `named valtype`, representing values that has an identifier associated to it.
-`ValType` is the aggregation of `AValType` and `NValType`.
 
 ```k
     syntax IValType ::= "i32" | "i64"
     syntax FValType ::= "f32" | "f64"
-    syntax AValType ::= IValType | FValType
-    syntax NValType ::= "{" Identifier AValType "}"
-    syntax ValType  ::= AValType | NValType
+    syntax ValType  ::= IValType | FValType
  // ---------------------------------------
 ```
 
@@ -137,24 +132,6 @@ There are two basic type-constructors: sequencing (`[_]`) and function spaces (`
  // -----------------------------------------------------------------
     rule lengthValTypes(.ValTypes) => 0
     rule lengthValTypes(V VS)      => 1 +Int lengthValTypes(VS)
-```
-
-We need helper functions to remove the identifiers from `FuncType`.
-
-```k
-    syntax FuncType ::= unnameFuncType ( FuncType ) [function, functional]
- // ----------------------------------------------------------------------
-    rule unnameFuncType ( [ V1 ]->[ V2 ] ) => [ unnameValTypes ( V1 ) ]->[ V2 ]
-```
-
-We need helper functions to remove all the identifiers from a `ValTypes`.
-
-```k
-    syntax ValTypes ::= unnameValTypes ( ValTypes ) [function, functional]
- // ----------------------------------------------------------------------
-    rule unnameValTypes ( .ValTypes     ) => .ValTypes
-    rule unnameValTypes ( { ID V }   VS ) => V unnameValTypes ( VS )
-    rule unnameValTypes ( V:AValType VS ) => V unnameValTypes ( VS )
 ```
 
 All told, a `Type` can be a value type, vector of types, or function type.
@@ -252,7 +229,7 @@ Proper values are numbers annotated with their types.
 ```k
     syntax IVal ::= "<" IValType ">" Int    [klabel(<_>_)]
     syntax FVal ::= "<" FValType ">" Float  [klabel(<_>_)]
-    syntax  Val ::= "<" AValType ">" Number [klabel(<_>_)]
+    syntax  Val ::= "<"  ValType ">" Number [klabel(<_>_)]
                   | IVal | FVal
  // ---------------------------
 ```
@@ -362,7 +339,6 @@ Each call site _must_ ensure that this is desired behavior before using these fu
     rule #zero(.ValTypes)             => .ValStack
     rule #zero(ITYPE:IValType VTYPES) => < ITYPE > 0   : #zero(VTYPES)
     rule #zero(FTYPE:FValType VTYPES) => < FTYPE > 0.0 : #zero(VTYPES)
-    rule #zero({ ID VT }      VTYPES) => #zero(VT VTYPES)
 
     rule #take(N, _)         => .ValStack               requires notBool N >Int 0
     rule #take(N, .ValStack) => .ValStack               requires         N >Int 0

--- a/numeric.md
+++ b/numeric.md
@@ -339,8 +339,8 @@ Conversion operators always take a single argument as input and cast it to anoth
 The operators are further broken down into subsorts for their input type, for simpler type-checking.
 
 ```k
-    syntax Val ::= AValType "." CvtOp Number [klabel(numberCvtOp), function]
- // ------------------------------------------------------------------------
+    syntax Val ::= ValType "." CvtOp Number [klabel(numberCvtOp), function]
+ // -----------------------------------------------------------------------
 
     syntax CvtOp ::= Cvti32Op | Cvti64Op | Cvtf32Op | Cvtf64Op
  // ----------------------------------------------------------

--- a/tests/proofs/wrc20-spec.k
+++ b/tests/proofs/wrc20-spec.k
@@ -35,7 +35,7 @@ module WRC20-SPEC
           ...
         </memInst>
         // TODO: Make function out of this tricky side condition.
-      requires notBool unnameFuncType(asFuncType(#wrc20ReverseBytesTypeDecls)) in values(TYPES)
+      requires notBool asFuncType(#wrc20ReverseBytesTypeDecls) in values(TYPES)
        andBool ADDR +Int #numBytes(i64) <=Int SIZE *Int #pageSize()
        andBool #inUnsignedRange(i32, ADDR)
       ensures  #getRange(BM, ADDR +Int 0, 1) ==Int #getRange(?BM', ADDR +Int 7, 1)

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -522,7 +522,7 @@ Since we do not have polymorphic functions available, we define one function per
     rule #t2aTypeUse<C>((param ID:Identifier AVT) TDS ) => (param AVT) {#t2aTypeUse<C>(TDS)}:>TypeDecls
     rule #t2aTypeUse<_>(TU) => TU [owise]
 
-    rule #t2aLocalDecl<C>(local ID:Identifier AVT:AValType) => local AVT .ValTypes
+    rule #t2aLocalDecl<C>(local ID:Identifier VT:ValType) => local VT .ValTypes
     rule #t2aLocalDecl<C>(LD) => LD [owise]
 ```
 


### PR DESCRIPTION
These are no longer needed, now that we resolve local identifiers in preprocessing.