### PR TITLE
Unfold instructions, remove #ContextLookup for labels

### DIFF
--- a/test.md
+++ b/test.md
@@ -58,8 +58,7 @@ Instruction sugar
 We allow writing instructions at the top level in the test embedder.
 
 ```k
-    rule <instrs> ( PI:PlainInstr IS:Instrs ):FoldedInstr => sequenceInstrs(IS) ~> PI ... </instrs>
-    rule <instrs> ( PI:PlainInstr           ):FoldedInstr =>                       PI ... </instrs>
+    rule <instrs> FI:FoldedInstr => sequenceInstrs(unfoldInstrs(FI .Instrs)) ... </instrs>
 ```
 
 Auxiliary

--- a/test.md
+++ b/test.md
@@ -52,6 +52,16 @@ This is purely a KWasm feature, which is useful for testing.
       [owise]
 ```
 
+Instruction sugar
+-----------------
+
+We allow writing instructions at the top level in the test embedder.
+
+```k
+    rule <instrs> ( PI:PlainInstr IS:Instrs ):FoldedInstr => sequenceInstrs(IS) ~> PI ... </instrs>
+    rule <instrs> ( PI:PlainInstr           ):FoldedInstr =>                       PI ... </instrs>
+```
+
 Auxiliary
 ---------
 

--- a/tests/proofs/locals-spec.k
+++ b/tests/proofs/locals-spec.k
@@ -3,7 +3,7 @@ requires "kwasm-lemmas.md"
 module LOCALS-SPEC
     imports KWASM-LEMMAS
 
-    rule <instrs> (local.get X:Int) ~> (local.set X:Int) => . ... </instrs>
+    rule <instrs> local.get X:Int ~> local.set X:Int => . ... </instrs>
          <locals>
            X |-> < _ITYPE > (VAL => VAL)
          </locals>

--- a/tests/proofs/loops-spec.k
+++ b/tests/proofs/loops-spec.k
@@ -8,17 +8,17 @@ module LOOPS-SPEC
                ~> label // Loop label.
                     [ .ValTypes ]
                     { loop .TypeDecls
-                        (local.get 0)
-                        (local.get 1)
-                        (ITYPE.add)
-                        (local.set 1)
-                        (local.get 0)
-                        (ITYPE.const 1)
-                        (ITYPE.sub)
-                        (local.tee 0)
-                        (ITYPE.eqz)
-                        (br_if 1)
-                        (br 0)
+                        local.get 0
+                        local.get 1
+                        ITYPE.add
+                        local.set 1
+                        local.get 0
+                        ITYPE.const 1
+                        ITYPE.sub
+                        local.tee 0
+                        ITYPE.eqz
+                        br_if 1
+                        br 0
                       end
                    }
                    .ValStack
@@ -40,19 +40,19 @@ module LOOPS-SPEC
     // Main claim.
     rule <instrs>
               block .TypeDecls
-                 ( loop .TypeDecls
-                     (local.get 0)
-                     (local.get 1)
-                     (ITYPE.add)
-                     (local.set 1)
-                     (local.get 0)
-                     (ITYPE.const 1)
-                     (ITYPE.sub)
-                     (local.tee 0)
-                     (ITYPE.eqz)
-                     (br_if 1)
-                     (br 0)
-                 )
+                 loop .TypeDecls
+                     local.get 0
+                     local.get 1
+                     ITYPE.add
+                     local.set 1
+                     local.get 0
+                     ITYPE.const 1
+                     ITYPE.sub
+                     local.tee 0
+                     ITYPE.eqz
+                     br_if 1
+                     br 0
+                end
              end
           => .
           ...

--- a/tests/proofs/memory-spec.k
+++ b/tests/proofs/memory-spec.k
@@ -3,7 +3,7 @@ requires "kwasm-lemmas.md"
 module MEMORY-SPEC
     imports KWASM-LEMMAS
 
-    rule <instrs> (i64.store16 (i32.const ADDR) (i64.load32_u (i32.const ADDR)):FoldedInstr):FoldedInstr => . ... </instrs>
+    rule <instrs> i32.const ADDR ~> i32.const ADDR ~> i64.load32_u ~> i64.store16 => . ... </instrs>
          <curModIdx> CUR </curModIdx>
          <moduleInst>
            <modIdx> CUR </modIdx>
@@ -20,7 +20,7 @@ module MEMORY-SPEC
         ADDR +Int #numBytes(i64) <=Int SIZE *Int #pageSize()
         andBool #inUnsignedRange(i32, ADDR)
 
-    rule <instrs> (ITYPE:IValType.store (i32.const ADDR) (ITYPE.load (i32.const ADDR)):Instr):Instr => . ... </instrs>
+    rule <instrs>  i32.const ADDR ~> i32.const ADDR ~> ITYPE:IValType.load ~> ITYPE.store => . ... </instrs>
          <curModIdx> CUR </curModIdx>
          <moduleInst>
            <modIdx> CUR </modIdx>

--- a/tests/proofs/simple-arithmetic-spec.k
+++ b/tests/proofs/simple-arithmetic-spec.k
@@ -3,20 +3,20 @@ requires "kwasm-lemmas.md"
 module SIMPLE-ARITHMETIC-SPEC
     imports KWASM-LEMMAS
 
-    rule <instrs> (ITYPE:IValType . const X:Int) => . ... </instrs>
+    rule <instrs> ITYPE:IValType . const X:Int => . ... </instrs>
          <valstack> S:ValStack => < ITYPE > X : S </valstack>
       requires #inUnsignedRange(ITYPE, X)
 
-    rule <instrs> (ITYPE:IValType . const X:Int) => . ... </instrs>
+    rule <instrs> ITYPE:IValType . const X:Int => . ... </instrs>
          <valstack> S:ValStack => < ITYPE > (X +Int #pow(ITYPE)) : S </valstack>
       requires (#minSigned(ITYPE) <=Int X) andBool (X <Int 0)
 
-    rule <instrs> (ITYPE:IValType . const X:Int) ~> (ITYPE . const Y:Int) => . ... </instrs>
+    rule <instrs> ITYPE:IValType . const X:Int ~> ITYPE . const Y:Int => . ... </instrs>
          <valstack> S:ValStack => < ITYPE > Y : < ITYPE > X : S </valstack>
       requires #inUnsignedRange(ITYPE, X)
        andBool #inUnsignedRange(ITYPE, Y)
 
-    rule <instrs> (ITYPE:IValType . const X:Int) ~> (ITYPE . const Y:Int) ~> (ITYPE . add) => . ... </instrs>
+    rule <instrs> ITYPE:IValType . const X:Int ~> ITYPE . const Y:Int ~> ITYPE . add => . ... </instrs>
          <valstack> S:ValStack => < ITYPE > (X +Int Y) : S </valstack>
       requires 0 <=Int X andBool 0 <=Int Y
        andBool (X +Int Y) <Int #pow(ITYPE)

--- a/tests/proofs/wrc20-spec.k
+++ b/tests/proofs/wrc20-spec.k
@@ -8,12 +8,11 @@ module WRC20-SPEC
     // Reverse bytes spec.
 
     rule <instrs> sequenceDefns(#t2aDefns<#freshCtx()>(#wrc20ReverseBytes)) // TODO: Have this pre-loaded in the store.
-               ~> sequenceInstrs( (i32.const ADDR)
-                                  (i32.const ADDR)
-                                  (i64.load)
-                                  ( invoke NEXTADDR ) // TODO: Use `call`.
-                                  (i64.store)
-                                )
+               ~> i32.const ADDR
+               ~> i32.const ADDR
+               ~> i64.load
+               ~> (invoke NEXTADDR) // TODO: Use `call`.
+               ~> i64.store
                => .
                   ...
          </instrs>

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -391,7 +391,6 @@ The correct label index is calculated by looking at whih depth the index occured
 Conceptually, `br ID => br CURRENT_EXECUTION_DEPTH -Int IDENTIFIER_LABEL_DEPTH -Int 1`.
 
 ```k
