### PR TITLE
introduce BlockMetaData for measureing wasm coverage

### DIFF
--- a/binary-parser/kwasm_ast.py
+++ b/binary-parser/kwasm_ast.py
@@ -154,14 +154,14 @@ def global_type(mut, valtype):
 NOP = KApply('aNop', [])
 UNREACHABLE = KApply('aUnreachable', [])
 
-def BLOCK(vec_type, instrs):
-    return KApply('aBlock', [vec_type, instrs])
+def BLOCK(vec_type, instrs, block_info):
+    return KApply('aBlock', [vec_type, instrs, block_info])
 
-def IF(vec_type, then_instrs, else_instrs):
-    return KApply('aIf', [vec_type, then_instrs, else_instrs])
+def IF(vec_type, then_instrs, else_instrs, block_info):
+    return KApply('aIf', [vec_type, then_instrs, else_instrs, block_info])
 
-def LOOP(vec_type, instrs):
-    return KApply('aLoop', [vec_type, instrs])
+def LOOP(vec_type, instrs, block_info):
+    return KApply('aLoop', [vec_type, instrs, block_info])
 
 RETURN = KApply('aReturn', [])
 

--- a/binary-parser/wasm2kast.py
+++ b/binary-parser/wasm2kast.py
@@ -123,7 +123,7 @@ def instr(i):
         iis = instrs(i.instructions)
         res = vec_type(i.result_type)
         block_id += 1
-        return a.BLOCK(res, iis, a.KApply("blockInfo", [a.KInt(block_id)]))
+        return a.BLOCK(res, iis, a.KInt(block_id))
     if i.opcode == B.BR:
         return a.BR(i.label_idx)
     if i.opcode == B.BR_IF:
@@ -163,7 +163,7 @@ def instr(i):
         els = instrs(i.else_instructions)
         res = vec_type(i.result_type)
         block_id += 1
-        return a.IF(res, thens, els, a.KApply("blockInfo", [a.KInt(block_id)]))
+        return a.IF(res, thens, els, a.KInt(block_id))
     if i.opcode == B.F32_STORE:
         return a.F32_STORE(i.memarg.offset)
     if i.opcode == B.F64_STORE:
@@ -214,7 +214,7 @@ def instr(i):
         iis = instrs(i.instructions)
         res = vec_type(i.result_type)
         block_id += 1
-        return a.LOOP(res, iis, a.KApply("blockInfo", [a.KInt(block_id)]))
+        return a.LOOP(res, iis, a.KInt(block_id))
     if i.opcode == B.SET_GLOBAL:
         return a.SET_GLOBAL(i.global_idx)
     if i.opcode == B.SET_LOCAL:

--- a/binary-parser/wasm2kast.py
+++ b/binary-parser/wasm2kast.py
@@ -104,6 +104,8 @@ def export(e : Export):
 # Instrs #
 ##########
 
+block_id = 0
+
 def instrs(iis):
     """Turn a list of instructions into KAST."""
     # We ignore `END`.
@@ -116,10 +118,12 @@ def instrs(iis):
 
 def instr(i):
     B = BinaryOpcode
+    global block_id
     if i.opcode == B.BLOCK:
         iis = instrs(i.instructions)
         res = vec_type(i.result_type)
-        return a.BLOCK(res, iis)
+        block_id += 1
+        return a.BLOCK(res, iis, a.KApply("blockInfo", [a.KInt(block_id)]))
     if i.opcode == B.BR:
         return a.BR(i.label_idx)
     if i.opcode == B.BR_IF:
@@ -158,7 +162,8 @@ def instr(i):
         thens = instrs(i.instructions)
         els = instrs(i.else_instructions)
         res = vec_type(i.result_type)
-        return a.IF(res, thens, els)
+        block_id += 1
+        return a.IF(res, thens, els, a.KApply("blockInfo", [a.KInt(block_id)]))
     if i.opcode == B.F32_STORE:
         return a.F32_STORE(i.memarg.offset)
     if i.opcode == B.F64_STORE:
