### PR TITLE
Elrond-related fixes to unfolding

### DIFF
--- a/test.md
+++ b/test.md
@@ -65,15 +65,7 @@ We allow writing instructions at the top level in the test embedder.
 Auxiliary
 ---------
 
-Here we extend the sort `Stmt` by adding a new subsort called `Auxil`.
-This subsort contains Auxiliary functions that only used in our KWASM semantics but not in the official specification including assertions, initializing a global variable and the invocation of a function by exported name.
-
-```k
-    syntax Stmt ::= Auxil
- // ---------------------
-```
-
-We also add `token` as a value in order to implement some test assertions.
+We add `token` as a value in order to implement some test assertions.
 
 ```k
     syntax Val ::= "token"
@@ -527,12 +519,14 @@ endmodule
 
 ```k
 module WASM-AUXIL
+    imports WASM
 ```
 
 Generally useful commands that are not part of the actual Wasm semantics.
 
 ```k
-    imports WASM
+    syntax Stmt ::= Auxil
+ // ---------------------
 
     syntax Auxil ::= "#clearConfig"
  // -------------------------------

--- a/test.md
+++ b/test.md
@@ -16,6 +16,7 @@ module WASM-TEST-SYNTAX
 endmodule
 
 module WASM-TEST
+    imports WASM-AUXIL
     imports WASM-TEXT
 ```
 
@@ -502,7 +503,37 @@ These assertions act on the last module defined.
 
 The modules are cleaned all together after the test file is executed.
 
+Registry Assertations
+---------------------
+
+We also want to be able to test that the embedder's registration function is working.
+
 ```k
+    syntax Assertion ::= "#assertRegistrationUnnamed" WasmString            WasmString
+                       | "#assertRegistrationNamed"   WasmString Identifier WasmString
+ // ----------------------------------------------------------------------------------
+    rule <instrs> #assertRegistrationUnnamed REGNAME _ => . ... </instrs>
+         <modIdx> IDX </modIdx>
+         <moduleRegistry> ... REGNAME |-> IDX ...  </moduleRegistry>
+
+    rule <instrs> #assertRegistrationNamed REGNAME _NAME _ => . ... </instrs>
+         <modIdx> IDX </modIdx>
+         <moduleRegistry> ... REGNAME |-> IDX ...  </moduleRegistry>
+```
+
+```k
+endmodule
+```
+
+```k
+module WASM-AUXIL
+```
+
+Generally useful commands that are not part of the actual Wasm semantics.
+
+```k
+    imports WASM
+
     syntax Auxil ::= "#clearConfig"
  // -------------------------------
     rule <instrs> #clearConfig => . ...     </instrs>
@@ -523,24 +554,6 @@ The modules are cleaned all together after the test file is executed.
            <nextGlobAddr>    _ => 0         </nextGlobAddr>
            <globals>         _ => .Bag      </globals>
          </mainStore>
-```
-
-Registry Assertations
----------------------
-
-We also want to be able to test that the embedder's registration function is working.
-
-```k
-    syntax Assertion ::= "#assertRegistrationUnnamed" WasmString            WasmString
-                       | "#assertRegistrationNamed"   WasmString Identifier WasmString
- // ----------------------------------------------------------------------------------
-    rule <instrs> #assertRegistrationUnnamed REGNAME _ => . ... </instrs>
-         <modIdx> IDX </modIdx>
-         <moduleRegistry> ... REGNAME |-> IDX ...  </moduleRegistry>
-
-    rule <instrs> #assertRegistrationNamed REGNAME _NAME _ => . ... </instrs>
-         <modIdx> IDX </modIdx>
-         <moduleRegistry> ... REGNAME |-> IDX ...  </moduleRegistry>
 ```
 
 ```k

