### PR TITLE
Bump Z3 version to 4.8.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,14 @@ RUN    apt-get update              \
                        python3     \
                        python3-pip
 
+RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.12 \
+    && cd z3                                                         \
+    && python scripts/mk_make.py                                     \
+    && cd build                                                      \
+    && make -j8                                                      \
+    && make install                                                  \
+    && cd ../..                                                      \
+    && rm -rf z3
 
 ARG USER_ID=1000
 ARG GROUP_ID=1000


### PR DESCRIPTION
This reflects a change in the downstream K distribution; the main PR is at https://github.com/kframework/k/pull/2225