@@ -208,7 +213,8 @@ def instr(i):
     if i.opcode == B.LOOP:
         iis = instrs(i.instructions)
         res = vec_type(i.result_type)
-        return a.LOOP(res, iis)
+        block_id += 1
+        return a.LOOP(res, iis, a.KApply("blockInfo", [a.KInt(block_id)]))
     if i.opcode == B.SET_GLOBAL:
         return a.SET_GLOBAL(i.global_idx)
     if i.opcode == B.SET_LOCAL:

--- a/tests/proofs/loops-spec.k
+++ b/tests/proofs/loops-spec.k
@@ -18,7 +18,8 @@ module LOOPS-SPEC
                          #local.tee(0)
                          ITYPE.eqz
                          #br_if(1)
-                         #br(0)
+                         #br(0),
+                         _
                        )
                     }
                     .ValStack
@@ -50,8 +51,10 @@ module LOOPS-SPEC
                       #local.tee(0)
                       ITYPE.eqz
                       #br_if(1)
-                      #br(0)
-                 )
+                      #br(0),
+                      _
+                 ),
+                 _
               )
            => .
            ...

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -979,9 +979,9 @@ There are several formats of block instructions, and the text-to-abstract transf
 At this point, all branching identifiers should have been resolved, so we can remove the id.
 
 ```k
-    rule #t2aInstr<C>( block _OID:OptionalId TDS:TypeDecls IS end _OID') => #block(gatherTypes(result, TDS), #t2aInstrs<C>(IS), #blockInfo(-1))
-    rule #t2aInstr<C>( loop  _OID:OptionalId TDS IS end _OID') => #loop(gatherTypes(result, TDS), #t2aInstrs<C>(IS), #blockInfo(-1))
-    rule #t2aInstr<C>( if    _OID:OptionalId TDS IS else _OID':OptionalId IS' end _OID'') => #if(gatherTypes(result, TDS), #t2aInstrs<C>(IS), #t2aInstrs<C>(IS'), #blockInfo(-1))
+    rule #t2aInstr<C>( block _OID:OptionalId TDS:TypeDecls IS end _OID') => #block(gatherTypes(result, TDS), #t2aInstrs<C>(IS), .Int)
+    rule #t2aInstr<C>( loop  _OID:OptionalId TDS IS end _OID') => #loop(gatherTypes(result, TDS), #t2aInstrs<C>(IS), .Int)
+    rule #t2aInstr<C>( if    _OID:OptionalId TDS IS else _OID':OptionalId IS' end _OID'') => #if(gatherTypes(result, TDS), #t2aInstrs<C>(IS), #t2aInstrs<C>(IS'), .Int)
 ```
 
 #### KWasm Administrative Instructions

--- a/wasm-text.md
+++ b/wasm-text.md
@@ -979,9 +979,9 @@ There are several formats of block instructions, and the text-to-abstract transf
 At this point, all branching identifiers should have been resolved, so we can remove the id.
 
 ```k
-    rule #t2aInstr<C>( block _OID:OptionalId TDS:TypeDecls IS end _OID') => #block(gatherTypes(result, TDS), #t2aInstrs<C>(IS))
-    rule #t2aInstr<C>( loop  _OID:OptionalId TDS IS end _OID') => #loop(gatherTypes(result, TDS), #t2aInstrs<C>(IS))
-    rule #t2aInstr<C>( if    _OID:OptionalId TDS IS else _OID':OptionalId IS' end _OID'') => #if(gatherTypes(result, TDS), #t2aInstrs<C>(IS), #t2aInstrs<C>(IS'))
+    rule #t2aInstr<C>( block _OID:OptionalId TDS:TypeDecls IS end _OID') => #block(gatherTypes(result, TDS), #t2aInstrs<C>(IS), #blockInfo(-1))
+    rule #t2aInstr<C>( loop  _OID:OptionalId TDS IS end _OID') => #loop(gatherTypes(result, TDS), #t2aInstrs<C>(IS), #blockInfo(-1))
+    rule #t2aInstr<C>( if    _OID:OptionalId TDS IS else _OID':OptionalId IS' end _OID'') => #if(gatherTypes(result, TDS), #t2aInstrs<C>(IS), #t2aInstrs<C>(IS'), #blockInfo(-1))
 ```
 
 #### KWasm Administrative Instructions
