### PR TITLE
Type desugaring during text -> core phase

### DIFF
--- a/tests/proofs/wrc20-spec.k
+++ b/tests/proofs/wrc20-spec.k
@@ -7,7 +7,7 @@ module WRC20-SPEC
 
     // Reverse bytes spec.
 
-    rule <instrs> sequenceDefns(#t2aDefns<#freshCtx()>(#wrc20ReverseBytes)) // TODO: Have this pre-loaded in the store.
+    rule <instrs> sequenceDefns(#t2aDefns<#freshCtx()>(unfoldDefns(#wrc20ReverseBytes))) // TODO: Have this pre-loaded in the store.
                ~> sequenceInstrs( (i32.const ADDR)
                                   (i32.const ADDR)
                                   (i64.load)

--- a/tests/proofs/wrc20-spec.k
+++ b/tests/proofs/wrc20-spec.k
@@ -7,7 +7,7 @@ module WRC20-SPEC
 
     // Reverse bytes spec.
 
-    rule <instrs> sequenceDefns(#t2aDefns<#freshCtx()>(unfoldDefns(#wrc20ReverseBytes))) // TODO: Have this pre-loaded in the store.
+    rule <instrs> sequenceDefns(#t2aDefns<#freshCtx()>(#wrc20ReverseBytes)) // TODO: Have this pre-loaded in the store.
                ~> sequenceInstrs( (i32.const ADDR)
                                   (i32.const ADDR)
                                   (i64.load)
@@ -21,8 +21,6 @@ module WRC20-SPEC
          <moduleInst>
            <modIdx> CUR </modIdx>
            <memAddrs> 0 |-> MEMADDR </memAddrs>
-           <types> TYPES => ?_ </types>
-           <nextTypeIdx> NEXTTYPEIDX => NEXTTYPEIDX +Int 1 </nextTypeIdx>
            <funcAddrs> _ => ?_ </funcAddrs>
            <nextFuncIdx> NEXTFUNCIDX => NEXTFUNCIDX +Int 1 </nextFuncIdx>
            ...
@@ -36,8 +34,7 @@ module WRC20-SPEC
            ...
          </memInst>
          // TODO: Make function out of this tricky side condition.
-      requires notBool asFuncType(#wrc20ReverseBytesTypeDecls) in values(TYPES)
-       andBool ADDR +Int #numBytes(i64) <=Int SIZE *Int #pageSize()
+      requires ADDR +Int #numBytes(i64) <=Int SIZE *Int #pageSize()
        andBool #inUnsignedRange(i32, ADDR)
       ensures  #getRange(BM, ADDR +Int 0, 1) ==Int #getRange(?BM', ADDR +Int 7, 1)
        andBool #getRange(BM, ADDR +Int 1, 1) ==Int #getRange(?BM', ADDR +Int 6, 1)

--- a/tests/simple/functions_call.wast
+++ b/tests/simple/functions_call.wast
@@ -62,8 +62,6 @@
 
 (assert_return (invoke "export-1" (i64.const 100) (i64.const 43) (i64.const 22)) (i64.const -121))
 #assertFunction 3 [ i64 i64 i64 ] -> [ i64 ] [ i64 ] "call function 1 exists"
-#assertType 1 [ i64 i64 i64 ] -> [ i64 ]
-#assertNextTypeIdx 2
 
 ;; Function with complicated declaration of types
 (module
@@ -243,5 +241,31 @@
 )
 
 (assert_return (invoke "foo") (i32.const 1))
+
+;; Check type is correctly desugared.
+
+(module
+  (func $1 param i64 i64 i64 result i64 local i64
+      (i64.sub (local.get 2) (i64.add (local.get 0) (local.get 1)))
+      (local.set 3)
+      (local.get 3)
+      (return)
+  )
+
+  ( export "export-1" (func $1) )
+
+  (func $2 param i64 i64 i64 result i64 local i64
+      (i64.sub (local.get 2) (i64.add (local.get 0) (local.get 1)))
+      (local.set 3)
+      (local.get 3)
+      (return)
+  )
+)
+
+(assert_return (invoke "export-1" (i64.const 100) (i64.const 43) (i64.const 22)) (i64.const -121))
+#assertFunction 0 [ i64 i64 i64 ] -> [ i64 ] [ i64 ] "call function 1 exists"
+#assertType 0 [ i64 i64 i64 ] -> [ i64 ]
+;; Check type was only added once.
+#assertNextTypeIdx 1
 
 #clearConfig

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -297,9 +297,25 @@ Other desugarings are either left for runtime or expressed as macros (for now).
     rule #unfoldDefns(D:Defn DS, I, M) => D #unfoldDefns(DS, I, M) [owise]
 ```
 
-#### Functions
+#### Types
 
-TODO: Unfold type-use into type declarations.
+A type can be be declared implicitly when a `TypeUse` is a `TypeDecls`.
+In this case it will allocate a type when the type is not in the current module instance.
+
+```k
+    rule #unfoldDefns(( func OID:OptionalId TDECLS:TypeDecls LOCALS:LocalDecls BODY:Instrs ) DS, I, M)
+      => (func OID (type {M [asFuncType(TDECLS)]}:>Identifier) TDECLS LOCALS BODY)
+         #unfoldDefns(DS, I, M)
+      requires         asFuncType(TDECLS) in_keys(M)
+
+    rule #unfoldDefns(( func OID:OptionalId TDECLS:TypeDecls LOCALS:LocalDecls BODY:Instrs ) DS, I, M)
+      => (type #freshId(I) (func TDECLS))
+         (func OID (type #freshId(I)) TDECLS LOCALS BODY)
+         #unfoldDefns(DS, I +Int 1, M [asFuncType(TDECLS) <- #freshId(I)])
+      requires notBool asFuncType(TDECLS) in_keys(M)
+```
+
+#### Functions
 
 ```k
     syntax FuncDefn ::= "(" "func" OptionalId  FuncSpec ")"

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -303,6 +303,18 @@ A type can be be declared implicitly when a `TypeUse` is a `TypeDecls`.
 In this case it will allocate a type when the type is not in the current module instance.
 
 ```k
+    rule #unfoldDefns((type ID:Identifier (func TDECLS)) DS, I, M)
+      => (type ID (func TDECLS)) #unfoldDefns(DS, I, M [ asFuncType(TDECLS) <- ID])
+      requires notBool asFuncType(TDECLS) in_keys(M)
+
+    rule #unfoldDefns((type               (func TDECLS)) DS, I, M)
+      => (type #freshId(I) (func TDECLS)) #unfoldDefns(DS, I +Int 1, M [ asFuncType(TDECLS) <- #freshId(I)])
+      requires notBool asFuncType(TDECLS) in_keys(M)
+
+    rule #unfoldDefns((type OID (func TDECLS)) DS, I, M)
+      => (type OID (func TDECLS)) #unfoldDefns(DS, I, M)
+      requires         asFuncType(TDECLS) in_keys(M)
+
     rule #unfoldDefns(( func OID:OptionalId TDECLS:TypeDecls LOCALS:LocalDecls BODY:Instrs ) DS, I, M)
       => (func OID (type {M [asFuncType(TDECLS)]}:>Identifier) TDECLS LOCALS BODY)
          #unfoldDefns(DS, I, M)

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -328,11 +328,8 @@ Since the inserted type is module-level, any subsequent functions declaring the 
 
     rule #types2indices(.Defns, TI) => TI
 
-    rule #types2indices((type OID (func TDECLS)) DS, #ti(... t2i: M, count: N)) => #types2indices(DS, #ti(... t2i: M [ asFuncType(TDECLS) <- N ], count: N +Int 1))
-      requires notBool asFuncType(TDECLS) in_keys(M)
-
-    rule #types2indices((type OID (func TDECLS)) DS, #ti(... t2i: M, count: N)) => #types2indices(DS, #ti(... t2i: M                            , count: N +Int 1))
-      requires         asFuncType(TDECLS) in_keys(M)
+    rule #types2indices((type OID (func TDECLS)) DS, #ti(... t2i: M, count: N))
+      => #types2indices(DS, #ti(... t2i: M [ asFuncType(TDECLS) <- (M [ asFuncType(TDECLS) ] orDefault N) ], count: N +Int 1))
 
     rule #types2indices(D DS, M) => #types2indices(DS, M) [owise]
 ```

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -78,6 +78,7 @@ Wasm Textual Format
 ```k
 module WASM-TEXT
     imports WASM
+    imports SET
 ```
 
 The text format is a concrete syntax for Wasm.
@@ -284,17 +285,17 @@ Other desugarings are either left for runtime or expressed as macros (for now).
 ### Unfolding Abbreviations
 
 ```k
-    syntax Stmts ::= unfoldStmts  ( Stmts )       [function]
-    syntax Defns ::= unfoldDefns  ( Defns )       [function]
-                   | #unfoldDefns ( Defns , Int ) [function]
- // --------------------------------------------------------
+    syntax Stmts ::= unfoldStmts  ( Stmts )            [function]
+    syntax Defns ::= unfoldDefns  ( Defns )            [function]
+                   | #unfoldDefns ( Defns , Int, Set ) [function]
+ // -------------------------------------------------------------
     rule unfoldStmts(( module OID:OptionalId DS) SS) => ( module OID unfoldDefns(DS) ) unfoldStmts(SS)
     rule unfoldStmts(.Stmts) => .Stmts
     rule unfoldStmts(S SS) => S unfoldStmts(SS) [owise]
 
-    rule unfoldDefns(DS) => #unfoldDefns(DS, 0)
-    rule #unfoldDefns(.Defns, _) => .Defns
-    rule #unfoldDefns(D:Defn DS, I) => D #unfoldDefns(DS, I) [owise]
+    rule unfoldDefns(DS) => #unfoldDefns(DS, 0, .Set)
+    rule #unfoldDefns(.Defns, _, _) => .Defns
+    rule #unfoldDefns(D:Defn DS, I, TS) => D #unfoldDefns(DS, I, TS) [owise]
 ```
 
 #### Functions
@@ -306,16 +307,16 @@ TODO: Unfold type-use into type declarations.
     syntax FuncSpec ::= TypeUse LocalDecls Instrs
                       | InlineImport TypeUse
  // ----------------------------------------
-    rule #unfoldDefns(( func OID:OptionalId (import MOD NAME) TUSE) DS, I)
-      => ( import MOD NAME (func OID TUSE) ) #unfoldDefns(DS, I)
+    rule #unfoldDefns(( func OID:OptionalId (import MOD NAME) TUSE) DS, I, TS)
+      => ( import MOD NAME (func OID TUSE) ) #unfoldDefns(DS, I, TS)
 
     syntax FuncSpec   ::= InlineExport FuncSpec
  // -------------------------------------------
-    rule #unfoldDefns(( func EXPO:InlineExport SPEC:FuncSpec ) DS, I)
-      => #unfoldDefns(( func #freshId(I) EXPO  SPEC) DS, I +Int 1)
+    rule #unfoldDefns(( func EXPO:InlineExport SPEC:FuncSpec ) DS, I, TS)
+      => #unfoldDefns(( func #freshId(I) EXPO  SPEC) DS, I +Int 1, TS)
 
-    rule #unfoldDefns(( func ID:Identifier ( export ENAME ) SPEC:FuncSpec ) DS, I)
-      => ( export ENAME ( func ID ) ) #unfoldDefns(( func ID SPEC ) DS, I)
+    rule #unfoldDefns(( func ID:Identifier ( export ENAME ) SPEC:FuncSpec ) DS, I, TS)
+      => ( export ENAME ( func ID ) ) #unfoldDefns(( func ID SPEC ) DS, I, TS)
 ```
 
 #### Tables
@@ -323,26 +324,26 @@ TODO: Unfold type-use into type declarations.
 ```k
     syntax TableSpec ::= TableElemType "(" "elem" ElemSegment ")"
  // -------------------------------------------------------------
-    rule #unfoldDefns(( table funcref ( elem ELEM ) ) DS, I)
-      => #unfoldDefns(( table #freshId(I) funcref ( elem ELEM ) ) DS, I +Int 1)
+    rule #unfoldDefns(( table funcref ( elem ELEM ) ) DS, I, TS)
+      => #unfoldDefns(( table #freshId(I) funcref ( elem ELEM ) ) DS, I +Int 1, TS)
 
-    rule #unfoldDefns(( table ID:Identifier funcref ( elem ELEM ) ) DS, I)
+    rule #unfoldDefns(( table ID:Identifier funcref ( elem ELEM ) ) DS, I, TS)
       => ( table ID #lenElemSegment(ELEM) #lenElemSegment(ELEM) funcref ):TableDefn
          ( elem  ID (offset (i32.const 0) .Instrs) ELEM )
-         #unfoldDefns(DS, I)
+         #unfoldDefns(DS, I, TS)
 
     syntax TableSpec  ::= InlineImport TableType
  // --------------------------------------------
-    rule #unfoldDefns(( table OID:OptionalId (import MOD NAME) TT:TableType ) DS, I)
-      => ( import MOD NAME (table OID TT) ) #unfoldDefns(DS, I)
+    rule #unfoldDefns(( table OID:OptionalId (import MOD NAME) TT:TableType ) DS, I, TS)
+      => ( import MOD NAME (table OID TT) ) #unfoldDefns(DS, I, TS)
 
     syntax TableSpec  ::= InlineExport TableSpec
  // --------------------------------------------
-    rule #unfoldDefns(( table EXPO:InlineExport SPEC:TableSpec ) DS, I)
-      => #unfoldDefns(( table #freshId(I) EXPO SPEC ) DS, I +Int 1)
+    rule #unfoldDefns(( table EXPO:InlineExport SPEC:TableSpec ) DS, I, TS)
+      => #unfoldDefns(( table #freshId(I) EXPO SPEC ) DS, I +Int 1, TS)
 
-    rule #unfoldDefns(( table ID:Identifier ( export ENAME ) SPEC:TableSpec ) DS, I)
-      => ( export ENAME ( table ID ) ) #unfoldDefns(( table ID SPEC ) DS, I)
+    rule #unfoldDefns(( table ID:Identifier ( export ENAME ) SPEC:TableSpec ) DS, I, TS)
+      => ( export ENAME ( table ID ) ) #unfoldDefns(( table ID SPEC ) DS, I, TS)
 ```
 
 #### Memories
@@ -350,13 +351,13 @@ TODO: Unfold type-use into type declarations.
 ```k
     syntax MemorySpec ::= "(" "data" DataString ")"
  // -----------------------------------------------
-    rule #unfoldDefns(( memory ( data DATA ) ) DS, I)
-      => #unfoldDefns(( memory #freshId(I) ( data DATA ) ) DS, I +Int 1)
+    rule #unfoldDefns(( memory ( data DATA ) ) DS, I, TS)
+      => #unfoldDefns(( memory #freshId(I) ( data DATA ) ) DS, I +Int 1, TS)
 
-    rule #unfoldDefns(( memory ID:Identifier ( data DATA ) ) DS, I)
+    rule #unfoldDefns(( memory ID:Identifier ( data DATA ) ) DS, I, TS)
       => ( memory ID #lengthDataPages(DATA) #lengthDataPages(DATA) ):MemoryDefn
          ( data   ID (offset (i32.const 0) .Instrs) DATA )
-         #unfoldDefns(DS, I)
+         #unfoldDefns(DS, I, TS)
 
     syntax Int ::= #lengthDataPages ( DataString ) [function]
  // ---------------------------------------------------------
@@ -364,16 +365,16 @@ TODO: Unfold type-use into type declarations.
 
     syntax MemorySpec ::= InlineImport MemType
  // ------------------------------------------
-    rule #unfoldDefns(( memory OID:OptionalId (import MOD NAME) MT:MemType ) DS, I)
-      => ( import MOD NAME (memory OID MT  ) ) #unfoldDefns(DS, I)
+    rule #unfoldDefns(( memory OID:OptionalId (import MOD NAME) MT:MemType ) DS, I, TS)
+      => ( import MOD NAME (memory OID MT  ) ) #unfoldDefns(DS, I, TS)
 
     syntax MemorySpec ::= InlineExport MemorySpec
  // ---------------------------------------------
-    rule #unfoldDefns(( memory EXPO:InlineExport SPEC:MemorySpec ) DS, I)
-      => #unfoldDefns(( memory #freshId(I:Int) EXPO SPEC ) DS, I +Int 1)
+    rule #unfoldDefns(( memory EXPO:InlineExport SPEC:MemorySpec ) DS, I, TS)
+      => #unfoldDefns(( memory #freshId(I:Int) EXPO SPEC ) DS, I +Int 1, TS)
 
-    rule #unfoldDefns(( memory ID:Identifier ( export ENAME ) SPEC:MemorySpec ) DS, I)
-      => ( export ENAME ( memory ID ) ) #unfoldDefns( ( memory ID SPEC ) DS, I)
+    rule #unfoldDefns(( memory ID:Identifier ( export ENAME ) SPEC:MemorySpec ) DS, I, TS)
+      => ( export ENAME ( memory ID ) ) #unfoldDefns( ( memory ID SPEC ) DS, I, TS)
 ```
 
 #### Globals
@@ -381,16 +382,16 @@ TODO: Unfold type-use into type declarations.
 ```k
     syntax GlobalSpec ::= InlineImport TextFormatGlobalType
  // -------------------------------------------------------
-    rule #unfoldDefns(( global OID:OptionalId (import MOD NAME) TYP ) DS, I)
-      => ( import MOD NAME (global OID TYP ) ) #unfoldDefns(DS, I) 
+    rule #unfoldDefns(( global OID:OptionalId (import MOD NAME) TYP ) DS, I, TS)
+      => ( import MOD NAME (global OID TYP ) ) #unfoldDefns(DS, I, TS)
 
     syntax GlobalSpec ::= InlineExport GlobalSpec
  // ---------------------------------------------
-    rule #unfoldDefns(( global EXPO:InlineExport SPEC:GlobalSpec ) DS, I)
-      => #unfoldDefns(( global #freshId(I) EXPO SPEC ) DS, I +Int 1)
+    rule #unfoldDefns(( global EXPO:InlineExport SPEC:GlobalSpec ) DS, I, TS)
+      => #unfoldDefns(( global #freshId(I) EXPO SPEC ) DS, I +Int 1, TS)
 
-    rule #unfoldDefns(( global ID:Identifier ( export ENAME ) SPEC:GlobalSpec ) DS, I)
-      => ( export ENAME ( global ID ) ) #unfoldDefns(( global ID SPEC ) DS, I)
+    rule #unfoldDefns(( global ID:Identifier ( export ENAME ) SPEC:GlobalSpec ) DS, I, TS)
+      => ( export ENAME ( global ID ) ) #unfoldDefns(( global ID SPEC ) DS, I, TS)
 ```
 
 #### Element Segments
@@ -398,8 +399,8 @@ TODO: Unfold type-use into type declarations.
 ```k
     syntax ElemDefn ::= "(" "elem" Offset ElemSegment ")"
  // -----------------------------------------------------
-    rule #unfoldDefns(( elem OFFSET:Offset ES ) DS, I)
-      => ( elem 0 OFFSET ES ) #unfoldDefns(DS, I)
+    rule #unfoldDefns(( elem OFFSET:Offset ES ) DS, I, TS)
+      => ( elem 0 OFFSET ES ) #unfoldDefns(DS, I, TS)
 ```
 
 ### Structuring Modules

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -234,7 +234,6 @@ In the text format, it is also allowed to have a conditional without the `else` 
 ```k
     syntax TypeDefn ::= "(type" OptionalId "(" "func" TypeDecls ")" ")"
  // -------------------------------------------------------------------
-
     rule <instrs> (type OID (func TDECLS:TypeDecls)) => #type(... type: asFuncType(TDECLS), metadata: OID) ... </instrs>
 ```
 

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -229,6 +229,15 @@ In the text format, it is also allowed to have a conditional without the `else` 
        andBool ( ID ==K OID'' orBool notBool isIdentifier(OID'') )
 ```
 
+### Types
+
+```k
+    syntax TypeDefn ::= "(type" OptionalId "(" "func" TypeDecls ")" ")"
+ // -------------------------------------------------------------------
+
+    rule <instrs> (type OID (func TDECLS:TypeDecls)) => #type(... type: asFuncType(TDECLS), metadata: OID) ... </instrs>
+```
+
 ### Exports
 
 Exports can be declared like regular functions, memories, etc., by giving an inline export declaration.
@@ -289,6 +298,8 @@ Other desugarings are either left for runtime or expressed as macros (for now).
 ```
 
 #### Functions
+
+TODO: Unfold type-use into type declarations.
 
 ```k
     syntax FuncDefn ::= "(" "func" OptionalId  FuncSpec ")"

--- a/wasm.md
+++ b/wasm.md
@@ -646,35 +646,6 @@ Function Declaration and Invocation
     rule #asLocalType(local _ID:Identifier VTYPE:ValType    LDECLS:LocalDecls , VTYPES) => #asLocalType(LDECLS , VTYPES + VTYPE .ValTypes)
 ```
 
-### Function Implicit Type Declaration
-
-It could also be declared implicitly when a `TypeUse` is a `TypeDecls`, in this case it will allocate a type when the type is not in the current module instance.
-
-```k
-    syntax Instr ::= #checkTypeUse ( TypeUse )
- // ------------------------------------------
-    rule <instrs> #checkTypeUse ( TDECLS:TypeDecls ) => #type(... type: asFuncType(TDECLS), metadata: ) ... </instrs>
-         <curModIdx> CUR </curModIdx>
-         <moduleInst>
-           <modIdx> CUR </modIdx>
-           <types> TYPES </types>
-           ...
-         </moduleInst>
-       requires notBool asFuncType(TDECLS) in values(TYPES)
-
-    rule <instrs> #checkTypeUse ( TDECLS:TypeDecls ) => . ... </instrs>
-         <curModIdx> CUR </curModIdx>
-         <moduleInst>
-           <modIdx> CUR </modIdx>
-           <types> TYPES </types>
-           ...
-         </moduleInst>
-       requires asFuncType(TDECLS) in values(TYPES)
-
-    rule <instrs> #checkTypeUse ( (type _TFIDF) )         => . ... </instrs>
-    rule <instrs> #checkTypeUse ( (type _TFIDF) _TDECLS ) => . ... </instrs>
-```
-
 ### Function Declaration
 
 Function declarations can look quite different depending on which fields are ommitted and what the context is.
@@ -693,7 +664,7 @@ TODO: Use a type index for type, and vec type for locals (moving `asLocalType` t
  // -------------------------------------------------------------------------
     rule <instrs> #func(... type: TUSE, locals: LDECLS, body: INSTRS, metadata: META) => allocfunc(TUSE, LDECLS, INSTRS, META) ... </instrs>
 
-    rule <instrs> allocfunc(TUSE, LDECLS, INSTRS, #meta(... id: OID, localIds: LIDS)) => #checkTypeUse ( TUSE ) ... </instrs>
+    rule <instrs> allocfunc(TUSE, LDECLS, INSTRS, #meta(... id: OID, localIds: LIDS)) => . ... </instrs>
          <curModIdx> CUR </curModIdx>
          <moduleInst>
            <modIdx> CUR </modIdx>

--- a/wasm.md
+++ b/wasm.md
@@ -609,11 +609,8 @@ When defining `TypeDefn`, the `identifier` for `param` will be ignored and will 
 ```k
     syntax Defn     ::= TypeDefn
     syntax TypeDefn ::= #type(type: FuncType, metadata: OptionalId)
-                      | "(type" OptionalId "(" "func" TypeDecls ")" ")"
     syntax Alloc    ::= alloctype (OptionalId, FuncType)
- // -----------------------------------------------------
-    // TODO: Move this to desugaring phase
-    rule <instrs> (type OID (func TDECLS:TypeDecls)) => #type(... type: asFuncType(TDECLS), metadata: OID) ... </instrs>
+ // ----------------------------------------------------
     rule <instrs> #type(... type: TYPE, metadata: OID) => alloctype(OID, TYPE) ... </instrs>
 
     rule <instrs> alloctype(OID, TYPE) => . ... </instrs>


### PR DESCRIPTION
This is in preparation of getting rid of `#ContextLookup` for types.