-syntax Instr ::= "testy" Identifier Int Map Int
     rule #unfoldInstrs(br       ID:Identifier  IS, DEPTH, M) => br       DEPTH -Int {M [ ID ]}:>Int -Int 1 #unfoldInstrs(IS, DEPTH, M)
     rule #unfoldInstrs(br_if    ID:Identifier  IS, DEPTH, M) => br_if    DEPTH -Int {M [ ID ]}:>Int -Int 1 #unfoldInstrs(IS, DEPTH, M)
     rule #unfoldInstrs(br_table ES:ElemSegment IS, DEPTH, M) => br_table elemSegment2Indices(ES, DEPTH, M) #unfoldInstrs(IS, DEPTH, M)

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -688,6 +688,8 @@ After unfolding, each type use in a function starts with an explicit reference t
 ```k
     syntax Instr ::= "#t2aInstr" "<" Context ">" "(" Instr ")" [function]
  // ---------------------------------------------------------------------
+    rule #t2aInstr<C>(( PI:PlainInstr  IS:Instrs ):FoldedInstr) => ({#t2aInstr<C>(PI)}:>PlainInstr #t2aInstrs<C>(IS))
+    rule #t2aInstr<C>(( PI:PlainInstr            ):FoldedInstr) =>  #t2aInstr<C>(PI)
 ```
 
 #### Basic Instructions

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -495,10 +495,17 @@ Since the inserted type is module-level, any subsequent functions declaring the 
     rule #unfoldInstrs(if TDS IS else IS' end IS'', DEPTH, M) => if TDS #unfoldInstrs(IS, DEPTH +Int 1, M) else #unfoldInstrs(IS', DEPTH +Int 1, M) end #unfoldInstrs(IS'', DEPTH, M)
 
 syntax Instr ::= "testy" Identifier Int Map Int