@@ -992,7 +992,7 @@ They are currently supported in KWasm text files, but may be deprecated.
 ```k
     rule #t2aInstr<_C>(trap) => trap
 
-    rule #t2aInstr<C>(#block(VT:VecType, IS:Instrs)) => #block(VT, #t2aInstrs<C>(IS))
+    rule #t2aInstr<C>(#block(VT:VecType, IS:Instrs, BLOCKINFO)) => #block(VT, #t2aInstrs<C>(IS), BLOCKINFO)
 
     rule #t2aInstr<_>(init_local I V) => init_local I V
     rule #t2aInstr<_>(init_locals VS) => init_locals VS

--- a/wasm.md
+++ b/wasm.md
@@ -434,9 +434,13 @@ It simply executes the block then records a label with an empty continuation.
     rule <instrs> label [ TYPES ] { _ } VALSTACK' => . ... </instrs>
          <valstack> VALSTACK => #take(lengthValTypes(TYPES), VALSTACK) ++ VALSTACK' </valstack>
 
-    syntax Instr ::= #block(VecType, Instrs) [klabel(aBlock), symbol]
- // ------------------------------------------------------------------
-    rule <instrs> #block(VECTYP, IS) => sequenceInstrs(IS) ~> label VECTYP { .Instrs } VALSTACK ... </instrs>
+    syntax BlockMetaData ::= #funcBlockInfo ( Int ) [klabel(funcBlockInfo), symbol]
+                           | #blockInfo     ( Int ) [klabel(blockInfo), symbol]
+ // ---------------------------------------------------------------------------
+
+    syntax Instr ::= #block(VecType, Instrs, BlockMetaData) [klabel(aBlock), symbol]
+ // --------------------------------------------------------------------------------
+    rule <instrs> #block(VECTYP, IS, _) => sequenceInstrs(IS) ~> label VECTYP { .Instrs } VALSTACK ... </instrs>
          <valstack> VALSTACK => .ValStack </valstack>
 ```
 
@@ -472,19 +476,19 @@ Note that, unlike in the WebAssembly specification document, we do not need the 
 Finally, we have the conditional and loop instructions.
 
 ```k
-    syntax Instr ::= #if( VecType, then : Instrs, else : Instrs) [klabel(aIf), symbol]
- // ----------------------------------------------------------------------------------
-    rule <instrs> #if(VECTYP, IS, _)  => sequenceInstrs(IS) ~> label VECTYP { .Instrs } VALSTACK ... </instrs>
+    syntax Instr ::= #if( VecType, then : Instrs, else : Instrs, blockInfo: BlockMetaData) [klabel(aIf), symbol]
+ // ------------------------------------------------------------------------------------------------------------
+    rule <instrs> #if(VECTYP, IS, _, _)  => sequenceInstrs(IS) ~> label VECTYP { .Instrs } VALSTACK ... </instrs>
          <valstack> < i32 > VAL : VALSTACK => VALSTACK </valstack>
       requires VAL =/=Int 0
 
-    rule <instrs> #if(VECTYP, _, IS) => sequenceInstrs(IS) ~> label VECTYP { .Instrs } VALSTACK ... </instrs>
+    rule <instrs> #if(VECTYP, _, IS, _) => sequenceInstrs(IS) ~> label VECTYP { .Instrs } VALSTACK ... </instrs>
          <valstack> < i32 > VAL : VALSTACK => VALSTACK </valstack>
       requires VAL ==Int 0
 
-    syntax Instr ::= #loop(VecType, Instrs) [klabel(aLoop), symbol]
- // ---------------------------------------------------------------
-    rule <instrs> #loop(VECTYP, IS) => sequenceInstrs(IS) ~> label VECTYP { #loop(VECTYP, IS) } VALSTACK ... </instrs>
+    syntax Instr ::= #loop(VecType, Instrs, BlockMetaData) [klabel(aLoop), symbol]
+ // ------------------------------------------------------------------------------
+    rule <instrs> #loop(VECTYP, IS, BLOCKMETA) => sequenceInstrs(IS) ~> label VECTYP { #loop(VECTYP, IS, BLOCKMETA) } VALSTACK ... </instrs>
          <valstack> VALSTACK => .ValStack </valstack>
 ```
 
