### PR TITLE
Using '+=' instead of '=' when setting KPROVE_OPTS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,10 +137,10 @@ KPROVE_MODULE := KWASM-LEMMAS
 KPROVE_OPTS   :=
 
 tests/proofs/functions-spec.k.prove: KPROVE_MODULE = FUNCTIONS-LEMMAS
-tests/proofs/functions-spec.k.prove: KPROVE_OPTS   = --concrete-rules WASM-DATA.wrap-Positive,WASM-DATA.setRange-Positive,WASM-DATA.getRange-Positive
-tests/proofs/memory-spec.k.prove:    KPROVE_OPTS   = --concrete-rules WASM-DATA.wrap-Positive,WASM-DATA.setRange-Positive,WASM-DATA.getRange-Positive
+tests/proofs/functions-spec.k.prove: KPROVE_OPTS   += --concrete-rules WASM-DATA.wrap-Positive,WASM-DATA.setRange-Positive,WASM-DATA.getRange-Positive
+tests/proofs/memory-spec.k.prove:    KPROVE_OPTS   += --concrete-rules WASM-DATA.wrap-Positive,WASM-DATA.setRange-Positive,WASM-DATA.getRange-Positive
 tests/proofs/wrc20-spec.k.prove:     KPROVE_MODULE = WRC20-LEMMAS
-tests/proofs/wrc20-spec.k.prove:     KPROVE_OPTS   = --concrete-rules WASM-DATA.wrap-Positive,WASM-DATA.setRange-Positive,WASM-DATA.getRange-Positive,WASM-DATA.get-Existing,WASM-DATA.set-Extend
+tests/proofs/wrc20-spec.k.prove:     KPROVE_OPTS   += --concrete-rules WASM-DATA.wrap-Positive,WASM-DATA.setRange-Positive,WASM-DATA.getRange-Positive,WASM-DATA.get-Existing,WASM-DATA.set-Extend
 
 test: test-execution test-prove test-binary-parser
 


### PR DESCRIPTION
Addresses https://github.com/kframework/kore/issues/2624