-    rule #unfoldInstrs((br    ID:Identifier => br DEPTH -Int {M [ ID ]}:>Int -Int 1):PlainInstr _IS, DEPTH, M)
-    rule #unfoldInstrs((br_if ID:Identifier => br DEPTH -Int {M [ ID ]}:>Int -Int 1):PlainInstr _IS, DEPTH, M)
+    rule #unfoldInstrs(br       ID:Identifier  IS, DEPTH, M) => br       DEPTH -Int {M [ ID ]}:>Int -Int 1 #unfoldInstrs(IS, DEPTH, M)
+    rule #unfoldInstrs(br_if    ID:Identifier  IS, DEPTH, M) => br_if    DEPTH -Int {M [ ID ]}:>Int -Int 1 #unfoldInstrs(IS, DEPTH, M)
+    rule #unfoldInstrs(br_table ES:ElemSegment IS, DEPTH, M) => br_table elemSegment2Indices(ES, DEPTH, M) #unfoldInstrs(IS, DEPTH, M)
 
     rule #unfoldInstrs(I IS, DEPTH, M) => I #unfoldInstrs(IS, DEPTH, M) [owise]
+
+    syntax ElemSegment ::= elemSegment2Indices( ElemSegment, Int, Map ) [function]
+ // ------------------------------------------------------------------------------
+    rule elemSegment2Indices(.ElemSegment    , _DEPTH, _M) => .ElemSegment
+    rule elemSegment2Indices(ID:Identifier ES,  DEPTH,  M) => DEPTH -Int {M [ ID ]}:>Int -Int 1 elemSegment2Indices(ES, DEPTH, M)
+    rule elemSegment2Indices(E             ES,  DEPTH,  M) => E                                 elemSegment2Indices(ES, DEPTH, M) [owise]
 
     syntax Instrs ::= Instrs "appendInstrs" Instrs      [function]
                     | #appendInstrs  ( Instrs, Instrs ) [function]

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -468,8 +468,13 @@ Since the inserted type is module-level, any subsequent functions declaring the 
 
     rule #unfoldInstrs(.Instrs, _, _) => .Instrs
 