--- a/tests/simple/table.wast
+++ b/tests/simple/table.wast
@@ -27,6 +27,16 @@
 #assertTable 0 4 .Int "table two with elements"
 
 (module
+  ( elem (i32.const 1) func $f $g)
+  ( table 4 funcref)
+  (func $f) (func $g)
+)
+
+#assertTableElem (1, 5) "table elem 1"
+#assertTableElem (2, 6) "table elem 2"
+#assertTable 0 4 .Int "table two with elements"
+
+(module
   (type $out-i32 (func (result i32)))
   (table $tab 10 funcref)
   (elem (i32.const 8) $const-i32-a)
@@ -57,8 +67,8 @@
 #assertFunction 2 [ ] -> [ i32 ] [ ] "call function 3 exists"
 #assertFunction 3 [ ] -> [ i32 ] [ ] "call function 4 exists"
 #assertFunction 4 [ ] -> [ i32 ] [ ] "call function 5 exists"
-#assertTableElem (8, 5) "table elem 8"
-#assertTableElem (9, 6) "table elem 9"
+#assertTableElem (8, 7) "table elem 8"
+#assertTableElem (9, 8) "table elem 9"
 #assertTable $tab 10 .Int "table three with elements"
 
 #clearConfig

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -353,10 +353,11 @@ Since the inserted type is module-level, any subsequent functions declaring the 
 #### Element Segments
 
 ```k
-    syntax ElemDefn ::= "(" "elem" Offset ElemSegment ")"
- // -----------------------------------------------------
-    rule #unfoldDefns(( elem OFFSET:Offset ES ) DS, I, M)
-      => ( elem 0 OFFSET ES ) #unfoldDefns(DS, I, M)
+    syntax ElemDefn ::= "(" "elem" Offset        ElemSegment ")"
+                      | "(" "elem" Offset "func" ElemSegment ")"
+ // -----------------------------------------------------------
+    rule #unfoldDefns(((elem OFFSET func ES) => (elem OFFSET ES)) _DS, _I, _M)
+    rule #unfoldDefns(((elem OFFSET:Offset ES ) => ( elem 0 OFFSET ES )) _DS, _I, _M)
 ```
 
 #### Instructions

--- a/wasm.md
+++ b/wasm.md
@@ -639,11 +639,9 @@ The importing and exporting parts of specifications are dealt with in the respec
 ```k
     syntax Defn     ::= FuncDefn
     syntax FuncDefn ::= #func(type: Int, locals: VecType, body: Instrs, metadata: FuncMetadata)
-    syntax Alloc    ::= allocfunc ( Int , VecType , Instrs , FuncMetadata )
- // -----------------------------------------------------------------------
-    rule <instrs> #func(... type: TYPIDX, locals: LOCALS, body: INSTRS, metadata: META) => allocfunc(TYPIDX, LOCALS, INSTRS, META) ... </instrs>
-
-    rule <instrs> allocfunc(TYPIDX, LOCALS, INSTRS, #meta(... id: OID, localIds: LIDS)) => . ... </instrs>
+    syntax Alloc    ::= allocfunc ( Int , Int , FuncType , VecType , Instrs , FuncMetadata )
+ // ----------------------------------------------------------------------------------------
+    rule <instrs> #func(... type: TYPIDX, locals: LOCALS, body: INSTRS, metadata: META) => allocfunc(CUR, NEXTADDR, TYPE, LOCALS, INSTRS, META) ... </instrs>
          <curModIdx> CUR </curModIdx>
          <moduleInst>
            <modIdx> CUR </modIdx>
@@ -653,14 +651,16 @@ The importing and exporting parts of specifications are dealt with in the respec
            ...
          </moduleInst>
          <nextFuncAddr> NEXTADDR => NEXTADDR +Int 1 </nextFuncAddr>
+
+    rule <instrs> allocfunc(MOD, ADDR, TYPE, LOCALS, INSTRS, #meta(... id: OID, localIds: LIDS)) => . ... </instrs>
          <funcs>
            ( .Bag
           => <funcDef>
-               <fAddr>    NEXTADDR </fAddr>
+               <fAddr>    ADDR </fAddr>
                <fCode>    INSTRS   </fCode>
                <fType>    TYPE     </fType>
                <fLocal>   LOCALS   </fLocal>
-               <fModInst> CUR      </fModInst>
+               <fModInst> MOD      </fModInst>
                <funcMetadata>
                  <funcId> OID </funcId>
                  <localIds> LIDS </localIds>


### PR DESCRIPTION
* Allow `elem` declarations to have the keyword `func` in them
* Specify in `allocfunc` where the function should be stored
* Unfold instructions inlined into `offset`s.
* Unfold global initializers.
* Break out `#clearConfig` from the testing module, so that it can be used without importing all of the testing module.