@@ -745,7 +749,7 @@ The `#take` function will return the parameter stack in the reversed order, then
  // -------------------------------------
     rule <instrs> ( invoke FADDR )
                => init_locals #revs(#take(lengthValTypes(TDOMAIN), VALSTACK)) ++ #zero(TLOCALS)
-               ~> #block([TRANGE], INSTRS)
+               ~> #block([TRANGE], INSTRS, #funcBlockInfo(FADDR))
                ~> frame MODIDX TRANGE #drop(lengthValTypes(TDOMAIN), VALSTACK) LOCAL
                ...
          </instrs>

--- a/wasm.md
+++ b/wasm.md
@@ -434,9 +434,8 @@ It simply executes the block then records a label with an empty continuation.
     rule <instrs> label [ TYPES ] { _ } VALSTACK' => . ... </instrs>
          <valstack> VALSTACK => #take(lengthValTypes(TYPES), VALSTACK) ++ VALSTACK' </valstack>
 
-    syntax BlockMetaData ::= #funcBlockInfo ( Int ) [klabel(funcBlockInfo), symbol]
-                           | #blockInfo     ( Int ) [klabel(blockInfo), symbol]
- // ---------------------------------------------------------------------------
+    syntax BlockMetaData ::= OptionalInt
+ // ------------------------------------
 
     syntax Instr ::= #block(VecType, Instrs, BlockMetaData) [klabel(aBlock), symbol]
  // --------------------------------------------------------------------------------
@@ -749,7 +748,7 @@ The `#take` function will return the parameter stack in the reversed order, then
  // -------------------------------------
     rule <instrs> ( invoke FADDR )
                => init_locals #revs(#take(lengthValTypes(TDOMAIN), VALSTACK)) ++ #zero(TLOCALS)
-               ~> #block([TRANGE], INSTRS, #funcBlockInfo(FADDR))
+               ~> #block([TRANGE], INSTRS, .Int)
                ~> frame MODIDX TRANGE #drop(lengthValTypes(TDOMAIN), VALSTACK) LOCAL
                ...
          </instrs>


### PR DESCRIPTION
We introduce
```
    syntax BlockMetaData ::= #funcBlockInfo ( Int ) [klabel(funcBlockInfo), symbol]
                                            | #blockInfo     ( Int ) [klabel(blockInfo), symbol]
```
In wasm_kast.py, we can only assign a unique #blockInfo(block_id) to #block, #if and #loop, not the function.

the `#funcBlockInfo` is used in the following rule
```
    rule <instrs> ( invoke FADDR )
               => init_locals #revs(#take(lengthValTypes(TDOMAIN), VALSTACK)) ++ #zero(TLOCALS)
               ~> #block([TRANGE], INSTRS, #funcBlockInfo(FADDR))
               ~> frame MODIDX TRANGE #drop(lengthValTypes(TDOMAIN), VALSTACK) LOCAL
               ...
         </instrs>
```