-    rule #unfoldInstrs(( PI:PlainInstr  IS:Instrs ):FoldedInstr IS', DEPTH, M) => IS appendInstrs PI #unfoldInstrs(IS', DEPTH, M)
-    rule #unfoldInstrs(( PI:PlainInstr            ):FoldedInstr IS', DEPTH, M) =>                 PI #unfoldInstrs(IS', DEPTH, M)
+    rule #unfoldInstrs(( PI:PlainInstr  IS:Instrs ):FoldedInstr IS', DEPTH, M)
+      =>             (#unfoldInstrs(IS        , DEPTH, M)
+         appendInstrs #unfoldInstrs(PI .Instrs, DEPTH, M))
+         appendInstrs #unfoldInstrs(IS'       , DEPTH, M)
+    rule #unfoldInstrs(( PI:PlainInstr            ):FoldedInstr IS', DEPTH, M)
+      =>              #unfoldInstrs(PI .Instrs, DEPTH, M)
+         appendInstrs #unfoldInstrs(IS'       , DEPTH, M)
 
     rule #unfoldInstrs(((block ID:Identifier TDS IS)          => block ID TDS IS end) _IS', _DEPTH, _M)
     rule #unfoldInstrs(((block               TDS IS)          => block    TDS IS end) _IS', _DEPTH, _M)

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -316,14 +316,14 @@ If there is no matching module-level type, a new such type is inserted *at the e
 Since the inserted type is module-level, any subsequent functions declaring the same type will not implicitly generate a new type.
 
 ```k
-    rule #unfoldDefns(( func OID:OptionalId TDECLS:TypeDecls LOCALS:LocalDecls BODY:Instrs ) DS, I, #ti(... t2i: M) #as TI)
-      => (func OID (type {M [asFuncType(TDECLS)]}:>Int) TDECLS LOCALS BODY)
-         #unfoldDefns(DS, I, TI)
+    rule #unfoldDefns(( func OID:OptionalId (TDECLS:TypeDecls => (type {M [asFuncType(TDECLS)]}:>Int) TDECLS) _LOCALS:LocalDecls _BODY:Instrs ) _DS
+                    , _I
+                    , #ti(... t2i: M))
       requires         asFuncType(TDECLS) in_keys(M)
 
-    rule #unfoldDefns(( func OID:OptionalId TDECLS:TypeDecls LOCALS:LocalDecls BODY:Instrs ) DS, I, #ti(... t2i: M, count: N))
-      => (func OID (type N) TDECLS LOCALS BODY)
-         #unfoldDefns(DS appendDefn (type (func TDECLS)), I, #ti(... t2i: M [asFuncType(TDECLS) <- N], count: N +Int 1))
+    rule #unfoldDefns(( func OID:OptionalId (TDECLS:TypeDecls => (type N) TDECLS) _LOCALS:LocalDecls _BODY:Instrs ) (DS => DS appendDefn  (type (func TDECLS)))
+                   , _I
+                   , #ti(... t2i: M => M [ asFuncType(TDECLS) <- N ], count: N => N +Int 1))
       requires notBool asFuncType(TDECLS) in_keys(M)
 
     rule #unfoldDefns(( import MOD NAME (func OID:OptionalId TDECLS:TypeDecls )) DS, I, #ti(... t2i: M) #as TI)

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -494,8 +494,9 @@ Since the inserted type is module-level, any subsequent functions declaring the 
     rule #unfoldInstrs( (if ID:Identifier  TDS      IS         else _OID':OptionalId IS' end _OID'' => if     TDS IS else IS'     end) _IS'',  DEPTH,  M => M [ ID <- DEPTH ])
     rule #unfoldInstrs(if TDS IS else IS' end IS'', DEPTH, M) => if TDS #unfoldInstrs(IS, DEPTH +Int 1, M) else #unfoldInstrs(IS', DEPTH +Int 1, M) end #unfoldInstrs(IS'', DEPTH, M)
 
-    rule #unfoldInstrs((br    ID:Identifier => br DEPTH -Int {M [ ID ]}:>Int -Int 1) _IS, DEPTH, M)
-    rule #unfoldInstrs((br_if ID:Identifier => br DEPTH -Int {M [ ID ]}:>Int -Int 1) _IS, DEPTH, M)
+syntax Instr ::= "testy" Identifier Int Map Int
+    rule #unfoldInstrs((br    ID:Identifier => br DEPTH -Int {M [ ID ]}:>Int -Int 1):PlainInstr _IS, DEPTH, M)
+    rule #unfoldInstrs((br_if ID:Identifier => br DEPTH -Int {M [ ID ]}:>Int -Int 1):PlainInstr _IS, DEPTH, M)
 
     rule #unfoldInstrs(I IS, DEPTH, M) => I #unfoldInstrs(IS, DEPTH, M) [owise]
 

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -326,9 +326,10 @@ Since the inserted type is module-level, any subsequent functions declaring the 
                    , #ti(... t2i: M => M [ asFuncType(TDECLS) <- N ], count: N => N +Int 1))
       requires notBool asFuncType(TDECLS) in_keys(M)
 
-    rule #unfoldDefns     (( func OID:OptionalId TUSE:TypeUse LOCALS:LocalDecls    BODY)   DS, I, TI)
+    rule #unfoldDefns(( func OID:OptionalId TUSE:TypeUse LOCALS:LocalDecls    BODY)   DS, I, TI)
       => (( func OID            TUSE         LOCALS unfoldInstrs(BODY)))
-         #unfoldDefns(DS, I, TI) requires notBool isTypeDecls(TUSE)
+         #unfoldDefns(DS, I, TI)
+      requires notBool isTypeDecls(TUSE)
 
     rule #unfoldDefns(( import MOD NAME (func OID:OptionalId TDECLS:TypeDecls )) DS, I, #ti(... t2i: M) #as TI)
       => (import MOD NAME (func OID (type {M [asFuncType(TDECLS)]}:>Int) TDECLS ))

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -492,7 +492,7 @@ Since the inserted type is module-level, any subsequent functions declaring the 
     rule #unfoldInstrs((br    ID:Identifier => br DEPTH -Int {M [ ID ]}:>Int -Int 1) _IS, DEPTH, M)
     rule #unfoldInstrs((br_if ID:Identifier => br DEPTH -Int {M [ ID ]}:>Int -Int 1) _IS, DEPTH, M)
 
-    rule #unfoldInstrs(_I IS => IS, _DEPTH, _M) [owise]
+    rule #unfoldInstrs(I IS, DEPTH, M) => I #unfoldInstrs(IS, DEPTH, M) [owise]
 
     syntax Instrs ::= Instrs "appendInstrs" Instrs      [function]
                     | #appendInstrs  ( Instrs, Instrs ) [function]

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -109,46 +109,6 @@ In the future should investigate which direction the subsort should go.
     rule WasmIntToken2Int(VAL) => WasmIntTokenString2Int(replaceAll(WasmIntToken2String(VAL), "_", ""))
 ```
 
-### Folded Instructions
-
-Folded instructions are a syntactic sugar where expressions can be grouped using parentheses for higher readability.
-
-```k
-    syntax Instr ::= FoldedInstr
- // ----------------------------
-```
-
-One type of folded instruction are `PlainInstr`s wrapped in parentheses and optionally includes nested folded instructions to indicate its operands.
-
-```k
-    syntax FoldedInstr ::= "(" PlainInstr Instrs ")"
-                         | "(" PlainInstr        ")" [prefer]
- // ---------------------------------------------------------
-    rule <instrs> ( PI:PlainInstr IS:Instrs ):FoldedInstr => sequenceInstrs(IS) ~> PI ... </instrs>
-    rule <instrs> ( PI:PlainInstr           ):FoldedInstr =>                       PI ... </instrs>
-```
-
-Another type of folded instruction is control flow blocks wrapped in parentheses, in which case the `end` keyword is omitted.
-
-```k
-    syntax FoldedInstr ::= "(" "block" OptionalId TypeDecls Instrs ")"
- // ------------------------------------------------------------------
-    rule <instrs> ( block               TDECLS:TypeDecls INSTRS:Instrs ) => block    TDECLS INSTRS end ... </instrs>
-    rule <instrs> ( block ID:Identifier TDECLS:TypeDecls INSTRS:Instrs ) => block ID TDECLS INSTRS end ... </instrs>
-
-    syntax FoldedInstr ::= "(" "if" OptionalId TypeDecls Instrs "(" "then" Instrs ")" ")"
-                         | "(" "if" OptionalId TypeDecls Instrs "(" "then" Instrs ")" "(" "else" Instrs ")" ")"
- // -----------------------------------------------------------------------------------------------------------
-    rule <instrs> ( if OID:OptionalId TDECLS:TypeDecls C:Instrs ( then IS ) )              => sequenceInstrs(C) ~> if OID TDECLS IS          end ... </instrs>
-    rule <instrs> ( if                TDECLS:TypeDecls C:Instrs ( then IS ) ( else IS' ) ) => sequenceInstrs(C) ~> if     TDECLS IS else IS' end ... </instrs>
-    rule <instrs> ( if  ID:Identifier TDECLS:TypeDecls C:Instrs ( then IS ) ( else IS' ) ) => sequenceInstrs(C) ~> if  ID TDECLS IS else IS' end ... </instrs>
-
-    syntax FoldedInstr ::= "(" "loop" OptionalId TypeDecls Instrs ")"
- // -----------------------------------------------------------------
-    rule <instrs> ( loop               TDECLS:TypeDecls IS ) => loop    TDECLS IS end ... </instrs>
-    rule <instrs> ( loop ID:Identifier TDECLS:TypeDecls IS ) => loop ID TDECLS IS end ... </instrs>
-```
-
 ### Identifiers
 
 When we want to specify an identifier, we can do so with the following helper function.
@@ -168,65 +128,6 @@ We also enable context lookups with identifiers.
  // ---------------------------
     rule #ContextLookup(IDS:Map, ID:Identifier) => {IDS [ ID ]}:>Int
       requires ID in_keys(IDS)
-```
-
-### Block Instructions
-TOD: Remove the rules in this section
-In the text format, block instructions can have identifiers attached to them, and branch instructions can refer to these identifiers.
-The `<labelIds>` cell maps labels to the depth at which they occur.
-To ensure the bookkeeping mapping in `<labelIds>` is properly updated when branching, we don't make a new `Label` production, but instead a different one: `IdLabel`.
-
-Branching with an identifier is the same as branching to the label with that identifier.
-The correct label index is calculated by looking at whih depth the index occured and what depth execution is currently at.
-
-```k
-    rule <instrs> br ID:Identifier => br DEPTH -Int DEPTH' -Int 1 ... </instrs>
-         <labelDepth> DEPTH </labelDepth>
-         <labelIds> ... ID |-> DEPTH' ... </labelIds>
-```
-
-Finally, we introduce the text format block instructions, which may have identifiers after each keyword.
-If more than one identifier is present, they all have to agree (they are just there to make clear what if-block they belong to).
-If identifiers are used, one must occur after the initial keyword (`block`, `if` or `loop`).
-
-```k
-    syntax Instr ::= BlockInstr
- // ---------------------------
-
-    syntax BlockInstr ::= "block" Identifier TypeDecls Instrs "end" OptionalId
- // --------------------------------------------------------------------------
-    rule <instrs> block ID:Identifier TDECLS IS end OID':OptionalId => block TDECLS IS end ... </instrs>
-         <labelDepth> DEPTH </labelDepth>
-         <labelIds> IDS => IDS[ID <- DEPTH] </labelIds>
-      requires ID ==K OID'
-        orBool notBool isIdentifier(OID')
-
-    syntax BlockInstr ::= "loop" Identifier TypeDecls Instrs "end" OptionalId
- // -------------------------------------------------------------------------
-    rule <instrs> loop ID:Identifier TDECLS:TypeDecls IS end OID':OptionalId => loop TDECLS IS end ... </instrs>
-         <labelDepth> DEPTH </labelDepth>
-         <labelIds> IDS => IDS[ID <- DEPTH] </labelIds>
-      requires ID ==K OID'
-        orBool notBool isIdentifier(OID')
-```
-
-In the text format, it is also allowed to have a conditional without the `else` branch.
-
-```k
-    syntax BlockInstr ::= "if" Identifier TypeDecls Instrs "else" OptionalId Instrs "end" OptionalId
-                        | "if" OptionalId TypeDecls Instrs                          "end" OptionalId
- // ------------------------------------------------------------------------------------------------
-    rule <instrs> if TDECLS:TypeDecls IS end => if TDECLS IS else .Instrs end ... </instrs>
-
-    rule <instrs> if ID:Identifier TDECLS:TypeDecls IS end OID'':OptionalId => if ID TDECLS IS else ID .Instrs end ID ... </instrs>
-      requires ID ==K OID''
-        orBool notBool isIdentifier(OID'')
-
-    rule <instrs> if ID:Identifier TDECLS:TypeDecls IS else OID':OptionalId IS' end OID'':OptionalId => if TDECLS:TypeDecls IS else IS' end ... </instrs>
-         <labelDepth> DEPTH </labelDepth>
-         <labelIds> IDS => IDS[ID <- DEPTH] </labelIds>
-      requires ( ID ==K OID'  orBool notBool isIdentifier(OID')  )
-       andBool ( ID ==K OID'' orBool notBool isIdentifier(OID'') )
 ```
 
 ### Types
@@ -465,9 +366,52 @@ Since the inserted type is module-level, any subsequent functions declaring the 
                     | #unfoldInstrs ( Instrs, Int, Map ) [function]
  // ---------------------------------------------------------------
     rule  unfoldInstrs(IS) => #unfoldInstrs(IS, 0, .Map)
-
     rule #unfoldInstrs(.Instrs, _, _) => .Instrs
+    rule #unfoldInstrs(I IS, DEPTH, M) => I #unfoldInstrs(IS, DEPTH, M) [owise]
+```
 
+##### Folded Instructions
+
+TODO: Remove rules
+Folded instructions are a syntactic sugar where expressions can be grouped using parentheses for higher readability.
+
+```k
+    syntax Instr ::= FoldedInstr
+ // ----------------------------
+```
+
+One type of folded instruction are `PlainInstr`s wrapped in parentheses and optionally includes nested folded instructions to indicate its operands.
+
+```k
+    syntax FoldedInstr ::= "(" PlainInstr Instrs ")"
+                         | "(" PlainInstr        ")" [prefer]
+ // ---------------------------------------------------------
+    rule <instrs> ( PI:PlainInstr IS:Instrs ):FoldedInstr => sequenceInstrs(IS) ~> PI ... </instrs>
+    rule <instrs> ( PI:PlainInstr           ):FoldedInstr =>                       PI ... </instrs>
+```
+
+Another type of folded instruction is control flow blocks wrapped in parentheses, in which case the `end` keyword is omitted.
+
+```k
+    syntax FoldedInstr ::= "(" "block" OptionalId TypeDecls Instrs ")"
+ // ------------------------------------------------------------------
+    rule <instrs> ( block               TDECLS:TypeDecls INSTRS:Instrs ) => block    TDECLS INSTRS end ... </instrs>
+    rule <instrs> ( block ID:Identifier TDECLS:TypeDecls INSTRS:Instrs ) => block ID TDECLS INSTRS end ... </instrs>
+
+    syntax FoldedInstr ::= "(" "if" OptionalId TypeDecls Instrs "(" "then" Instrs ")" ")"
+                         | "(" "if" OptionalId TypeDecls Instrs "(" "then" Instrs ")" "(" "else" Instrs ")" ")"
+ // -----------------------------------------------------------------------------------------------------------
+    rule <instrs> ( if OID:OptionalId TDECLS:TypeDecls C:Instrs ( then IS ) )              => sequenceInstrs(C) ~> if OID TDECLS IS          end ... </instrs>
+    rule <instrs> ( if                TDECLS:TypeDecls C:Instrs ( then IS ) ( else IS' ) ) => sequenceInstrs(C) ~> if     TDECLS IS else IS' end ... </instrs>
+    rule <instrs> ( if  ID:Identifier TDECLS:TypeDecls C:Instrs ( then IS ) ( else IS' ) ) => sequenceInstrs(C) ~> if  ID TDECLS IS else IS' end ... </instrs>
+
+    syntax FoldedInstr ::= "(" "loop" OptionalId TypeDecls Instrs ")"
+ // -----------------------------------------------------------------
+    rule <instrs> ( loop               TDECLS:TypeDecls IS ) => loop    TDECLS IS end ... </instrs>
+    rule <instrs> ( loop ID:Identifier TDECLS:TypeDecls IS ) => loop ID TDECLS IS end ... </instrs>
+```
+
+```k
     rule #unfoldInstrs(( PI:PlainInstr  IS:Instrs ):FoldedInstr IS', DEPTH, M)
       =>             (#unfoldInstrs(IS        , DEPTH, M)
          appendInstrs #unfoldInstrs(PI .Instrs, DEPTH, M))
@@ -475,7 +419,61 @@ Since the inserted type is module-level, any subsequent functions declaring the 
     rule #unfoldInstrs(( PI:PlainInstr            ):FoldedInstr IS', DEPTH, M)
       =>              #unfoldInstrs(PI .Instrs, DEPTH, M)
          appendInstrs #unfoldInstrs(IS'       , DEPTH, M)
+```
 
+##### Block Instructions
+
+In the text format, block instructions can have identifiers attached to them, and branch instructions can refer to these identifiers.
+Branching with an identifier is the same as branching to the label with that identifier.
+The correct label index is calculated by looking at whih depth the index occured and what depth execution is currently at.
+
+Conceptually, `br ID => br CURRENT_EXECUTION_DEPTH -Int IDENTIFIER_LABEL_DEPTH -Int 1`.
+
+There are several syntactic sugars for block instructions, some of which may have identifiers.
+The same identifier can optionally be repeated at the end of the block instruction (to mark which block is ending) and on the branches in an `if`.
+
+TODO: Remove rules.
+```k
+    syntax Instr ::= BlockInstr
+ // ---------------------------
+
+    syntax BlockInstr ::= "block" Identifier TypeDecls Instrs "end" OptionalId
+ // --------------------------------------------------------------------------
+    rule <instrs> block ID:Identifier TDECLS IS end OID':OptionalId => block TDECLS IS end ... </instrs>
+         <labelDepth> DEPTH </labelDepth>
+         <labelIds> IDS => IDS[ID <- DEPTH] </labelIds>
+      requires ID ==K OID'
+        orBool notBool isIdentifier(OID')
+
+    syntax BlockInstr ::= "loop" Identifier TypeDecls Instrs "end" OptionalId
+ // -------------------------------------------------------------------------
+    rule <instrs> loop ID:Identifier TDECLS:TypeDecls IS end OID':OptionalId => loop TDECLS IS end ... </instrs>
+         <labelDepth> DEPTH </labelDepth>
+         <labelIds> IDS => IDS[ID <- DEPTH] </labelIds>
+      requires ID ==K OID'
+        orBool notBool isIdentifier(OID')
+```
+
+In the text format, it is also allowed to have a conditional without the `else` branch.
+
+```k
+    syntax BlockInstr ::= "if" Identifier TypeDecls Instrs "else" OptionalId Instrs "end" OptionalId
+                        | "if" OptionalId TypeDecls Instrs                          "end" OptionalId
+ // ------------------------------------------------------------------------------------------------
+    rule <instrs> if TDECLS:TypeDecls IS end => if TDECLS IS else .Instrs end ... </instrs>
+
+    rule <instrs> if ID:Identifier TDECLS:TypeDecls IS end OID'':OptionalId => if ID TDECLS IS else ID .Instrs end ID ... </instrs>
+      requires ID ==K OID''
+        orBool notBool isIdentifier(OID'')
+
+    rule <instrs> if ID:Identifier TDECLS:TypeDecls IS else OID':OptionalId IS' end OID'':OptionalId => if TDECLS:TypeDecls IS else IS' end ... </instrs>
+         <labelDepth> DEPTH </labelDepth>
+         <labelIds> IDS => IDS[ID <- DEPTH] </labelIds>
+      requires ( ID ==K OID'  orBool notBool isIdentifier(OID')  )
+       andBool ( ID ==K OID'' orBool notBool isIdentifier(OID'') )
+```
+
+```k
     rule #unfoldInstrs(((block ID:Identifier TDS IS)          => block ID TDS IS end) _IS', _DEPTH, _M)
     rule #unfoldInstrs(((block               TDS IS)          => block    TDS IS end) _IS', _DEPTH, _M)
     rule #unfoldInstrs( (block ID:Identifier TDS IS end _OID' => block    TDS IS end) _IS',  DEPTH,  M => M [ ID <- DEPTH ])
@@ -499,14 +497,15 @@ syntax Instr ::= "testy" Identifier Int Map Int
     rule #unfoldInstrs(br_if    ID:Identifier  IS, DEPTH, M) => br_if    DEPTH -Int {M [ ID ]}:>Int -Int 1 #unfoldInstrs(IS, DEPTH, M)
     rule #unfoldInstrs(br_table ES:ElemSegment IS, DEPTH, M) => br_table elemSegment2Indices(ES, DEPTH, M) #unfoldInstrs(IS, DEPTH, M)
 
-    rule #unfoldInstrs(I IS, DEPTH, M) => I #unfoldInstrs(IS, DEPTH, M) [owise]
 
     syntax ElemSegment ::= elemSegment2Indices( ElemSegment, Int, Map ) [function]
  // ------------------------------------------------------------------------------
     rule elemSegment2Indices(.ElemSegment    , _DEPTH, _M) => .ElemSegment
     rule elemSegment2Indices(ID:Identifier ES,  DEPTH,  M) => DEPTH -Int {M [ ID ]}:>Int -Int 1 elemSegment2Indices(ES, DEPTH, M)
     rule elemSegment2Indices(E             ES,  DEPTH,  M) => E                                 elemSegment2Indices(ES, DEPTH, M) [owise]
+```
 
+```k
     syntax Instrs ::= Instrs "appendInstrs" Instrs      [function]
                     | #appendInstrs  ( Instrs, Instrs ) [function]
                     | #reverseInstrs ( Instrs, Instrs ) [function]

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -468,8 +468,8 @@ Since the inserted type is module-level, any subsequent functions declaring the 
 
     rule #unfoldInstrs(.Instrs, _, _) => .Instrs
 
-    rule #unfoldInstrs(( PI:PlainInstr  IS:Instrs ):FoldedInstr IS', DEPTH, M) => IS appendInstrs (PI #unfoldInstrs(IS', DEPTH, M))
-    rule #unfoldInstrs(( PI:PlainInstr            ):FoldedInstr IS', DEPTH, M) =>                  PI #unfoldInstrs(IS', DEPTH, M)
+    rule #unfoldInstrs(( PI:PlainInstr  IS:Instrs ):FoldedInstr IS', DEPTH, M) => IS appendInstrs PI #unfoldInstrs(IS', DEPTH, M)
+    rule #unfoldInstrs(( PI:PlainInstr            ):FoldedInstr IS', DEPTH, M) =>                 PI #unfoldInstrs(IS', DEPTH, M)
 
     rule #unfoldInstrs(((block ID:Identifier TDS IS)          => block ID TDS IS end) _IS', _DEPTH, _M)
     rule #unfoldInstrs(((block               TDS IS)          => block    TDS IS end) _IS', _DEPTH, _M)


### PR DESCRIPTION
This unfolds (normalizes) all instructions in function bodies during the unfolding pass.
This makes later traversal easier and it removes `#ContextLookup` for block instructions.